### PR TITLE
Regen from wb_oa_4.gpad using biolink/ontobio#604

### DIFF
--- a/models/WB_WBGene00000011.ttl
+++ b/models/WB_WBGene00000011.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000011> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "abc-1 (WB:WBGene00000011)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000011> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000011/699d5331-9d48-497d-9424-62136ec6a96d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000011/26bb495c-2543-421a-9a0d-3e5e423b313d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091444" ;
+    ns1:evidence-with "WB:WBVar00091444" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000011/e73440f0-b782-462e-865b-4349c1957ecf> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000011/401d94c3-fcf2-4a59-932a-b57b82582012> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091444" ;
+    ns1:evidence-with "WB:WBVar00091444" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000011/3852099a-df54-4499-8299-e9c49336f65d> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000011/093d2916-9493-4b59-bbff-ea53a6782a80> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000011/d452262c-5c6c-4f3d-9c9e-3b9f95999a44> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000011/97619fbb-743a-4250-93d3-5111645a2243> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000011/ad5c7c24-8cc5-488a-8aaa-5872e7682e44> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000011/19b315d9-b843-4d2f-9626-8f59cd33c6e0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000011/97619fbb-743a-4250-93d3-5111645a2243> a GO:0051306,
+<http://model.geneontology.org/WB_WBGene00000011/19b315d9-b843-4d2f-9626-8f59cd33c6e0> a GO:0051306,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000011/d452262c-5c6c-4f3d-9c9e-3b9f95999a44> a WB:WBGene00000011,
+<http://model.geneontology.org/WB_WBGene00000011/ad5c7c24-8cc5-488a-8aaa-5872e7682e44> a WB:WBGene00000011,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000011/699d5331-9d48-497d-9424-62136ec6a96d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000011/401d94c3-fcf2-4a59-932a-b57b82582012> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000011  RO:0002264 GO:0051306 WB:WBPaper00003120|PMID:9649522 ECO:0000315 WB:WBVar00091444  2021-05-13 WB  id=WBOA:9|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000011/3852099a-df54-4499-8299-e9c49336f65d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000011/d452262c-5c6c-4f3d-9c9e-3b9f95999a44> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000011/e73440f0-b782-462e-865b-4349c1957ecf> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000011  RO:0002264 GO:0051306 WB:WBPaper00003120|PMID:9649522 ECO:0000315 WB:WBVar00091444  2021-05-13 WB  id=WBOA:9|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000011/3852099a-df54-4499-8299-e9c49336f65d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000011/97619fbb-743a-4250-93d3-5111645a2243> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000011/093d2916-9493-4b59-bbff-ea53a6782a80> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000011/19b315d9-b843-4d2f-9626-8f59cd33c6e0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000011/26bb495c-2543-421a-9a0d-3e5e423b313d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000011  RO:0002264 GO:0051306 WB:WBPaper00003120|PMID:9649522 ECO:0000315 WB:WBVar00091444  2021-05-13 WB  id=WBOA:9|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000011/093d2916-9493-4b59-bbff-ea53a6782a80> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000011/ad5c7c24-8cc5-488a-8aaa-5872e7682e44> .
 

--- a/models/WB_WBGene00000078.ttl
+++ b/models/WB_WBGene00000078.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,49 +29,53 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000078> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "adp-1 (WB:WBGene00000078)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000078> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000078/7d2b8b96-454f-4e64-9712-7bcc675548f1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000078/7f0da37c-b549-4d53-9cdd-cf9fc9992850> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088389" ;
+    ns1:evidence-with "WB:WBVar00088389" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:7718242" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Note that this gene is defined by a single dominant mutation, ky20." .
 
-<http://model.geneontology.org/WB_WBGene00000078/a131787c-c6ba-4ab0-a769-9780a9694e44> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00000078/be72e847-d3a8-44fa-98e5-f72b9e7263a2> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003889" ;
+    ns1:evidence-with "WB:WBGene00003889" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:7718242" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Note that this gene is defined by a single dominant mutation, ky20." .
 
-<http://model.geneontology.org/WB_WBGene00000078/ac621742-ce79-4bc5-a08a-097a7b2d8c37> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00000078/d105fbfd-e0e2-4903-a34c-93f0d484fc3a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003889" ;
+    ns1:evidence-with "WB:WBVar00088389" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:7718242" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Note that this gene is defined by a single dominant mutation, ky20." .
 
-<http://model.geneontology.org/WB_WBGene00000078/c5a2fd1d-7385-44cc-bf6f-431596c06b3f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000078/ecd64b6c-6672-4a8b-871d-989f90093a98> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088389" ;
+    ns1:evidence-with "WB:WBGene00003889" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:7718242" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Note that this gene is defined by a single dominant mutation, ky20." .
 
@@ -79,57 +83,57 @@ obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000078/53cb2db4-17b2-4d30-99ab-fbba195c6c11> a GO:0022401,
+<http://model.geneontology.org/WB_WBGene00000078/03add0c5-caf1-44f1-ae8b-b26ffa23ea4c> a GO:0022401,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000078/94ba0405-d52f-4913-9a11-74ec602f76fd> a WB:WBGene00000078,
+<http://model.geneontology.org/WB_WBGene00000078/b67d0063-bd97-47fc-8ca1-f370ef74c2c9> a WB:WBGene00000078,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000078/beb9e2a7-17c5-45ae-a6f9-836a9f69a32f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000078/be28ede4-4a77-4fe0-af54-5b9c23a1ead1> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000078/94ba0405-d52f-4913-9a11-74ec602f76fd> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000078/53cb2db4-17b2-4d30-99ab-fbba195c6c11> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000078/b67d0063-bd97-47fc-8ca1-f370ef74c2c9> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000078/03add0c5-caf1-44f1-ae8b-b26ffa23ea4c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000078/ac621742-ce79-4bc5-a08a-097a7b2d8c37>,
-        <http://model.geneontology.org/WB_WBGene00000078/c5a2fd1d-7385-44cc-bf6f-431596c06b3f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000078/7f0da37c-b549-4d53-9cdd-cf9fc9992850>,
+        <http://model.geneontology.org/WB_WBGene00000078/ecd64b6c-6672-4a8b-871d-989f90093a98> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000078  RO:0002264 GO:0022401 WB:WBPaper00002166|PMID:7718242 ECO:0000315 WB:WBVar00088389  2020-05-13 WB  id=WBOA:132|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Note that this gene is defined by a single dominant mutation, ky20.|creation-date=2020-05-13|modification-date=2020-05-13",
         "WB:WBGene00000078  RO:0002264 GO:0022401 WB:WBPaper00002166|PMID:7718242 ECO:0000316 WB:WBGene00003889  2020-05-13 WB  id=WBOA:133|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Note that this gene is defined by a single dominant mutation, ky20.|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000078/beb9e2a7-17c5-45ae-a6f9-836a9f69a32f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000078/94ba0405-d52f-4913-9a11-74ec602f76fd> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000078/be28ede4-4a77-4fe0-af54-5b9c23a1ead1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000078/b67d0063-bd97-47fc-8ca1-f370ef74c2c9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000078/7d2b8b96-454f-4e64-9712-7bcc675548f1>,
-        <http://model.geneontology.org/WB_WBGene00000078/a131787c-c6ba-4ab0-a769-9780a9694e44> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000078/be72e847-d3a8-44fa-98e5-f72b9e7263a2>,
+        <http://model.geneontology.org/WB_WBGene00000078/d105fbfd-e0e2-4903-a34c-93f0d484fc3a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000078  RO:0002264 GO:0022401 WB:WBPaper00002166|PMID:7718242 ECO:0000315 WB:WBVar00088389  2020-05-13 WB  id=WBOA:132|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Note that this gene is defined by a single dominant mutation, ky20.|creation-date=2020-05-13|modification-date=2020-05-13",
         "WB:WBGene00000078  RO:0002264 GO:0022401 WB:WBPaper00002166|PMID:7718242 ECO:0000316 WB:WBGene00003889  2020-05-13 WB  id=WBOA:133|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Note that this gene is defined by a single dominant mutation, ky20.|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000078/beb9e2a7-17c5-45ae-a6f9-836a9f69a32f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000078/53cb2db4-17b2-4d30-99ab-fbba195c6c11> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000078/be28ede4-4a77-4fe0-af54-5b9c23a1ead1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000078/03add0c5-caf1-44f1-ae8b-b26ffa23ea4c> .
 

--- a/models/WB_WBGene00000278.ttl
+++ b/models/WB_WBGene00000278.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000278> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dc:title "cad-1 (WB:WBGene00000278)" ;
     dct:created "2012-01-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000278> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000278/82b91bc7-0f8c-4818-b0cd-be430ac11e15> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00000278/b3d440fa-ced3-4275-b385-ecc76a5a9288> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003168" ;
+    ns1:evidence-with "WB:WBGene00003168" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dc:source "PMID:22157748" ;
+    dct:created "2012-01-25" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000278/d92b328c-2838-4dd7-a38f-df45ee95fd65> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00000278/b3ef9ff4-66e2-4706-8049-96e65044962e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003168,WB:WBGene00006840" ;
+    ns1:evidence-with "WB:WBGene00003168" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dc:source "PMID:22157748" ;
+    dct:created "2012-01-25" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000278/ec68af8a-5925-438c-9e53-5a49d88f9688> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00000278/b818c5a1-4053-4ff7-b13f-4fd7c627aebd> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003168,WB:WBGene00006840" ;
+    ns1:evidence-with "WB:WBGene00003168,WB:WBGene00006840" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dc:source "PMID:22157748" ;
+    dct:created "2012-01-25" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000278/fa1a8384-541f-434c-b6f9-f7f1c0db10ce> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00000278/c88feb88-36fa-457a-9534-3132195430fc> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003168" ;
+    ns1:evidence-with "WB:WBGene00003168,WB:WBGene00006840" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dc:source "PMID:22157748" ;
+    dct:created "2012-01-25" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000278/1238c854-0ae6-4f58-b842-b6985aa808e9> a GO:0070265,
+<http://model.geneontology.org/WB_WBGene00000278/0a62da0a-b33d-4de9-9bb5-8b049979570e> a GO:0070265,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dct:created "2012-01-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000278/5dcda7e7-c8d6-4b74-b23a-ed8cbd9dece6> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000278/bbf8440a-ef39-45b9-bfc1-65d54aa97dbc> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000278/ff398f75-d2f9-4d1c-a492-31d2d910868d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000278/1238c854-0ae6-4f58-b842-b6985aa808e9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000278/ddeb5bae-21eb-4ff6-b060-ad78012c3b0b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000278/0a62da0a-b33d-4de9-9bb5-8b049979570e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dct:created "2012-01-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000278/ff398f75-d2f9-4d1c-a492-31d2d910868d> a WB:WBGene00000278,
+<http://model.geneontology.org/WB_WBGene00000278/ddeb5bae-21eb-4ff6-b060-ad78012c3b0b> a WB:WBGene00000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dct:created "2012-01-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000278/82b91bc7-0f8c-4818-b0cd-be430ac11e15>,
-        <http://model.geneontology.org/WB_WBGene00000278/d92b328c-2838-4dd7-a38f-df45ee95fd65> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000278/b3ef9ff4-66e2-4706-8049-96e65044962e>,
+        <http://model.geneontology.org/WB_WBGene00000278/b818c5a1-4053-4ff7-b13f-4fd7c627aebd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dct:created "2012-01-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000278  RO:0002264 GO:0070265 WB:WBPaper00040525|PMID:22157748 ECO:0000316 WB:WBGene00003168  2012-01-25 WB  id=WBOA:12735|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2012-01-25|modification-date=2012-01-25",
         "WB:WBGene00000278  RO:0002264 GO:0070265 WB:WBPaper00040525|PMID:22157748 ECO:0000316 WB:WBGene00003168,WB:WBGene00006840  2012-01-25 WB  id=WBOA:12746|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2012-01-25|modification-date=2012-01-25" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000278/5dcda7e7-c8d6-4b74-b23a-ed8cbd9dece6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000278/1238c854-0ae6-4f58-b842-b6985aa808e9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000278/bbf8440a-ef39-45b9-bfc1-65d54aa97dbc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000278/0a62da0a-b33d-4de9-9bb5-8b049979570e> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000278/ec68af8a-5925-438c-9e53-5a49d88f9688>,
-        <http://model.geneontology.org/WB_WBGene00000278/fa1a8384-541f-434c-b6f9-f7f1c0db10ce> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000278/b3d440fa-ced3-4275-b385-ecc76a5a9288>,
+        <http://model.geneontology.org/WB_WBGene00000278/c88feb88-36fa-457a-9534-3132195430fc> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-01-25" ;
     dct:created "2012-01-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000278  RO:0002264 GO:0070265 WB:WBPaper00040525|PMID:22157748 ECO:0000316 WB:WBGene00003168  2012-01-25 WB  id=WBOA:12735|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2012-01-25|modification-date=2012-01-25",
         "WB:WBGene00000278  RO:0002264 GO:0070265 WB:WBPaper00040525|PMID:22157748 ECO:0000316 WB:WBGene00003168,WB:WBGene00006840  2012-01-25 WB  id=WBOA:12746|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2012-01-25|modification-date=2012-01-25" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000278/5dcda7e7-c8d6-4b74-b23a-ed8cbd9dece6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000278/ff398f75-d2f9-4d1c-a492-31d2d910868d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000278/bbf8440a-ef39-45b9-bfc1-65d54aa97dbc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000278/ddeb5bae-21eb-4ff6-b060-ad78012c3b0b> .
 

--- a/models/WB_WBGene00000300.ttl
+++ b/models/WB_WBGene00000300.ttl
@@ -4,14 +4,14 @@
 @prefix WBbt: <http://purl.obolibrary.org/obo/WBbt_> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -30,38 +30,41 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000300> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "cat-6 (WB:WBGene00000300)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000300> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000300/8f0e12cf-7779-4f86-b8e2-da9236cdab97> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000300/00766c10-23d5-4866-a868-2212fd63e0e1> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144367" ;
+    ns1:evidence-with "WB:WBVar00144367" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:2428682" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000300/be2c9be5-8198-4eff-bf18-e69d7e532e03> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000300/0c045326-c978-43fc-9d4c-0a3913b2e32d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144367" ;
+    ns1:evidence-with "WB:WBVar00144367" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:2428682" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000300/f4ff03c4-6795-418d-a03c-04fdbb2d2ee6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000300/b3e9fe9a-1a3c-4e01-a683-4a0b92d91935> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144367" ;
+    ns1:evidence-with "WB:WBVar00144367" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:2428682" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000066 a owl:ObjectProperty .
@@ -70,74 +73,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000300/5cf7d470-f753-4b71-be2e-f219c18475b6> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000300/40fef64f-c8f0-4365-bbed-7ecd858b8f6e> a WB:WBGene00000300,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000300/8e79d82c-b05b-4e0f-8bfa-b797116a59f9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000300/b670bd6f-54b4-4fde-bdbb-d8296070183f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000300/8e79d82c-b05b-4e0f-8bfa-b797116a59f9> a WB:WBGene00000300,
+<http://model.geneontology.org/WB_WBGene00000300/bff5af8b-c775-4bd9-a01b-1122545088dd> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000300/40fef64f-c8f0-4365-bbed-7ecd858b8f6e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000300/33091d55-d105-4ca3-a0d2-c64326dcfae9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000300/93283994-8c64-40d0-a2bb-f34ff7fa25ae> a WBbt:0005244,
+<http://model.geneontology.org/WB_WBGene00000300/ded7a0a9-ff6a-4776-b26a-fe9fcd62ddf6> a WBbt:0005244,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000300/b670bd6f-54b4-4fde-bdbb-d8296070183f> a GO:1905515,
+<http://model.geneontology.org/WB_WBGene00000300/33091d55-d105-4ca3-a0d2-c64326dcfae9> a GO:1905515,
         owl:NamedIndividual ;
-    obo:BFO_0000066 <http://model.geneontology.org/WB_WBGene00000300/93283994-8c64-40d0-a2bb-f34ff7fa25ae> ;
+    obo:BFO_0000066 <http://model.geneontology.org/WB_WBGene00000300/ded7a0a9-ff6a-4776-b26a-fe9fcd62ddf6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000300/f4ff03c4-6795-418d-a03c-04fdbb2d2ee6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000300/0c045326-c978-43fc-9d4c-0a3913b2e32d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000300  RO:0002264 GO:1905515 WB:WBPaper00000932|PMID:2428682 ECO:0000315 WB:WBVar00144367  2021-05-13 WB BFO:0000066(WBbt:0005244) id=WBOA:540|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000300/5cf7d470-f753-4b71-be2e-f219c18475b6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000300/8e79d82c-b05b-4e0f-8bfa-b797116a59f9> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000300/be2c9be5-8198-4eff-bf18-e69d7e532e03> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000300  RO:0002264 GO:1905515 WB:WBPaper00000932|PMID:2428682 ECO:0000315 WB:WBVar00144367  2021-05-13 WB BFO:0000066(WBbt:0005244) id=WBOA:540|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:BFO_0000066 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000300/b670bd6f-54b4-4fde-bdbb-d8296070183f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000300/93283994-8c64-40d0-a2bb-f34ff7fa25ae> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000300/8f0e12cf-7779-4f86-b8e2-da9236cdab97> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000300  RO:0002264 GO:1905515 WB:WBPaper00000932|PMID:2428682 ECO:0000315 WB:WBVar00144367  2021-05-13 WB BFO:0000066(WBbt:0005244) id=WBOA:540|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000300/5cf7d470-f753-4b71-be2e-f219c18475b6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000300/b670bd6f-54b4-4fde-bdbb-d8296070183f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000300/bff5af8b-c775-4bd9-a01b-1122545088dd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000300/33091d55-d105-4ca3-a0d2-c64326dcfae9> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000300/b3e9fe9a-1a3c-4e01-a683-4a0b92d91935> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000300  RO:0002264 GO:1905515 WB:WBPaper00000932|PMID:2428682 ECO:0000315 WB:WBVar00144367  2021-05-13 WB BFO:0000066(WBbt:0005244) id=WBOA:540|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:BFO_0000066 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000300/33091d55-d105-4ca3-a0d2-c64326dcfae9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000300/ded7a0a9-ff6a-4776-b26a-fe9fcd62ddf6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000300/00766c10-23d5-4866-a868-2212fd63e0e1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000300  RO:0002264 GO:1905515 WB:WBPaper00000932|PMID:2428682 ECO:0000315 WB:WBVar00144367  2021-05-13 WB BFO:0000066(WBbt:0005244) id=WBOA:540|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000300/bff5af8b-c775-4bd9-a01b-1122545088dd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000300/40fef64f-c8f0-4365-bbed-7ecd858b8f6e> .
 

--- a/models/WB_WBGene00000373.ttl
+++ b/models/WB_WBGene00000373.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000373> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:title "cyp-14A5 (WB:WBGene00000373)" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000373> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000373/99efd348-0043-4e37-b090-350ae3733fa0> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00000373/d889da20-a739-455e-9353-e005173686af> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000373/ddc75c30-804d-49eb-b29c-b41d57fffe03> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00000373/fe8a1558-09bb-4f1f-93fa-5ea36004afe9> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000373/6ee6074c-e62e-4e5c-b93e-ccf846f761bc> a WB:WBGene00000373,
+<http://model.geneontology.org/WB_WBGene00000373/050600e3-f282-4e28-9a33-ce4238335be8> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00000373/bd44b948-b346-404e-a451-12c38dba849e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000373/8b7afed5-7202-49ec-9c3b-d5a693f6686e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000373/8b357d01-3a3a-45d3-8d22-c4abd0463416> a GO:0010332,
+<http://model.geneontology.org/WB_WBGene00000373/8b7afed5-7202-49ec-9c3b-d5a693f6686e> a WB:WBGene00000373,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000373/e45db4a5-585f-48bc-855c-3f18ebc857d9> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000373/bd44b948-b346-404e-a451-12c38dba849e> a GO:0010332,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00000373/8b357d01-3a3a-45d3-8d22-c4abd0463416> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000373/6ee6074c-e62e-4e5c-b93e-ccf846f761bc> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000373/ddc75c30-804d-49eb-b29c-b41d57fffe03> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000373/fe8a1558-09bb-4f1f-93fa-5ea36004afe9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000373  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12039|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000373/e45db4a5-585f-48bc-855c-3f18ebc857d9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000373/6ee6074c-e62e-4e5c-b93e-ccf846f761bc> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000373/99efd348-0043-4e37-b090-350ae3733fa0> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2011-08-29" ;
-    dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000373  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12039|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000373/e45db4a5-585f-48bc-855c-3f18ebc857d9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000373/8b357d01-3a3a-45d3-8d22-c4abd0463416> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000373/050600e3-f282-4e28-9a33-ce4238335be8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000373/bd44b948-b346-404e-a451-12c38dba849e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000373/d889da20-a739-455e-9353-e005173686af> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2011-08-29" ;
+    dct:created "2011-08-29" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000373  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12039|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000373/050600e3-f282-4e28-9a33-ce4238335be8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000373/8b7afed5-7202-49ec-9c3b-d5a693f6686e> .
 

--- a/models/WB_WBGene00000504.ttl
+++ b/models/WB_WBGene00000504.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000504> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cib-1 (WB:WBGene00000504)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000504> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000504/7581fbcf-302b-43d4-ba37-b554caf4bb3d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000504/67c433de-e24a-403f-a43e-a92cbd94ea33> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:2351058" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated to more granular term - Jenkins flags." .
 
-<http://model.geneontology.org/WB_WBGene00000504/9120e8b2-814b-4202-b2c6-8a156a40b1f8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000504/9a395014-2039-4781-bbae-cbb81c15fea2> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:2351058" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000504/a5da04b5-ed24-4cdb-b126-0cc033c50273> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000504/bcf9a5d7-6da4-4614-b8a7-116d56afdbc0> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:2351058" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000504/d2abcfbb-b636-443f-b254-4083d64b202f> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:2351058" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated to more granular term - Jenkins flags." .
 
-<http://model.geneontology.org/WB_WBGene00000504/b7471636-9834-425c-a192-8b9c02ed456a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000504/1d0bb7d4-f01f-412e-a452-e084381deb8d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000504/d661c99a-c3c5-43ec-bf5e-bbc1bd384b33> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000504/9ff7519a-5669-4694-a616-cf6a5fa3870d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
-    dc:source "PMID:2351058" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000504/744ed6f7-3786-438f-a43d-e0f55f9380ef> a GO:0001708,
+<http://model.geneontology.org/WB_WBGene00000504/70e456af-0621-4ad1-a1fa-bcf05b667203> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000504/8c52302d-fb79-4ba9-9388-6ec657ea9862> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000504/e0790772-d70b-4a0d-93b3-a2ac856101f3> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000504/744ed6f7-3786-438f-a43d-e0f55f9380ef> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000504/9485fc0a-4639-4c66-adbf-57849959aae9> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000504/b9ff0368-8a4b-442f-abc2-7bbbbc9691c5> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000504/a456db13-0920-4def-b0aa-c82fbae3f8c8> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000504/a456db13-0920-4def-b0aa-c82fbae3f8c8> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00000504/9ff7519a-5669-4694-a616-cf6a5fa3870d> a GO:0001708,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000504/b9ff0368-8a4b-442f-abc2-7bbbbc9691c5> a WB:WBGene00000504,
+<http://model.geneontology.org/WB_WBGene00000504/a1770a72-0d19-4a59-b6a5-6ea060a5eb86> a WB:WBGene00000504,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000504/e0790772-d70b-4a0d-93b3-a2ac856101f3> a WB:WBGene00000504,
+<http://model.geneontology.org/WB_WBGene00000504/b78366d3-7061-4518-9888-a3d29cfaafee> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000504/a1770a72-0d19-4a59-b6a5-6ea060a5eb86> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000504/70e456af-0621-4ad1-a1fa-bcf05b667203> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000504/d661c99a-c3c5-43ec-bf5e-bbc1bd384b33> a WB:WBGene00000504,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000504/9120e8b2-814b-4202-b2c6-8a156a40b1f8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000504/9a395014-2039-4781-bbae-cbb81c15fea2> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000504  RO:0002264 GO:0001708 WB:WBPaper00001240|PMID:2351058 ECO:0000315   2021-05-13 WB  id=WBOA:930|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/8c52302d-fb79-4ba9-9388-6ec657ea9862> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/744ed6f7-3786-438f-a43d-e0f55f9380ef> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/1d0bb7d4-f01f-412e-a452-e084381deb8d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/9ff7519a-5669-4694-a616-cf6a5fa3870d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000504/7581fbcf-302b-43d4-ba37-b554caf4bb3d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000504/d2abcfbb-b636-443f-b254-4083d64b202f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000504  RO:0002264 GO:0009792 WB:WBPaper00001240|PMID:2351058 ECO:0000315   2021-05-13 WB  id=WBOA:931|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated to more granular term - Jenkins flags.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/9485fc0a-4639-4c66-adbf-57849959aae9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/b9ff0368-8a4b-442f-abc2-7bbbbc9691c5> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000504/b7471636-9834-425c-a192-8b9c02ed456a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000504  RO:0002264 GO:0001708 WB:WBPaper00001240|PMID:2351058 ECO:0000315   2021-05-13 WB  id=WBOA:930|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/8c52302d-fb79-4ba9-9388-6ec657ea9862> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/e0790772-d70b-4a0d-93b3-a2ac856101f3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000504/a5da04b5-ed24-4cdb-b126-0cc033c50273> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000504  RO:0002264 GO:0009792 WB:WBPaper00001240|PMID:2351058 ECO:0000315   2021-05-13 WB  id=WBOA:931|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated to more granular term - Jenkins flags.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/9485fc0a-4639-4c66-adbf-57849959aae9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/a456db13-0920-4def-b0aa-c82fbae3f8c8> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/b78366d3-7061-4518-9888-a3d29cfaafee> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/70e456af-0621-4ad1-a1fa-bcf05b667203> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000504/bcf9a5d7-6da4-4614-b8a7-116d56afdbc0> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000504  RO:0002264 GO:0001708 WB:WBPaper00001240|PMID:2351058 ECO:0000315   2021-05-13 WB  id=WBOA:930|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/1d0bb7d4-f01f-412e-a452-e084381deb8d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/d661c99a-c3c5-43ec-bf5e-bbc1bd384b33> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000504/67c433de-e24a-403f-a43e-a92cbd94ea33> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000504  RO:0002264 GO:0009792 WB:WBPaper00001240|PMID:2351058 ECO:0000315   2021-05-13 WB  id=WBOA:931|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated to more granular term - Jenkins flags.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000504/b78366d3-7061-4518-9888-a3d29cfaafee> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000504/a1770a72-0d19-4a59-b6a5-6ea060a5eb86> .
 

--- a/models/WB_WBGene00000538.ttl
+++ b/models/WB_WBGene00000538.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,147 +29,157 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000538> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "clk-3 (WB:WBGene00000538)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000538> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000538/0351817c-04e2-48b2-8834-e3799bf23179> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000538/06a86226-3eda-4d04-9121-382b6df98921> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144863" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/22fe71f4-ef99-43cb-a9fb-f2933278b6c1> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144863" ;
+    ns1:evidence-with "WB:WBVar00144863" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/301d93ef-e01a-42b9-adf5-66daf67a094b> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144863" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/36c8ec66-f7e4-4d20-a44e-f6e2a4e8733c> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000912" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/57d83117-cb7b-4ab4-aaa1-5a61e56a0f97> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000536" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/c05847eb-5e85-40ff-9fad-f8dccd0240e8> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00144863" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/c1c2abcf-1b90-4d28-9cef-7ff9bfad9730> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000537" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/d649bf97-8fff-4f2f-a493-8048c0d8efaf> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000537" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/dabaaa06-2c18-4319-aab2-e2a4af32d0e9> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000912" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/f4be058b-c0e0-45c5-8e67-45e0b6a64f62> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000536" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:8638122" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/849875ad-d3db-4fcc-b8f5-e4b18d13bb61> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000538/c71e78a9-e9ef-466f-aad8-e835bd710b27> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000538/ef47348f-69d8-4055-84fe-c5fa5a05dbc7> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000538/aad5b8de-6418-4707-a493-8a9e14a725d9> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000538/11c8fb93-8860-4283-b47e-88f8859f1277> a ECO:0000315,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000538/f2a0e108-d6df-4101-a513-4e1aaac3bab3> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000538/dc29f8cb-564e-4be4-8d5a-9813b7e68634> ;
+    ns1:evidence-with "WB:WBVar00144863" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000538/c71e78a9-e9ef-466f-aad8-e835bd710b27> a WB:WBGene00000538,
+<http://model.geneontology.org/WB_WBGene00000538/1d7481ad-3f56-4e81-b6f8-4dd0924544ca> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000537" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/4722173d-4a30-43d9-9dc2-7543eb6ea19b> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000912" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/55ca49ae-d525-43a7-bb3c-823e28d54ba4> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000536" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/ae4bdc47-f7e7-468a-a7bb-e9010aae0398> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000912" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/bdaf6d12-ce99-4f0c-a6ce-d54296b90c66> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000536" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/c25d4ac1-b86a-41f3-a260-9ff99d2c704c> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00144863" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/d3dc64fd-091c-4e81-880b-6ad3d8938deb> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00144863" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/d689dbbe-18f3-440d-891b-f3896a5f20b6> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000537" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:8638122" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/3f771367-9fe2-4763-ad1d-b7936e812f47> a WB:WBGene00000538,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000538/dc29f8cb-564e-4be4-8d5a-9813b7e68634> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00000538/4b2ce31f-9ede-42a3-ab3e-f76db364f594> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000538/ef47348f-69d8-4055-84fe-c5fa5a05dbc7> a GO:0008340,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000538/f2a0e108-d6df-4101-a513-4e1aaac3bab3> a WB:WBGene00000538,
+<http://model.geneontology.org/WB_WBGene00000538/867cdac4-48e0-4fd7-acd8-df7ed9fd4c02> a WB:WBGene00000538,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/88a2eb1e-4a71-4bab-a50a-8121646be57f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000538/3f771367-9fe2-4763-ad1d-b7936e812f47> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000538/917313ff-c6fa-4c17-a1fa-b14a653003f4> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/917313ff-c6fa-4c17-a1fa-b14a653003f4> a GO:0008340,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000538/a215cf4f-d97e-4e42-a95e-306ab1f69b69> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000538/867cdac4-48e0-4fd7-acd8-df7ed9fd4c02> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000538/4b2ce31f-9ede-42a3-ab3e-f76db364f594> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -177,62 +187,62 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000538/301d93ef-e01a-42b9-adf5-66daf67a094b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000538/06a86226-3eda-4d04-9121-382b6df98921> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000538  RO:0002264 GO:0035264 WB:WBPaper00002456|PMID:8638122 ECO:0000315 WB:WBVar00144863  2021-05-13 WB  id=WBOA:9757|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/aad5b8de-6418-4707-a493-8a9e14a725d9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/dc29f8cb-564e-4be4-8d5a-9813b7e68634> .
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/a215cf4f-d97e-4e42-a95e-306ab1f69b69> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/867cdac4-48e0-4fd7-acd8-df7ed9fd4c02> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000538/36c8ec66-f7e4-4d20-a44e-f6e2a4e8733c>,
-        <http://model.geneontology.org/WB_WBGene00000538/57d83117-cb7b-4ab4-aaa1-5a61e56a0f97>,
-        <http://model.geneontology.org/WB_WBGene00000538/c05847eb-5e85-40ff-9fad-f8dccd0240e8>,
-        <http://model.geneontology.org/WB_WBGene00000538/c1c2abcf-1b90-4d28-9cef-7ff9bfad9730> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000538/55ca49ae-d525-43a7-bb3c-823e28d54ba4>,
+        <http://model.geneontology.org/WB_WBGene00000538/ae4bdc47-f7e7-468a-a7bb-e9010aae0398>,
+        <http://model.geneontology.org/WB_WBGene00000538/c25d4ac1-b86a-41f3-a260-9ff99d2c704c>,
+        <http://model.geneontology.org/WB_WBGene00000538/d689dbbe-18f3-440d-891b-f3896a5f20b6> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000315 WB:WBVar00144863  2021-05-13 WB  id=WBOA:9747|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000316 WB:WBGene00000536  2021-05-13 WB  id=WBOA:9749|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000316 WB:WBGene00000537  2021-05-13 WB  id=WBOA:9752|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000316 WB:WBGene00000912  2021-05-13 WB  id=WBOA:9753|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/849875ad-d3db-4fcc-b8f5-e4b18d13bb61> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/ef47348f-69d8-4055-84fe-c5fa5a05dbc7> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/88a2eb1e-4a71-4bab-a50a-8121646be57f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/917313ff-c6fa-4c17-a1fa-b14a653003f4> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000538/22fe71f4-ef99-43cb-a9fb-f2933278b6c1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000538/11c8fb93-8860-4283-b47e-88f8859f1277> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000538  RO:0002264 GO:0035264 WB:WBPaper00002456|PMID:8638122 ECO:0000315 WB:WBVar00144863  2021-05-13 WB  id=WBOA:9757|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/aad5b8de-6418-4707-a493-8a9e14a725d9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/f2a0e108-d6df-4101-a513-4e1aaac3bab3> .
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/a215cf4f-d97e-4e42-a95e-306ab1f69b69> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/4b2ce31f-9ede-42a3-ab3e-f76db364f594> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000538/0351817c-04e2-48b2-8834-e3799bf23179>,
-        <http://model.geneontology.org/WB_WBGene00000538/d649bf97-8fff-4f2f-a493-8048c0d8efaf>,
-        <http://model.geneontology.org/WB_WBGene00000538/dabaaa06-2c18-4319-aab2-e2a4af32d0e9>,
-        <http://model.geneontology.org/WB_WBGene00000538/f4be058b-c0e0-45c5-8e67-45e0b6a64f62> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000538/1d7481ad-3f56-4e81-b6f8-4dd0924544ca>,
+        <http://model.geneontology.org/WB_WBGene00000538/4722173d-4a30-43d9-9dc2-7543eb6ea19b>,
+        <http://model.geneontology.org/WB_WBGene00000538/bdaf6d12-ce99-4f0c-a6ce-d54296b90c66>,
+        <http://model.geneontology.org/WB_WBGene00000538/d3dc64fd-091c-4e81-880b-6ad3d8938deb> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000315 WB:WBVar00144863  2021-05-13 WB  id=WBOA:9747|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000316 WB:WBGene00000536  2021-05-13 WB  id=WBOA:9749|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000316 WB:WBGene00000537  2021-05-13 WB  id=WBOA:9752|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00000538  RO:0002264 GO:0008340 WB:WBPaper00002456|PMID:8638122 ECO:0000316 WB:WBGene00000912  2021-05-13 WB  id=WBOA:9753|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/849875ad-d3db-4fcc-b8f5-e4b18d13bb61> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/c71e78a9-e9ef-466f-aad8-e835bd710b27> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000538/88a2eb1e-4a71-4bab-a50a-8121646be57f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000538/3f771367-9fe2-4763-ad1d-b7936e812f47> .
 

--- a/models/WB_WBGene00000560.ttl
+++ b/models/WB_WBGene00000560.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,94 +29,98 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000560> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:title "cnc-6 (WB:WBGene00000560)" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000560> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000560/4b9cd6ed-e6ba-4660-a1b7-2f3e4c5d491f> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00000560/1e6a0a40-6de5-461c-897f-120a29d12db8> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
+    dct:created "2010-03-19" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/a451a8e8-2ba8-40ff-bfd6-af9b3c9e11a9> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00000560/217b8f92-a710-4932-aba9-904b51c4754c> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
+    dct:created "2010-03-19" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/bf6506cb-f658-4bc0-85c1-1c806faa35c2> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00000560/74ec6a76-af5a-4125-93c4-c351f99d261d> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
+    dct:created "2010-03-19" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/e9d97509-0fce-4b37-a624-9b6de5917a01> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00000560/9fbe208e-bb3b-4722-98ad-bffbcf5b992c> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000560/5b8aa03e-3b9a-4a9e-97d8-d6270f66fb14> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00000560/83addf9f-6cd7-4659-9a96-6c62f663658f> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000560/75aebf72-43cc-42c1-ad31-5c4a770d1c7d> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/75aebf72-43cc-42c1-ad31-5c4a770d1c7d> a WB:WBGene00000560,
+<http://model.geneontology.org/WB_WBGene00000560/042d1d05-b361-44a1-a16a-195c68e22cbb> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/7ba1235b-d1a7-49bf-ab86-2b25cf39bbcb> a GO:0050832,
+<http://model.geneontology.org/WB_WBGene00000560/1891672b-d70c-493e-89f3-bce8b1ba554d> a WB:WBGene00000560,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/8399e272-0777-4af8-8868-81abe8801ef1> a WB:WBGene00000560,
+<http://model.geneontology.org/WB_WBGene00000560/2b1b8203-b4fd-4362-909d-95da891ee44a> a GO:0050832,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/83addf9f-6cd7-4659-9a96-6c62f663658f> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00000560/9298963a-db5b-4359-abce-5bb29c4bdc3c> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00000560/2b1b8203-b4fd-4362-909d-95da891ee44a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000560/998e067b-1e3b-4d72-b77c-a8a461923ded> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-19" ;
+    dct:created "2010-03-19" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000560/998e067b-1e3b-4d72-b77c-a8a461923ded> a WB:WBGene00000560,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000560/d4398d14-7968-4ae1-925e-34757c25d75e> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000560/bcea1a9a-c24c-4d56-8ea2-8eb2c715a065> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00000560/7ba1235b-d1a7-49bf-ab86-2b25cf39bbcb> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000560/8399e272-0777-4af8-8868-81abe8801ef1> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00000560/042d1d05-b361-44a1-a16a-195c68e22cbb> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000560/1891672b-d70c-493e-89f3-bce8b1ba554d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -124,50 +128,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000560/bf6506cb-f658-4bc0-85c1-1c806faa35c2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000560/1e6a0a40-6de5-461c-897f-120a29d12db8> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000560  RO:0002331 GO:0045087 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9485|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/5b8aa03e-3b9a-4a9e-97d8-d6270f66fb14> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/83addf9f-6cd7-4659-9a96-6c62f663658f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000560/e9d97509-0fce-4b37-a624-9b6de5917a01> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-19" ;
-    dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000560  RO:0002331 GO:0050832 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9490|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/d4398d14-7968-4ae1-925e-34757c25d75e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/8399e272-0777-4af8-8868-81abe8801ef1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/9298963a-db5b-4359-abce-5bb29c4bdc3c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/998e067b-1e3b-4d72-b77c-a8a461923ded> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000560/4b9cd6ed-e6ba-4660-a1b7-2f3e4c5d491f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000560/74ec6a76-af5a-4125-93c4-c351f99d261d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000560  RO:0002331 GO:0045087 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9485|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/bcea1a9a-c24c-4d56-8ea2-8eb2c715a065> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/042d1d05-b361-44a1-a16a-195c68e22cbb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000560/217b8f92-a710-4932-aba9-904b51c4754c> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-19" ;
+    dct:created "2010-03-19" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000560  RO:0002331 GO:0050832 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9490|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/d4398d14-7968-4ae1-925e-34757c25d75e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/7ba1235b-d1a7-49bf-ab86-2b25cf39bbcb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/9298963a-db5b-4359-abce-5bb29c4bdc3c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/2b1b8203-b4fd-4362-909d-95da891ee44a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000560/a451a8e8-2ba8-40ff-bfd6-af9b3c9e11a9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000560/9fbe208e-bb3b-4722-98ad-bffbcf5b992c> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000560  RO:0002331 GO:0045087 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9485|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/5b8aa03e-3b9a-4a9e-97d8-d6270f66fb14> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/75aebf72-43cc-42c1-ad31-5c4a770d1c7d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000560/bcea1a9a-c24c-4d56-8ea2-8eb2c715a065> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000560/1891672b-d70c-493e-89f3-bce8b1ba554d> .
 

--- a/models/WB_WBGene00000842.ttl
+++ b/models/WB_WBGene00000842.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000842> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cup-1 (WB:WBGene00000842)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000842> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000842/1a3fd75b-a89f-415b-ba73-cf4195185c61> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000842/aad87540-9abf-4b51-a82b-a22ceb56969d> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000842/f134f203-b5f6-46ef-a3de-7ea1a42b05ce> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000842/b01c0693-1bf3-4319-a3b0-6fcf8235e6cd> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000842/567ef417-e6ec-4e18-9690-30edc5ae9afd> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000842/5e93992c-8509-4c0e-96f0-30661af2d2e6> a GO:0006897,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000842/88f4d53b-67c3-496a-821d-1de99f973366> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000842/6e8e6a2d-0e70-42c2-bc68-26f7f793db1a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000842/6e8e6a2d-0e70-42c2-bc68-26f7f793db1a> a GO:0006897,
+<http://model.geneontology.org/WB_WBGene00000842/8dc9ab4a-5f40-4c41-aa3e-6c73eb1651c4> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000842/eac6e46b-8b39-4cec-9bd9-4b7ff7f0a3cf> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000842/5e93992c-8509-4c0e-96f0-30661af2d2e6> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000842/88f4d53b-67c3-496a-821d-1de99f973366> a WB:WBGene00000842,
+<http://model.geneontology.org/WB_WBGene00000842/eac6e46b-8b39-4cec-9bd9-4b7ff7f0a3cf> a WB:WBGene00000842,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000842/1a3fd75b-a89f-415b-ba73-cf4195185c61> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000842/b01c0693-1bf3-4319-a3b0-6fcf8235e6cd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000842  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1139|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000842/567ef417-e6ec-4e18-9690-30edc5ae9afd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000842/6e8e6a2d-0e70-42c2-bc68-26f7f793db1a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000842/8dc9ab4a-5f40-4c41-aa3e-6c73eb1651c4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000842/5e93992c-8509-4c0e-96f0-30661af2d2e6> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000842/f134f203-b5f6-46ef-a3de-7ea1a42b05ce> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000842/aad87540-9abf-4b51-a82b-a22ceb56969d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000842  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1139|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000842/567ef417-e6ec-4e18-9690-30edc5ae9afd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000842/88f4d53b-67c3-496a-821d-1de99f973366> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000842/8dc9ab4a-5f40-4c41-aa3e-6c73eb1651c4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000842/eac6e46b-8b39-4cec-9bd9-4b7ff7f0a3cf> .
 

--- a/models/WB_WBGene00000844.ttl
+++ b/models/WB_WBGene00000844.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000844> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cup-3 (WB:WBGene00000844)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000844> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000844/18ca11fc-a641-4066-9a36-e7c50722eed1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000844/ac1fc01e-e295-4bc7-93d0-99d35fe7eb78> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000844/b9745e3c-a064-4cbb-9365-3d2d3870ee11> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000844/b1897aa2-e7e7-43e9-91cb-ce8a6cfd2d93> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000844/784290c2-5f81-47d2-b25a-495882be90a7> a WB:WBGene00000844,
+<http://model.geneontology.org/WB_WBGene00000844/6a6ce67e-7996-4460-a669-140c03e4c9d9> a WB:WBGene00000844,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000844/834c201d-ff32-4f45-95a7-982a6a70e33a> a GO:0006897,
+<http://model.geneontology.org/WB_WBGene00000844/893689cf-fb41-4942-8051-a7ae21b5a1d3> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000844/6a6ce67e-7996-4460-a669-140c03e4c9d9> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000844/e419edd6-b983-4f8d-8157-52404ee1a1b7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000844/836dd882-498d-459a-ba53-727d711eabf5> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000844/e419edd6-b983-4f8d-8157-52404ee1a1b7> a GO:0006897,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000844/784290c2-5f81-47d2-b25a-495882be90a7> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000844/834c201d-ff32-4f45-95a7-982a6a70e33a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000844/18ca11fc-a641-4066-9a36-e7c50722eed1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000844/ac1fc01e-e295-4bc7-93d0-99d35fe7eb78> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000844  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1141|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000844/836dd882-498d-459a-ba53-727d711eabf5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000844/834c201d-ff32-4f45-95a7-982a6a70e33a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000844/893689cf-fb41-4942-8051-a7ae21b5a1d3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000844/e419edd6-b983-4f8d-8157-52404ee1a1b7> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000844/b9745e3c-a064-4cbb-9365-3d2d3870ee11> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000844/b1897aa2-e7e7-43e9-91cb-ce8a6cfd2d93> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000844  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1141|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000844/836dd882-498d-459a-ba53-727d711eabf5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000844/784290c2-5f81-47d2-b25a-495882be90a7> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000844/893689cf-fb41-4942-8051-a7ae21b5a1d3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000844/6a6ce67e-7996-4460-a669-140c03e4c9d9> .
 

--- a/models/WB_WBGene00000848.ttl
+++ b/models/WB_WBGene00000848.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000848> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cup-8 (WB:WBGene00000848)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000848> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000848/1c3a96ff-7dc8-47bc-adbd-02127562da89> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000848/94dc5041-9cc6-4697-ae16-cd58cd02b9a6> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000848/e75aade2-ce14-4565-90de-76f19d6514a8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000848/e1bcbd6f-1d27-4f95-b1ce-4ce518d55c2d> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000848/25cd4f59-7ecb-47bb-a8dd-c8086b03a275> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000848/63d5ec4e-90c1-4f9b-843b-5a493bf28696> a WB:WBGene00000848,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000848/643c24b3-a2d2-42f4-b1a0-c26afe9fbc39> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000848/fe5d5960-7687-4361-838d-6bf58043d301> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000848/643c24b3-a2d2-42f4-b1a0-c26afe9fbc39> a WB:WBGene00000848,
+<http://model.geneontology.org/WB_WBGene00000848/c6a118d7-0a95-4086-a608-afbdc57ef15d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000848/63d5ec4e-90c1-4f9b-843b-5a493bf28696> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000848/cecb8811-20b0-49a4-b24a-929c8f441909> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000848/fe5d5960-7687-4361-838d-6bf58043d301> a GO:0006897,
+<http://model.geneontology.org/WB_WBGene00000848/cecb8811-20b0-49a4-b24a-929c8f441909> a GO:0006897,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000848/1c3a96ff-7dc8-47bc-adbd-02127562da89> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000848/94dc5041-9cc6-4697-ae16-cd58cd02b9a6> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000848  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1148|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000848/25cd4f59-7ecb-47bb-a8dd-c8086b03a275> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000848/fe5d5960-7687-4361-838d-6bf58043d301> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000848/c6a118d7-0a95-4086-a608-afbdc57ef15d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000848/cecb8811-20b0-49a4-b24a-929c8f441909> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000848/e75aade2-ce14-4565-90de-76f19d6514a8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000848/e1bcbd6f-1d27-4f95-b1ce-4ce518d55c2d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000848  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1148|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000848/25cd4f59-7ecb-47bb-a8dd-c8086b03a275> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000848/643c24b3-a2d2-42f4-b1a0-c26afe9fbc39> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000848/c6a118d7-0a95-4086-a608-afbdc57ef15d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000848/63d5ec4e-90c1-4f9b-843b-5a493bf28696> .
 

--- a/models/WB_WBGene00000849.ttl
+++ b/models/WB_WBGene00000849.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000849> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cup-9 (WB:WBGene00000849)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000849> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000849/9071522a-a425-4411-be79-45eaaade5625> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000849/56634883-74ae-40c4-996c-39082caedd11> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000849/c6368fa9-0df0-4fc9-b14d-fbf42d400d5b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000849/7892d0a0-3f24-44c3-8334-0f2c8acdbe08> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000849/0a6c4bb2-ee75-4abe-aa63-d942468327b2> a GO:0006897,
+<http://model.geneontology.org/WB_WBGene00000849/471ddb54-47fd-424d-8005-1ad8e42168e8> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000849/90deb3c8-af0d-42e8-9d02-58cd774aba7e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000849/540c9251-b050-4ff8-a412-3f81e2644ecd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000849/0f55fcd1-71c4-40b5-b060-93365d2b40cd> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000849/540c9251-b050-4ff8-a412-3f81e2644ecd> a GO:0006897,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000849/362599d7-5f74-4bc7-b689-94efc4a983ba> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000849/0a6c4bb2-ee75-4abe-aa63-d942468327b2> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000849/362599d7-5f74-4bc7-b689-94efc4a983ba> a WB:WBGene00000849,
+<http://model.geneontology.org/WB_WBGene00000849/90deb3c8-af0d-42e8-9d02-58cd774aba7e> a WB:WBGene00000849,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000849/c6368fa9-0df0-4fc9-b14d-fbf42d400d5b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000849/7892d0a0-3f24-44c3-8334-0f2c8acdbe08> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000849  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1149|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000849/0f55fcd1-71c4-40b5-b060-93365d2b40cd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000849/362599d7-5f74-4bc7-b689-94efc4a983ba> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000849/471ddb54-47fd-424d-8005-1ad8e42168e8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000849/90deb3c8-af0d-42e8-9d02-58cd774aba7e> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000849/9071522a-a425-4411-be79-45eaaade5625> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000849/56634883-74ae-40c4-996c-39082caedd11> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000849  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1149|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000849/0f55fcd1-71c4-40b5-b060-93365d2b40cd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000849/0a6c4bb2-ee75-4abe-aa63-d942468327b2> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000849/471ddb54-47fd-424d-8005-1ad8e42168e8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000849/540c9251-b050-4ff8-a412-3f81e2644ecd> .
 

--- a/models/WB_WBGene00000850.ttl
+++ b/models/WB_WBGene00000850.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000850> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cup-11 (WB:WBGene00000850)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000850> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000850/4ac95e2d-2756-4ecf-bcda-086ca4dfb2f2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000850/91569b7b-a97c-42c8-9bdb-412f5674a777> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000850/7ac5d8ab-3fc0-4ab2-b731-a50af2c7e9cf> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000850/fc04f49f-798b-472a-8ae1-9ce7945f70e2> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11560892" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00000850/60ad1ce8-48a4-456d-87bc-75bcdc8a9d6f> a GO:0006897,
+<http://model.geneontology.org/WB_WBGene00000850/5c05990e-01ce-4573-8925-61d1b4834d24> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000850/c5c9c55c-cd31-41aa-9334-d36f649e255d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000850/e6237ac3-f7b0-4484-b6c0-8e1c79d2804d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000850/8b0137bd-eef5-43f8-8f16-6c7833b97990> a WB:WBGene00000850,
+<http://model.geneontology.org/WB_WBGene00000850/c5c9c55c-cd31-41aa-9334-d36f649e255d> a WB:WBGene00000850,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000850/9dfe58e8-e485-405a-8fd9-215f4604ef77> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000850/e6237ac3-f7b0-4484-b6c0-8e1c79d2804d> a GO:0006897,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000850/8b0137bd-eef5-43f8-8f16-6c7833b97990> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000850/60ad1ce8-48a4-456d-87bc-75bcdc8a9d6f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000850/7ac5d8ab-3fc0-4ab2-b731-a50af2c7e9cf> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000850/fc04f49f-798b-472a-8ae1-9ce7945f70e2> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000850  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1150|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000850/9dfe58e8-e485-405a-8fd9-215f4604ef77> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000850/8b0137bd-eef5-43f8-8f16-6c7833b97990> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000850/5c05990e-01ce-4573-8925-61d1b4834d24> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000850/c5c9c55c-cd31-41aa-9334-d36f649e255d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000850/4ac95e2d-2756-4ecf-bcda-086ca4dfb2f2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000850/91569b7b-a97c-42c8-9bdb-412f5674a777> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000850  RO:0002264 GO:0006897 WB:WBPaper00004883|PMID:11560892 ECO:0000315   2021-05-13 WB  id=WBOA:1150|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000850/9dfe58e8-e485-405a-8fd9-215f4604ef77> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000850/60ad1ce8-48a4-456d-87bc-75bcdc8a9d6f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000850/5c05990e-01ce-4573-8925-61d1b4834d24> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000850/e6237ac3-f7b0-4484-b6c0-8e1c79d2804d> .
 

--- a/models/WB_WBGene00000873.ttl
+++ b/models/WB_WBGene00000873.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,134 +29,140 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00000873> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "cyk-2 (WB:WBGene00000873)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00000873> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00000873/0f0e867f-51fd-425b-a8a9-e4c65545e6ae> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000873/03bfa91c-93f6-44b2-b495-7fcb3f43d1bd> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/71812b06-bce0-43cf-96c1-838436ef47e6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000873/06a1cbc1-213c-4b98-9966-6a2e604a0920> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/76950a7c-fea0-44d3-aa5e-e7fce70ec08e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000873/5d3a254b-a7f5-4cea-82b0-901521607627> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/a3a024be-f1b4-4c07-816b-516571ef7964> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000873/81f7301c-7b78-4fa5-b119-98ffc9f8f428> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/ce9ac995-07cc-465b-bb1d-620d8eecea84> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000873/8ad65588-bd66-47e2-9c50-4ce37d126be0> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/d514f816-c0b5-4740-9ce8-86fc01f3cebb> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00000873/cbf5c874-6182-4e45-af39-0fc120c22540> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/46bf46b8-b0a3-41d1-997b-aecd50127fbe> a WB:WBGene00000873,
+<http://model.geneontology.org/WB_WBGene00000873/650113c0-8df9-4064-aed3-76767f27ed4d> a GO:1902410,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/5e8861a8-3027-4ac3-adfa-0a93ccaf4ec4> a GO:1903673,
+<http://model.geneontology.org/WB_WBGene00000873/6b8e44f7-b0dd-4752-abf6-10178432cee6> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/9483ed77-a0c2-4a69-b327-e4992951b2a2> a GO:1902410,
+<http://model.geneontology.org/WB_WBGene00000873/6eba9576-e0a3-4d0d-92d7-30179c3f2a58> a WB:WBGene00000873,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/9b6a71ca-bd5a-4e83-8a2e-46b64e4f379d> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00000873/7967e9cc-2b12-48a1-aa14-37e17617bb91> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000873/d18bff8c-9aee-4d4c-a490-48afbeccda09> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000873/9483ed77-a0c2-4a69-b327-e4992951b2a2> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000873/d6904460-d6a1-4e8f-a5e1-f84c7d29ef21> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000873/650113c0-8df9-4064-aed3-76767f27ed4d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/9ebbe5dc-1e98-43cc-90bf-5fa0550c4ef6> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000873/46bf46b8-b0a3-41d1-997b-aecd50127fbe> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000873/5e8861a8-3027-4ac3-adfa-0a93ccaf4ec4> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000873/a8d87f02-e6f3-4514-a876-0be567ec1eaf> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000873/bc07867e-f916-47fc-9b72-6b13aebeaa85> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000873/f16b36da-fd93-4168-aba5-c2c7cca7ba95> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00000873/bc07867e-f916-47fc-9b72-6b13aebeaa85> a WB:WBGene00000873,
+<http://model.geneontology.org/WB_WBGene00000873/8790d56c-b021-4476-b935-8f4e383a2dd1> a GO:1903673,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/d18bff8c-9aee-4d4c-a490-48afbeccda09> a WB:WBGene00000873,
+<http://model.geneontology.org/WB_WBGene00000873/92d60c6f-96a0-4f64-933b-cfa8f8911c52> a WB:WBGene00000873,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00000873/f16b36da-fd93-4168-aba5-c2c7cca7ba95> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00000873/b0e8aab1-1a75-4faf-a5b5-de7dac7543d8> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000873/92d60c6f-96a0-4f64-933b-cfa8f8911c52> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000873/8790d56c-b021-4476-b935-8f4e383a2dd1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000873/c594edbe-c421-4952-b934-136d1bedcad3> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00000873/6eba9576-e0a3-4d0d-92d7-30179c3f2a58> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00000873/6b8e44f7-b0dd-4752-abf6-10178432cee6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00000873/d6904460-d6a1-4e8f-a5e1-f84c7d29ef21> a WB:WBGene00000873,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -164,74 +170,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000873/a3a024be-f1b4-4c07-816b-516571ef7964> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000873/81f7301c-7b78-4fa5-b119-98ffc9f8f428> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1173|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/a8d87f02-e6f3-4514-a876-0be567ec1eaf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/bc07867e-f916-47fc-9b72-6b13aebeaa85> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000873/d514f816-c0b5-4740-9ce8-86fc01f3cebb> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1903673 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1172|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/9ebbe5dc-1e98-43cc-90bf-5fa0550c4ef6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/5e8861a8-3027-4ac3-adfa-0a93ccaf4ec4> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000873/0f0e867f-51fd-425b-a8a9-e4c65545e6ae> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1902410 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1174|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/9b6a71ca-bd5a-4e83-8a2e-46b64e4f379d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/9483ed77-a0c2-4a69-b327-e4992951b2a2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000873/71812b06-bce0-43cf-96c1-838436ef47e6> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1903673 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1172|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/9ebbe5dc-1e98-43cc-90bf-5fa0550c4ef6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/46bf46b8-b0a3-41d1-997b-aecd50127fbe> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000873/76950a7c-fea0-44d3-aa5e-e7fce70ec08e> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1902410 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1174|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/9b6a71ca-bd5a-4e83-8a2e-46b64e4f379d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/d18bff8c-9aee-4d4c-a490-48afbeccda09> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/7967e9cc-2b12-48a1-aa14-37e17617bb91> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/d6904460-d6a1-4e8f-a5e1-f84c7d29ef21> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00000873/ce9ac995-07cc-465b-bb1d-620d8eecea84> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000873/5d3a254b-a7f5-4cea-82b0-901521607627> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1903673 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1172|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/b0e8aab1-1a75-4faf-a5b5-de7dac7543d8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/8790d56c-b021-4476-b935-8f4e383a2dd1> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000873/03bfa91c-93f6-44b2-b495-7fcb3f43d1bd> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1173|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/c594edbe-c421-4952-b934-136d1bedcad3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/6eba9576-e0a3-4d0d-92d7-30179c3f2a58> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000873/cbf5c874-6182-4e45-af39-0fc120c22540> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000873  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1173|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/a8d87f02-e6f3-4514-a876-0be567ec1eaf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/f16b36da-fd93-4168-aba5-c2c7cca7ba95> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/c594edbe-c421-4952-b934-136d1bedcad3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/6b8e44f7-b0dd-4752-abf6-10178432cee6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000873/8ad65588-bd66-47e2-9c50-4ce37d126be0> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1902410 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1174|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/7967e9cc-2b12-48a1-aa14-37e17617bb91> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/650113c0-8df9-4064-aed3-76767f27ed4d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00000873/06a1cbc1-213c-4b98-9966-6a2e604a0920> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00000873  RO:0002264 GO:1903673 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:1172|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00000873/b0e8aab1-1a75-4faf-a5b5-de7dac7543d8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00000873/92d60c6f-96a0-4f64-933b-cfa8f8911c52> .
 

--- a/models/WB_WBGene00001141.ttl
+++ b/models/WB_WBGene00001141.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001141> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "eat-10 (WB:WBGene00001141)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001141> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001141/3edd073a-a4dd-46d9-9491-fc46185011a9> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001141/1a78024a-dbf7-4805-856a-0d747923c9dd> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000044" ;
+    ns1:evidence-with "WB:WBVar00000044" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:16884547" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001141/7a5ae596-a150-472a-a95d-ad9f186383a6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001141/adfcdb8c-58b4-42e1-a75e-ebfe4cb8cb38> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000044" ;
+    ns1:evidence-with "WB:WBVar00000044" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:16884547" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001141/a6e8dd6f-62ec-4358-8b42-1ab2b9833221> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001141/30712503-177e-40d0-997e-72ffdda4eec3> a GO:0035264,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001141/d20086bb-f9c1-4908-89e5-73c56f390faf> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001141/aa2e92c8-b6bb-46d0-81f5-785f75f745ca> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001141/aa2e92c8-b6bb-46d0-81f5-785f75f745ca> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00001141/6f32bb81-c3dc-4a10-b842-80b93e921947> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001141/ad2e9d4b-86c7-4dd0-8030-6f32e8659b4c> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001141/30712503-177e-40d0-997e-72ffdda4eec3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001141/d20086bb-f9c1-4908-89e5-73c56f390faf> a WB:WBGene00001141,
+<http://model.geneontology.org/WB_WBGene00001141/ad2e9d4b-86c7-4dd0-8030-6f32e8659b4c> a WB:WBGene00001141,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001141/3edd073a-a4dd-46d9-9491-fc46185011a9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001141/1a78024a-dbf7-4805-856a-0d747923c9dd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001141  RO:0002264 GO:0035264 WB:WBPaper00028380|PMID:16884547 ECO:0000315 WB:WBVar00000044  2021-05-13 WB  id=WBOA:9021|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001141/a6e8dd6f-62ec-4358-8b42-1ab2b9833221> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001141/aa2e92c8-b6bb-46d0-81f5-785f75f745ca> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001141/7a5ae596-a150-472a-a95d-ad9f186383a6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001141  RO:0002264 GO:0035264 WB:WBPaper00028380|PMID:16884547 ECO:0000315 WB:WBVar00000044  2021-05-13 WB  id=WBOA:9021|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001141/a6e8dd6f-62ec-4358-8b42-1ab2b9833221> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001141/d20086bb-f9c1-4908-89e5-73c56f390faf> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001141/6f32bb81-c3dc-4a10-b842-80b93e921947> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001141/ad2e9d4b-86c7-4dd0-8030-6f32e8659b4c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001141/adfcdb8c-58b4-42e1-a75e-ebfe4cb8cb38> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001141  RO:0002264 GO:0035264 WB:WBPaper00028380|PMID:16884547 ECO:0000315 WB:WBVar00000044  2021-05-13 WB  id=WBOA:9021|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001141/6f32bb81-c3dc-4a10-b842-80b93e921947> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001141/30712503-177e-40d0-997e-72ffdda4eec3> .
 

--- a/models/WB_WBGene00001198.ttl
+++ b/models/WB_WBGene00001198.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,174 +29,184 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001198> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "GOC:cab1",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "egl-32 (WB:WBGene00001198)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001198> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001198/21c549af-4b9a-4d2c-b59e-0e37887ab052> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001198/100870d1-293c-4f6b-a012-78aed306e948> a ECO:0000316,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:10978280" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/3a41e2f8-d871-40dd-89a0-5adcd4df33b6> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089289" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:17472754" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/3f8bfa31-709d-4ee7-b3fb-e62da812d0f1> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000899" ;
+    ns1:evidence-with "WB:WBGene00000899" ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "with respect to egg-laying" .
 
-<http://model.geneontology.org/WB_WBGene00001198/55fa3929-980d-4f50-b0eb-f956d8462111> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001198/31a60bbb-c980-4478-a660-0a22d6f43eec> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089289" ;
+    ns1:evidence-with "WB:WBGene00000901" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
-    dc:source "PMID:17472754" ;
+    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001198/6ce89523-4f21-497f-a13c-7e01ecc2c65f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001198/4aa2126c-b24e-4932-9354-47975c19d942> a ECO:0000316,
         owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000899" ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:10978280" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/7e7efa0d-e82f-4dff-8b4b-6745a5a8de45> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "GOC:cab1" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:10978280" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/9465fddf-bfcc-4ed9-a689-4050d5b012cf> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:10978280" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/9509ab5c-1bcf-40fd-9cae-70bb99f0ea2d> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000901" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:10978280" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/c04baf0f-c731-4320-917e-7e6db8b5861e> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000901" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:10978280" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/c927ca61-89c1-4241-9dfb-8099ebd342d1> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000899" ;
-    dc:contributor "GOC:cab1" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "with respect to egg-laying" .
 
-<http://model.geneontology.org/WB_WBGene00001198/056fe0e2-5537-434d-bfe9-ba9bebb4557d> a WB:WBGene00001198,
+<http://model.geneontology.org/WB_WBGene00001198/7f18ba76-ce9d-41b8-8ce9-969c2cd37a15> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089289" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:17472754" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/7f4e6d35-a2fa-48a5-8e7f-679fc0cf0ba1> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000901" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/830d5e02-376a-4c67-b26f-500f280afdea> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "GOC:cab1" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/b8f07191-4fbb-464c-ae68-6470223c1b6f> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/cb9edec2-b781-4b71-9078-ae9d5c33c404> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "GOC:cab1" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/d50f1ae0-ef55-49db-b4a3-53df2e6d804f> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089289" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:17472754" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/d59326cb-e983-44bd-9407-526f10b7d4e6> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:10978280" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/27f0559a-13cd-4b1b-a691-6d9d8e1a633d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001198/ce7c8cc4-9984-4440-a14b-766ef186f435> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001198/d283f052-1ccb-41a1-b048-d86e452f2cc2> ;
+    dc:contributor "GOC:cab1",
+        "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/2b0e2f1d-edfe-4405-bcc6-d7a0bfdeaacb> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001198/5a3ce917-0fad-4b03-95ab-71751a83f4f0> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001198/2b2056bc-20fc-4caf-86e3-8fe293922076> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/2b2056bc-20fc-4caf-86e3-8fe293922076> a GO:0018991,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/5a3ce917-0fad-4b03-95ab-71751a83f4f0> a WB:WBGene00001198,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/76d6f836-08af-4d41-89f1-654619d4296d> a GO:0007606,
+        owl:NamedIndividual ;
+    dc:contributor "GOC:cab1" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/cdfd16ac-7838-48f5-b41d-f8e48b107d09> a WB:WBGene00001198,
+        owl:NamedIndividual ;
+    dc:contributor "GOC:cab1" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001198/ce7c8cc4-9984-4440-a14b-766ef186f435> a WB:WBGene00001198,
         owl:NamedIndividual ;
     dc:contributor "GOC:cab1",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001198/141da69c-76cf-4aaf-959d-ed0d466e5acc> a WB:WBGene00001198,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/2be81935-2990-4295-8f29-5ff1056cc010> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001198/141da69c-76cf-4aaf-959d-ed0d466e5acc> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001198/2f63ed88-b0ac-4816-9c7d-9cb85234f517> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/2f63ed88-b0ac-4816-9c7d-9cb85234f517> a GO:0018991,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/43ae88d1-8532-48d8-8a44-cd38811209f2> a WB:WBGene00001198,
-        owl:NamedIndividual ;
-    dc:contributor "GOC:cab1" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/52bccc7c-f657-47d4-b611-e4329012257d> a GO:0007606,
-        owl:NamedIndividual ;
-    dc:contributor "GOC:cab1" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/ae4fcd5d-fa0b-455a-bd7b-fca5922bad51> a GO:0007179,
+<http://model.geneontology.org/WB_WBGene00001198/d283f052-1ccb-41a1-b048-d86e452f2cc2> a GO:0007179,
         owl:NamedIndividual ;
     dc:contributor "GOC:cab1",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001198/b44e67e0-74cc-47c9-9293-46e46221cc4b> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001198/d8828402-43eb-44d3-a2b5-457a7553d6b7> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001198/43ae88d1-8532-48d8-8a44-cd38811209f2> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001198/52bccc7c-f657-47d4-b611-e4329012257d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001198/cdfd16ac-7838-48f5-b41d-f8e48b107d09> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001198/76d6f836-08af-4d41-89f1-654619d4296d> ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001198/fac249d8-a52e-4e88-9d81-10e3b858176b> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001198/056fe0e2-5537-434d-bfe9-ba9bebb4557d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001198/ae4fcd5d-fa0b-455a-bd7b-fca5922bad51> ;
-    dc:contributor "GOC:cab1",
-        "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -204,84 +214,84 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001198/55fa3929-980d-4f50-b0eb-f956d8462111>,
-        <http://model.geneontology.org/WB_WBGene00001198/9465fddf-bfcc-4ed9-a689-4050d5b012cf> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0018991 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1806|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13",
-        "WB:WBGene00001198  RO:0002264 GO:0018991 WB:WBPaper00029335|PMID:17472754 ECO:0000315 WB:WBVar00089289  2020-05-13 WB  id=WBOA:1809|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/2be81935-2990-4295-8f29-5ff1056cc010> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/2f63ed88-b0ac-4816-9c7d-9cb85234f517> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001198/6ce89523-4f21-497f-a13c-7e01ecc2c65f> ;
-    dc:contributor "GOC:cab1" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007606 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1808|contributor-id=GOC:cab1|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/b44e67e0-74cc-47c9-9293-46e46221cc4b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/43ae88d1-8532-48d8-8a44-cd38811209f2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001198/c04baf0f-c731-4320-917e-7e6db8b5861e>,
-        <http://model.geneontology.org/WB_WBGene00001198/c927ca61-89c1-4241-9dfb-8099ebd342d1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001198/31a60bbb-c980-4478-a660-0a22d6f43eec>,
+        <http://model.geneontology.org/WB_WBGene00001198/4aa2126c-b24e-4932-9354-47975c19d942> ;
     dc:contributor "GOC:cab1",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007179 WB:WBPaper00004310|PMID:10978280 ECO:0000316 WB:WBGene00000899  2020-05-13 WB  id=WBOA:1807|contributor-id=GOC:cab1|comment=with respect to egg-laying|creation-date=2020-05-13|modification-date=2020-05-13",
-        "WB:WBGene00001198  RO:0002264 GO:0007179 WB:WBPaper00004310|PMID:10978280 ECO:0000316 WB:WBGene00000901  2020-05-13 WB  id=WBOA:14260|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/fac249d8-a52e-4e88-9d81-10e3b858176b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/056fe0e2-5537-434d-bfe9-ba9bebb4557d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001198/7e7efa0d-e82f-4dff-8b4b-6745a5a8de45> ;
-    dc:contributor "GOC:cab1" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007606 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1808|contributor-id=GOC:cab1|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/b44e67e0-74cc-47c9-9293-46e46221cc4b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/52bccc7c-f657-47d4-b611-e4329012257d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001198/3f8bfa31-709d-4ee7-b3fb-e62da812d0f1>,
-        <http://model.geneontology.org/WB_WBGene00001198/9509ab5c-1bcf-40fd-9cae-70bb99f0ea2d> ;
-    dc:contributor "GOC:cab1",
-        "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007179 WB:WBPaper00004310|PMID:10978280 ECO:0000316 WB:WBGene00000899  2020-05-13 WB  id=WBOA:1807|contributor-id=GOC:cab1|comment=with respect to egg-laying|creation-date=2020-05-13|modification-date=2020-05-13",
         "WB:WBGene00001198  RO:0002264 GO:0007179 WB:WBPaper00004310|PMID:10978280 ECO:0000316 WB:WBGene00000901  2020-05-13 WB  id=WBOA:14260|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/fac249d8-a52e-4e88-9d81-10e3b858176b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/ae4fcd5d-fa0b-455a-bd7b-fca5922bad51> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/27f0559a-13cd-4b1b-a691-6d9d8e1a633d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/d283f052-1ccb-41a1-b048-d86e452f2cc2> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001198/21c549af-4b9a-4d2c-b59e-0e37887ab052>,
-        <http://model.geneontology.org/WB_WBGene00001198/3a41e2f8-d871-40dd-89a0-5adcd4df33b6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001198/d50f1ae0-ef55-49db-b4a3-53df2e6d804f>,
+        <http://model.geneontology.org/WB_WBGene00001198/d59326cb-e983-44bd-9407-526f10b7d4e6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0018991 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1806|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13",
         "WB:WBGene00001198  RO:0002264 GO:0018991 WB:WBPaper00029335|PMID:17472754 ECO:0000315 WB:WBVar00089289  2020-05-13 WB  id=WBOA:1809|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/2be81935-2990-4295-8f29-5ff1056cc010> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/141da69c-76cf-4aaf-959d-ed0d466e5acc> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/2b0e2f1d-edfe-4405-bcc6-d7a0bfdeaacb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/5a3ce917-0fad-4b03-95ab-71751a83f4f0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001198/830d5e02-376a-4c67-b26f-500f280afdea> ;
+    dc:contributor "GOC:cab1" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007606 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1808|contributor-id=GOC:cab1|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/d8828402-43eb-44d3-a2b5-457a7553d6b7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/cdfd16ac-7838-48f5-b41d-f8e48b107d09> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001198/7f18ba76-ce9d-41b8-8ce9-969c2cd37a15>,
+        <http://model.geneontology.org/WB_WBGene00001198/b8f07191-4fbb-464c-ae68-6470223c1b6f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0018991 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1806|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13",
+        "WB:WBGene00001198  RO:0002264 GO:0018991 WB:WBPaper00029335|PMID:17472754 ECO:0000315 WB:WBVar00089289  2020-05-13 WB  id=WBOA:1809|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/2b0e2f1d-edfe-4405-bcc6-d7a0bfdeaacb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/2b2056bc-20fc-4caf-86e3-8fe293922076> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001198/100870d1-293c-4f6b-a012-78aed306e948>,
+        <http://model.geneontology.org/WB_WBGene00001198/7f4e6d35-a2fa-48a5-8e7f-679fc0cf0ba1> ;
+    dc:contributor "GOC:cab1",
+        "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007179 WB:WBPaper00004310|PMID:10978280 ECO:0000316 WB:WBGene00000899  2020-05-13 WB  id=WBOA:1807|contributor-id=GOC:cab1|comment=with respect to egg-laying|creation-date=2020-05-13|modification-date=2020-05-13",
+        "WB:WBGene00001198  RO:0002264 GO:0007179 WB:WBPaper00004310|PMID:10978280 ECO:0000316 WB:WBGene00000901  2020-05-13 WB  id=WBOA:14260|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/27f0559a-13cd-4b1b-a691-6d9d8e1a633d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/ce7c8cc4-9984-4440-a14b-766ef186f435> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001198/cb9edec2-b781-4b71-9078-ae9d5c33c404> ;
+    dc:contributor "GOC:cab1" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001198  RO:0002264 GO:0007606 WB:WBPaper00004310|PMID:10978280 ECO:0000315   2020-05-13 WB  id=WBOA:1808|contributor-id=GOC:cab1|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001198/d8828402-43eb-44d3-a2b5-457a7553d6b7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001198/76d6f836-08af-4d41-89f1-654619d4296d> .
 

--- a/models/WB_WBGene00001205.ttl
+++ b/models/WB_WBGene00001205.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001205> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dc:title "egl-40 (WB:WBGene00001205)" ;
     dct:created "2021-03-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001205> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001205/83d3cdd5-8051-4e19-88fc-2791d599c597> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001205/62ba3656-28fa-4444-9418-8c346d0ee5fc> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089623" ;
+    ns1:evidence-with "WB:WBVar00089623" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dc:source "PMID:6583682" ;
+    dct:created "2021-03-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001205/fd897c9a-24af-467d-85e8-ed6818f211fc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001205/e59f1ea1-1e18-4bcc-b60d-2cc534b9fef9> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089623" ;
+    ns1:evidence-with "WB:WBVar00089623" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dc:source "PMID:6583682" ;
+    dct:created "2021-03-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001205/210c435e-93a5-4f14-9e32-4dad4285a11a> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001205/07e8f499-6043-43fe-b5cc-d01674967b88> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001205/69d64718-a8f9-434f-bbee-6207a88a1cb7> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001205/c9267f92-5f86-44c4-a625-237e35f95d85> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001205/dfa54c9f-8401-42c5-9a27-c0b820e2fe67> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001205/5804a687-4042-4964-b758-2588aa14741b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dct:created "2021-03-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001205/69d64718-a8f9-434f-bbee-6207a88a1cb7> a WB:WBGene00001205,
+<http://model.geneontology.org/WB_WBGene00001205/5804a687-4042-4964-b758-2588aa14741b> a GO:0040024,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dct:created "2021-03-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001205/c9267f92-5f86-44c4-a625-237e35f95d85> a GO:0040024,
+<http://model.geneontology.org/WB_WBGene00001205/dfa54c9f-8401-42c5-9a27-c0b820e2fe67> a WB:WBGene00001205,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dct:created "2021-03-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001205/fd897c9a-24af-467d-85e8-ed6818f211fc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001205/e59f1ea1-1e18-4bcc-b60d-2cc534b9fef9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dct:created "2021-03-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001205  RO:0002264 GO:0040024 WB:WBPaper00000680|PMID:6583682 ECO:0000315 WB:WBVar00089623  2021-03-09 WB  id=WBOA:51801|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-09|modification-date=2021-03-09" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001205/210c435e-93a5-4f14-9e32-4dad4285a11a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001205/69d64718-a8f9-434f-bbee-6207a88a1cb7> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001205/07e8f499-6043-43fe-b5cc-d01674967b88> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001205/dfa54c9f-8401-42c5-9a27-c0b820e2fe67> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001205/83d3cdd5-8051-4e19-88fc-2791d599c597> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001205/62ba3656-28fa-4444-9418-8c346d0ee5fc> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-09" ;
     dct:created "2021-03-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001205  RO:0002264 GO:0040024 WB:WBPaper00000680|PMID:6583682 ECO:0000315 WB:WBVar00089623  2021-03-09 WB  id=WBOA:51801|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-09|modification-date=2021-03-09" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001205/210c435e-93a5-4f14-9e32-4dad4285a11a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001205/c9267f92-5f86-44c4-a625-237e35f95d85> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001205/07e8f499-6043-43fe-b5cc-d01674967b88> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001205/5804a687-4042-4964-b758-2588aa14741b> .
 

--- a/models/WB_WBGene00001267.ttl
+++ b/models/WB_WBGene00001267.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,31 +29,33 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001267> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "emb-13 (WB:WBGene00001267)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001267> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001267/0b7eb39f-4d30-4acf-9715-5b533cfd36eb> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001267/b641d2fd-91b9-40f0-99bc-a3aecc3ac9a9> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145355" ;
+    ns1:evidence-with "WB:WBVar00145355" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:6683689" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Switched reference to an earlier paper with a PMID reference, that describes emb-13; the deleted paper, WBPaper00000689 does not have a PMID." .
 
-<http://model.geneontology.org/WB_WBGene00001267/1a5a818b-f343-49b1-9216-6b121ad0cd06> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001267/d60bbe14-be2e-4a52-9c75-6eeed82ef28e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145355" ;
+    ns1:evidence-with "WB:WBVar00145355" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:6683689" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Switched reference to an earlier paper with a PMID reference, that describes emb-13; the deleted paper, WBPaper00000689 does not have a PMID." .
 
@@ -61,53 +63,53 @@ obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001267/1a0202e7-0f8b-4d03-ac7d-641e467a091f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001267/064dbc5b-837e-4f65-ae48-5b3710f0c15d> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001267/af98a768-c75f-4408-b5fc-1ff3a631bfba> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001267/73f0b491-b8da-45a3-8b62-a96cb510e2b9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001267/1052b713-c0c8-4a11-8215-b669e209f45d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001267/4a0a8f92-31cb-4d59-a35e-ca5a3815c86b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001267/73f0b491-b8da-45a3-8b62-a96cb510e2b9> a GO:0048598,
+<http://model.geneontology.org/WB_WBGene00001267/1052b713-c0c8-4a11-8215-b669e209f45d> a WB:WBGene00001267,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001267/af98a768-c75f-4408-b5fc-1ff3a631bfba> a WB:WBGene00001267,
+<http://model.geneontology.org/WB_WBGene00001267/4a0a8f92-31cb-4d59-a35e-ca5a3815c86b> a GO:0048598,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001267/0b7eb39f-4d30-4acf-9715-5b533cfd36eb> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001267/b641d2fd-91b9-40f0-99bc-a3aecc3ac9a9> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001267  RO:0002264 GO:0048598 WB:WBPaper00000661|PMID:6683689 ECO:0000315 WB:WBVar00145355  2021-05-13 WB  id=WBOA:9859|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Switched reference to an earlier paper with a PMID reference, that describes emb-13; the deleted paper, WBPaper00000689 does not have a PMID.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001267/1a0202e7-0f8b-4d03-ac7d-641e467a091f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001267/73f0b491-b8da-45a3-8b62-a96cb510e2b9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001267/064dbc5b-837e-4f65-ae48-5b3710f0c15d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001267/4a0a8f92-31cb-4d59-a35e-ca5a3815c86b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001267/1a5a818b-f343-49b1-9216-6b121ad0cd06> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001267/d60bbe14-be2e-4a52-9c75-6eeed82ef28e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001267  RO:0002264 GO:0048598 WB:WBPaper00000661|PMID:6683689 ECO:0000315 WB:WBVar00145355  2021-05-13 WB  id=WBOA:9859|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Switched reference to an earlier paper with a PMID reference, that describes emb-13; the deleted paper, WBPaper00000689 does not have a PMID.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001267/1a0202e7-0f8b-4d03-ac7d-641e467a091f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001267/af98a768-c75f-4408-b5fc-1ff3a631bfba> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001267/064dbc5b-837e-4f65-ae48-5b3710f0c15d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001267/1052b713-c0c8-4a11-8215-b669e209f45d> .
 

--- a/models/WB_WBGene00001326.ttl
+++ b/models/WB_WBGene00001326.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001326> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "eos-1 (WB:WBGene00001326)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001326> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001326/4adab0e3-9cac-4a03-9326-e8c6fe7e3939> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001326/131ec1ba-62c5-43c9-be5d-821d5d9bcbc6> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091420" ;
+    ns1:evidence-with "WB:WBVar00091420" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10066248" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001326/550e50f1-ddda-4b84-915a-4d48f7ee6b3b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001326/3d231bd0-0e89-4338-be90-8ae308ddb09a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091420" ;
+    ns1:evidence-with "WB:WBVar00091420" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10066248" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001326/79ab8bb9-b537-43da-8e8a-2216e7a3027c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001326/be8912f1-dad9-4204-a83e-bc5a9e2a533e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091420" ;
+    ns1:evidence-with "WB:WBVar00091420" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10066248" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001326/d944afa9-eb2f-488d-ab2b-bd482d4ffeb9> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001326/c600a975-b696-4fcc-9a7a-28702a808209> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091420" ;
+    ns1:evidence-with "WB:WBVar00091420" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10066248" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001326/1d7cf1ba-5ded-44af-bd20-02e2ce832bf4> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001326/62274f4f-14d2-4098-ac62-b6e9116a61d3> a WB:WBGene00001326,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001326/cd488986-fe78-4aad-85e5-8cae094be363> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001326/b9f71fba-71c1-4b70-a9ec-d25f2e4aaf13> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001326/b9f71fba-71c1-4b70-a9ec-d25f2e4aaf13> a GO:0007231,
+<http://model.geneontology.org/WB_WBGene00001326/92ae9ba5-4dc2-4e28-b0e1-003955d042c5> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001326/62274f4f-14d2-4098-ac62-b6e9116a61d3> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001326/9be56bff-13a2-42fe-b845-47edd0b75a9b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001326/cd488986-fe78-4aad-85e5-8cae094be363> a WB:WBGene00001326,
+<http://model.geneontology.org/WB_WBGene00001326/9be56bff-13a2-42fe-b845-47edd0b75a9b> a GO:0007231,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001326/550e50f1-ddda-4b84-915a-4d48f7ee6b3b>,
-        <http://model.geneontology.org/WB_WBGene00001326/d944afa9-eb2f-488d-ab2b-bd482d4ffeb9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001326/131ec1ba-62c5-43c9-be5d-821d5d9bcbc6>,
+        <http://model.geneontology.org/WB_WBGene00001326/be8912f1-dad9-4204-a83e-bc5a9e2a533e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001326  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091420  2021-05-13 WB  id=WBOA:9852|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00001326  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091420  2021-05-13 WB  id=WBOA:9857|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001326/1d7cf1ba-5ded-44af-bd20-02e2ce832bf4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001326/cd488986-fe78-4aad-85e5-8cae094be363> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001326/4adab0e3-9cac-4a03-9326-e8c6fe7e3939>,
-        <http://model.geneontology.org/WB_WBGene00001326/79ab8bb9-b537-43da-8e8a-2216e7a3027c> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001326  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091420  2021-05-13 WB  id=WBOA:9852|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00001326  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091420  2021-05-13 WB  id=WBOA:9857|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001326/1d7cf1ba-5ded-44af-bd20-02e2ce832bf4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001326/b9f71fba-71c1-4b70-a9ec-d25f2e4aaf13> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001326/92ae9ba5-4dc2-4e28-b0e1-003955d042c5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001326/9be56bff-13a2-42fe-b845-47edd0b75a9b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001326/3d231bd0-0e89-4338-be90-8ae308ddb09a>,
+        <http://model.geneontology.org/WB_WBGene00001326/c600a975-b696-4fcc-9a7a-28702a808209> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001326  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091420  2021-05-13 WB  id=WBOA:9852|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00001326  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091420  2021-05-13 WB  id=WBOA:9857|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001326/92ae9ba5-4dc2-4e28-b0e1-003955d042c5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001326/62274f4f-14d2-4098-ac62-b6e9116a61d3> .
 

--- a/models/WB_WBGene00001327.ttl
+++ b/models/WB_WBGene00001327.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,158 +29,162 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001327> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "eos-2 (WB:WBGene00001327)" ;
     dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001327> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001327/18ace3c8-5300-4b76-8dc7-7e75ff0b8815> a WB:WBGene00001327,
+<http://model.geneontology.org/WB_WBGene00001327/2b614939-69b3-425a-ad99-d45ece6c46a7> a ECO:0000307,
         owl:NamedIndividual ;
-    obo:RO_0002432 <http://model.geneontology.org/WB_WBGene00001327/b1bd15e3-d220-416d-8cc4-74d1af955d53> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "GO_REF:0000015" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001327/2edfa50e-f65d-48ed-bb37-ba0b3effb115> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00091419" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:10066248" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001327/55646794-57fd-4127-a0ae-74dd036d587e> a ECO:0000307,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-20" ;
+    dc:source "GO_REF:0000015" ;
+    dct:created "2020-04-20" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001327/6d9a44cb-8bed-41bf-94e7-34f81034a2a1> a WB:WBGene00001327,
+        owl:NamedIndividual ;
+    obo:RO_0002432 <http://model.geneontology.org/WB_WBGene00001327/f143de51-2d5b-4858-9a2d-8fbb84edfe52> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001327/337b958b-11f2-48c1-9933-eb189621993c> a ECO:0000307,
+<http://model.geneontology.org/WB_WBGene00001327/b736e638-7c80-46cd-a450-b197cb5b2497> a ECO:0000315,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-20" ;
-    dc:source "GO_REF:0000015" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001327/b0714982-a068-4616-8377-1f62e72451c0> a ECO:0000307,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "GO_REF:0000015" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001327/b43920de-60eb-46e1-96c5-91d323d54611> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091419" ;
+    ns1:evidence-with "WB:WBVar00091419" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10066248" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001327/ea42685d-0e71-4dc9-99bb-76ca58e246a4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001327/d163b6ac-bf73-4db1-a182-a0d699715259> a GO:0003674,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00091419" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:10066248" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001327/fe2c3dc0-227e-4d7e-ba44-987e9647be25> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001327/7c96893b-4087-42f6-a680-d4c74b1db2bf> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001327/fd7bf41c-957d-4967-89f0-fd03fb0f1e64> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-20" ;
     dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
 obo:RO_0002432 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001327/2e9fb43c-e150-403b-9ad7-c98d2f55d58b> a GO:0007231,
+<http://model.geneontology.org/WB_WBGene00001327/0d03ca5f-e5c6-4e09-b1ef-b3721a0241c6> a GO:0007231,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001327/4035c04a-4109-442e-b060-5dd335c532fb> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001327/837c085a-1103-4246-b6ee-7ad49f455e3f> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001327/2e9fb43c-e150-403b-9ad7-c98d2f55d58b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001327/7c96893b-4087-42f6-a680-d4c74b1db2bf> a WB:WBGene00001327,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-20" ;
-    dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001327/837c085a-1103-4246-b6ee-7ad49f455e3f> a WB:WBGene00001327,
+<http://model.geneontology.org/WB_WBGene00001327/28c58de5-d956-47b4-bfed-eb9288782131> a WB:WBGene00001327,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001327/b1bd15e3-d220-416d-8cc4-74d1af955d53> a GO:0005575,
+<http://model.geneontology.org/WB_WBGene00001327/d6b6cce2-b391-4ff7-8856-2ffee8d9ba71> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001327/28c58de5-d956-47b4-bfed-eb9288782131> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001327/0d03ca5f-e5c6-4e09-b1ef-b3721a0241c6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001327/f143de51-2d5b-4858-9a2d-8fbb84edfe52> a GO:0005575,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001327/fd7bf41c-957d-4967-89f0-fd03fb0f1e64> a WB:WBGene00001327,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-20" ;
+    dct:created "2020-04-20" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001327/b0714982-a068-4616-8377-1f62e72451c0> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001327  RO:0002432 GO:0005575 GO_REF:0000015 ECO:0000307   2020-05-13 WB  id=WBOA:89553|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:RO_0002432 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/18ace3c8-5300-4b76-8dc7-7e75ff0b8815> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/b1bd15e3-d220-416d-8cc4-74d1af955d53> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001327/ea42685d-0e71-4dc9-99bb-76ca58e246a4> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001327  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091419  2021-05-13 WB  id=WBOA:9853|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/4035c04a-4109-442e-b060-5dd335c532fb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/837c085a-1103-4246-b6ee-7ad49f455e3f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001327/b43920de-60eb-46e1-96c5-91d323d54611> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001327  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091419  2021-05-13 WB  id=WBOA:9853|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/4035c04a-4109-442e-b060-5dd335c532fb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/2e9fb43c-e150-403b-9ad7-c98d2f55d58b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001327/337b958b-11f2-48c1-9933-eb189621993c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001327/55646794-57fd-4127-a0ae-74dd036d587e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-20" ;
     dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001327  RO:0002327 GO:0003674 GO_REF:0000015 ECO:0000307   2020-04-20 WB  id=WBOA:9856|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-20|modification-date=2020-04-20" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/fe2c3dc0-227e-4d7e-ba44-987e9647be25> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/7c96893b-4087-42f6-a680-d4c74b1db2bf> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/d163b6ac-bf73-4db1-a182-a0d699715259> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/fd7bf41c-957d-4967-89f0-fd03fb0f1e64> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001327/b736e638-7c80-46cd-a450-b197cb5b2497> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001327  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091419  2021-05-13 WB  id=WBOA:9853|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/d6b6cce2-b391-4ff7-8856-2ffee8d9ba71> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/0d03ca5f-e5c6-4e09-b1ef-b3721a0241c6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001327/2edfa50e-f65d-48ed-bb37-ba0b3effb115> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001327  RO:0002264 GO:0007231 WB:WBPaper00003408|PMID:10066248 ECO:0000315 WB:WBVar00091419  2021-05-13 WB  id=WBOA:9853|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/d6b6cce2-b391-4ff7-8856-2ffee8d9ba71> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/28c58de5-d956-47b4-bfed-eb9288782131> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001327/2b614939-69b3-425a-ad99-d45ece6c46a7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001327  RO:0002432 GO:0005575 GO_REF:0000015 ECO:0000307   2020-05-13 WB  id=WBOA:89553|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:RO_0002432 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001327/6d9a44cb-8bed-41bf-94e7-34f81034a2a1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001327/f143de51-2d5b-4858-9a2d-8fbb84edfe52> .
 

--- a/models/WB_WBGene00001362.ttl
+++ b/models/WB_WBGene00001362.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001362> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dc:title "exc-1 (WB:WBGene00001362)" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001362> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001362/08225a98-426a-481f-aa3f-f939d7ebaf01> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001362/781faf0b-6d08-4832-bec2-73a5f953d213> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241508" ;
+    ns1:evidence-with "WB:WBVar00241508" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dc:source "PMID:10491271" ;
+    dct:created "2009-03-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/467e2a63-c148-4121-979a-f0e1e1b76388> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001362/91f1541b-23ab-4163-aef7-dde455b69be9> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241508" ;
+    ns1:evidence-with "WB:WBVar00241508" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dc:source "PMID:10491271" ;
+    dct:created "2009-03-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/5675f369-9669-4778-ad96-7a58e7573804> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001362/c73560e5-f77c-4d4a-a1ee-80a58b5d1dd1> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241508" ;
+    ns1:evidence-with "WB:WBVar00241508" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dc:source "PMID:10491271" ;
+    dct:created "2009-03-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/b69ee928-4d15-4f51-af72-7781f789be24> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001362/d4d8588c-e3fb-4e02-9d42-e9cdbde0a60c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241508" ;
+    ns1:evidence-with "WB:WBVar00241508" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dc:source "PMID:10491271" ;
+    dct:created "2009-03-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/2f232552-6bad-4bde-b6ef-abb5142bf551> a GO:0035150,
+<http://model.geneontology.org/WB_WBGene00001362/416d3d9f-347f-45bc-ab72-5713e6803c45> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001362/5fa497c9-8af1-4d99-88a6-1bd1e545b0ff> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001362/bd258f42-f420-41f6-85a0-083abd0b492c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-03-02" ;
+    dct:created "2009-03-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001362/5fa497c9-8af1-4d99-88a6-1bd1e545b0ff> a GO:0002064,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/37db6f81-8229-4a6b-a099-7b73c6107bfb> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001362/90ca2bd3-ba11-4ec4-8fd6-027c2ba4942a> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001362/5d12c1be-1f0b-48c9-bae9-b61fe3a51c65> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001362/9c9afb29-a135-4e4d-875d-69d1e581e6f6> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001362/be63ead2-4f0c-49b7-b201-ca505b3b78f9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001362/a3c7c8c9-f64b-4534-be20-6566cb2d2bf4> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/5d12c1be-1f0b-48c9-bae9-b61fe3a51c65> a GO:0002064,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-03-02" ;
-    dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001362/76ed8750-a645-4951-a8d8-c0e01cc115e2> a WB:WBGene00001362,
+<http://model.geneontology.org/WB_WBGene00001362/a3c7c8c9-f64b-4534-be20-6566cb2d2bf4> a WB:WBGene00001362,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001362/8fc21e78-419f-4ef2-a938-84c2b66acee1> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001362/2f232552-6bad-4bde-b6ef-abb5142bf551> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001362/76ed8750-a645-4951-a8d8-c0e01cc115e2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-03-02" ;
-    dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001362/9c9afb29-a135-4e4d-875d-69d1e581e6f6> a WB:WBGene00001362,
+<http://model.geneontology.org/WB_WBGene00001362/bd258f42-f420-41f6-85a0-083abd0b492c> a WB:WBGene00001362,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001362/be63ead2-4f0c-49b7-b201-ca505b3b78f9> a GO:0035150,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-03-02" ;
+    dct:created "2009-03-02" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001362/b69ee928-4d15-4f51-af72-7781f789be24> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001362/91f1541b-23ab-4163-aef7-dde455b69be9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001362  RO:0002331 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241508  2009-03-02 WB  id=WBOA:8061|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2009-03-02|modification-date=2009-03-02" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/37db6f81-8229-4a6b-a099-7b73c6107bfb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/9c9afb29-a135-4e4d-875d-69d1e581e6f6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/416d3d9f-347f-45bc-ab72-5713e6803c45> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/bd258f42-f420-41f6-85a0-083abd0b492c> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001362/5675f369-9669-4778-ad96-7a58e7573804> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001362/781faf0b-6d08-4832-bec2-73a5f953d213> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001362  RO:0002331 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241508  2009-03-02 WB  id=WBOA:8062|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2009-03-02|modification-date=2009-03-02" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/8fc21e78-419f-4ef2-a938-84c2b66acee1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/2f232552-6bad-4bde-b6ef-abb5142bf551> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/90ca2bd3-ba11-4ec4-8fd6-027c2ba4942a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/be63ead2-4f0c-49b7-b201-ca505b3b78f9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001362/08225a98-426a-481f-aa3f-f939d7ebaf01> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001362/c73560e5-f77c-4d4a-a1ee-80a58b5d1dd1> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-03-02" ;
     dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001362  RO:0002331 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241508  2009-03-02 WB  id=WBOA:8062|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2009-03-02|modification-date=2009-03-02" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/8fc21e78-419f-4ef2-a938-84c2b66acee1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/76ed8750-a645-4951-a8d8-c0e01cc115e2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001362/467e2a63-c148-4121-979a-f0e1e1b76388> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-03-02" ;
-    dct:created "2009-03-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001362  RO:0002331 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241508  2009-03-02 WB  id=WBOA:8061|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2009-03-02|modification-date=2009-03-02" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/37db6f81-8229-4a6b-a099-7b73c6107bfb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/5d12c1be-1f0b-48c9-bae9-b61fe3a51c65> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/416d3d9f-347f-45bc-ab72-5713e6803c45> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/5fa497c9-8af1-4d99-88a6-1bd1e545b0ff> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001362/d4d8588c-e3fb-4e02-9d42-e9cdbde0a60c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-03-02" ;
+    dct:created "2009-03-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001362  RO:0002331 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241508  2009-03-02 WB  id=WBOA:8062|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2009-03-02|modification-date=2009-03-02" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001362/90ca2bd3-ba11-4ec4-8fd6-027c2ba4942a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001362/a3c7c8c9-f64b-4534-be20-6566cb2d2bf4> .
 

--- a/models/WB_WBGene00001363.ttl
+++ b/models/WB_WBGene00001363.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,194 +29,210 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001363> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "exc-2 (WB:WBGene00001363)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001363> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001363/30d8aa01-cc63-4d8d-ad9f-c276104eed2b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/185cbbb0-05e9-4b2c-978e-25e9fef2699c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278483" ;
+    ns1:evidence-with "WB:WBVar00241543" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/4084b156-2000-4f8c-9896-a9da4e0b0211> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/35f4224b-847d-4a34-900a-8dbbc0e4d744> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241537" ;
+    ns1:evidence-with "WB:WBVar00241537" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/4c76cf78-d527-468c-8711-386ee7f7cdbb> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/41b4975f-7836-4623-ad8e-52de75cda178> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241543" ;
+    ns1:evidence-with "WB:WBVar00278483" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/4dd3922b-2a99-4cf5-8bb8-f95172635b23> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/44dfc722-c484-480e-9fca-33d8440c1b78> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278483" ;
+    ns1:evidence-with "WB:WBVar00241543" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/4e03aafa-12b1-4249-9d4c-6399cd4c4ac0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/698578fc-be6e-472a-8820-aa0cc1431dec> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241543" ;
+    ns1:evidence-with "WB:WBVar00278481" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/522ba51f-3bc1-479d-9613-dac2629bb378> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/97acb481-7cbb-4f8a-8265-f4fe285e3f9b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278481" ;
+    ns1:evidence-with "WB:WBVar00241543" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/56c409ac-c037-4d43-a9e5-d1800d48fc82> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/9d5bc063-4bea-4400-b5f6-f005b89ef169> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278483" ;
+    ns1:evidence-with "WB:WBVar00278481" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/60e9d4ca-4ab4-4acb-ae3b-f26a04f0317c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/a52190ad-491a-4092-917b-5353670ac996> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278483" ;
+    ns1:evidence-with "WB:WBVar00241543" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/6673c093-d167-4eb0-bc52-a51f7a88ac13> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/a936b0b6-3053-4d60-9aca-61d4270b582e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278481" ;
+    ns1:evidence-with "WB:WBVar00278481" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/6ac570be-7363-43a8-83e2-3e7137e8bbb9> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/b39b97e4-d01c-458f-9a50-8b8a2620614b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241543" ;
+    ns1:evidence-with "WB:WBVar00241537" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/a8da53d0-9e39-4636-bc4e-f43b49b446a4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/b90ed9d8-e078-4282-abca-a974b2d0fdb9> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241543" ;
+    ns1:evidence-with "WB:WBVar00278483" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/ae00963c-c886-4045-862e-8245940a1e8b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/c92af4ee-81cc-423b-986e-580ed5bc2f77> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241537" ;
+    ns1:evidence-with "WB:WBVar00278483" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/b5a503a7-cc93-4b68-98a7-77e1f3d4afd1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/d0d39cc4-6b49-4b48-9851-c4574ae70ced> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278481" ;
+    ns1:evidence-with "WB:WBVar00241537" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/b5d7eccc-aa95-4a07-a3a5-7d4754959b7c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/e6bddff5-486b-42c6-aba3-6ba1471bf423> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278481" ;
+    ns1:evidence-with "WB:WBVar00278481" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/bc2608ce-52c0-4038-b4ae-d7bb499c9e2b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/eedc3b6b-5ed3-47b9-8581-5f7ccdbf3f5c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241537" ;
+    ns1:evidence-with "WB:WBVar00278483" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/d02b4c0f-3c2b-45a8-9f35-299379c34d6d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001363/f1f4c6e0-f721-4198-8e88-a1c6328831cd> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241537" ;
+    ns1:evidence-with "WB:WBVar00241537" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/65e4f861-93e8-4efe-903d-8bca05f30f42> a WB:WBGene00001363,
+<http://model.geneontology.org/WB_WBGene00001363/4b47ed90-a109-47a0-a504-3f1e5d638787> a WB:WBGene00001363,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/8a217e69-ecba-40f1-9864-78e6f19d3786> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001363/65e4f861-93e8-4efe-903d-8bca05f30f42> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001363/d71b8d2a-914c-486e-af84-4cae3af7062c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001363/8b79c658-6f29-46a9-a146-75e18f1cd98a> a GO:0002064,
+<http://model.geneontology.org/WB_WBGene00001363/7bcdde23-e9b7-4802-a02c-d591730ad987> a GO:0002064,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/b4da6b9b-6b73-4d16-890f-5d8479a2dc59> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001363/c9595b6d-6825-4676-86f2-bef71bc857be> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001363/cc24d0bc-f493-4e7a-9347-da44a2f9a3a6> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001363/8b79c658-6f29-46a9-a146-75e18f1cd98a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001363/4b47ed90-a109-47a0-a504-3f1e5d638787> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001363/7bcdde23-e9b7-4802-a02c-d591730ad987> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/cc24d0bc-f493-4e7a-9347-da44a2f9a3a6> a WB:WBGene00001363,
+<http://model.geneontology.org/WB_WBGene00001363/d1dd9fa3-885d-43f1-a377-d99a3ef2cedf> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001363/f4da1a86-fcb4-4bfb-8725-31cc04820fdb> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001363/efcc2a39-b0d7-40d9-852a-4f357e4b0597> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001363/efcc2a39-b0d7-40d9-852a-4f357e4b0597> a GO:0035150,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001363/d71b8d2a-914c-486e-af84-4cae3af7062c> a GO:0035150,
+<http://model.geneontology.org/WB_WBGene00001363/f4da1a86-fcb4-4bfb-8725-31cc04820fdb> a WB:WBGene00001363,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -224,74 +240,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001363/4dd3922b-2a99-4cf5-8bb8-f95172635b23>,
-        <http://model.geneontology.org/WB_WBGene00001363/4e03aafa-12b1-4249-9d4c-6399cd4c4ac0>,
-        <http://model.geneontology.org/WB_WBGene00001363/6673c093-d167-4eb0-bc52-a51f7a88ac13>,
-        <http://model.geneontology.org/WB_WBGene00001363/bc2608ce-52c0-4038-b4ae-d7bb499c9e2b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001363/97acb481-7cbb-4f8a-8265-f4fe285e3f9b>,
+        <http://model.geneontology.org/WB_WBGene00001363/9d5bc063-4bea-4400-b5f6-f005b89ef169>,
+        <http://model.geneontology.org/WB_WBGene00001363/c92af4ee-81cc-423b-986e-580ed5bc2f77>,
+        <http://model.geneontology.org/WB_WBGene00001363/f1f4c6e0-f721-4198-8e88-a1c6328831cd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8064|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89574|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89573|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89572|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/8a217e69-ecba-40f1-9864-78e6f19d3786> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/65e4f861-93e8-4efe-903d-8bca05f30f42> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001363/4084b156-2000-4f8c-9896-a9da4e0b0211>,
-        <http://model.geneontology.org/WB_WBGene00001363/60e9d4ca-4ab4-4acb-ae3b-f26a04f0317c>,
-        <http://model.geneontology.org/WB_WBGene00001363/a8da53d0-9e39-4636-bc4e-f43b49b446a4>,
-        <http://model.geneontology.org/WB_WBGene00001363/b5d7eccc-aa95-4a07-a3a5-7d4754959b7c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8064|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89574|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89573|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89572|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/8a217e69-ecba-40f1-9864-78e6f19d3786> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/d71b8d2a-914c-486e-af84-4cae3af7062c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001363/4c76cf78-d527-468c-8711-386ee7f7cdbb>,
-        <http://model.geneontology.org/WB_WBGene00001363/56c409ac-c037-4d43-a9e5-d1800d48fc82>,
-        <http://model.geneontology.org/WB_WBGene00001363/b5a503a7-cc93-4b68-98a7-77e1f3d4afd1>,
-        <http://model.geneontology.org/WB_WBGene00001363/d02b4c0f-3c2b-45a8-9f35-299379c34d6d> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8063|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89571|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89570|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89569|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/b4da6b9b-6b73-4d16-890f-5d8479a2dc59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/8b79c658-6f29-46a9-a146-75e18f1cd98a> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001363/30d8aa01-cc63-4d8d-ad9f-c276104eed2b>,
-        <http://model.geneontology.org/WB_WBGene00001363/522ba51f-3bc1-479d-9613-dac2629bb378>,
-        <http://model.geneontology.org/WB_WBGene00001363/6ac570be-7363-43a8-83e2-3e7137e8bbb9>,
-        <http://model.geneontology.org/WB_WBGene00001363/ae00963c-c886-4045-862e-8245940a1e8b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8063|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89571|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89570|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89569|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/b4da6b9b-6b73-4d16-890f-5d8479a2dc59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/cc24d0bc-f493-4e7a-9347-da44a2f9a3a6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/c9595b6d-6825-4676-86f2-bef71bc857be> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/4b47ed90-a109-47a0-a504-3f1e5d638787> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001363/44dfc722-c484-480e-9fca-33d8440c1b78>,
+        <http://model.geneontology.org/WB_WBGene00001363/a936b0b6-3053-4d60-9aca-61d4270b582e>,
+        <http://model.geneontology.org/WB_WBGene00001363/b39b97e4-d01c-458f-9a50-8b8a2620614b>,
+        <http://model.geneontology.org/WB_WBGene00001363/b90ed9d8-e078-4282-abca-a974b2d0fdb9> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8064|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89574|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89573|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89572|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/d1dd9fa3-885d-43f1-a377-d99a3ef2cedf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/f4da1a86-fcb4-4bfb-8725-31cc04820fdb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001363/41b4975f-7836-4623-ad8e-52de75cda178>,
+        <http://model.geneontology.org/WB_WBGene00001363/a52190ad-491a-4092-917b-5353670ac996>,
+        <http://model.geneontology.org/WB_WBGene00001363/d0d39cc4-6b49-4b48-9851-c4574ae70ced>,
+        <http://model.geneontology.org/WB_WBGene00001363/e6bddff5-486b-42c6-aba3-6ba1471bf423> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8063|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89571|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89570|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89569|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/c9595b6d-6825-4676-86f2-bef71bc857be> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/7bcdde23-e9b7-4802-a02c-d591730ad987> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001363/185cbbb0-05e9-4b2c-978e-25e9fef2699c>,
+        <http://model.geneontology.org/WB_WBGene00001363/35f4224b-847d-4a34-900a-8dbbc0e4d744>,
+        <http://model.geneontology.org/WB_WBGene00001363/698578fc-be6e-472a-8820-aa0cc1431dec>,
+        <http://model.geneontology.org/WB_WBGene00001363/eedc3b6b-5ed3-47b9-8581-5f7ccdbf3f5c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241537  2021-03-12 WB  id=WBOA:8064|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241543  2021-03-12 WB  id=WBOA:89574|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278481  2021-03-12 WB  id=WBOA:89573|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001363  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278483  2021-03-12 WB  id=WBOA:89572|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001363/d1dd9fa3-885d-43f1-a377-d99a3ef2cedf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001363/efcc2a39-b0d7-40d9-852a-4f357e4b0597> .
 

--- a/models/WB_WBGene00001364.ttl
+++ b/models/WB_WBGene00001364.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,226 +29,246 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001364> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "exc-3 (WB:WBGene00001364)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001364> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001364/00c31215-5f75-4706-8faa-c7065acd4a39> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001364/04d1a665-c25d-427e-840a-8b7eafb9ee0b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241570" ;
+    ns1:evidence-with "WB:WBVar00241575" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/01b468a9-ee3a-4384-bdd3-8aece7f5fe66> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241570" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/05fffeb0-8906-4474-8fc2-21d30ebfa689> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241570" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/08781e86-3239-4802-92a2-5e4cd58b2283> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278482" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/0b371357-1736-4c47-ac20-af9758559e65> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278487" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/1b4939e8-558a-4ef0-9cea-efc0b1431209> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241581" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/2bbea168-807b-4009-8a2f-7511be0d8395> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278482" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/3520f552-1a64-4c74-a69f-caae4e823c58> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241581" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/4b30fe50-8bcb-4a81-8963-883a01f8c45f> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278487" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/57eb9e3e-73ec-43ad-abd2-231c73f84381> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241575" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/5c07ea96-36ff-4def-8e28-cb34744b0d44> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278482" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/704f8f23-a216-4b3c-9247-67deca21e85d> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241581" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/72aa3d37-5e59-4fb2-ab3a-9a9983582577> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241581" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/7a4e16de-59c0-415e-979e-14cae26dd6ac> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278487" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/88631aab-dd32-4d0b-9180-8d53d3abfe13> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241575" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/be930e10-6d19-4aa2-ae11-a97f4baacf21> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241570" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/ca9d87dc-194f-410b-84d7-82009e25ea33> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278487" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/d507a4bb-c7ab-4fa0-a337-0d9bbe2fafc9> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278482" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/d90dfaad-9f4c-41ef-8f58-c85994367624> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241575" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/fca2f1db-1e8d-42b9-8505-c37cb1c23619> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241575" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10491271" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001364/1551c535-8d12-4767-8770-c77502e748c3> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001364/f0a8f505-5052-40f8-86da-2951aefc49d8> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001364/4486988c-97cb-41ee-ba84-21be6de603f8> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001364/4486988c-97cb-41ee-ba84-21be6de603f8> a GO:0035150,
+<http://model.geneontology.org/WB_WBGene00001364/093daa8c-a0d8-4e6f-8d2f-71ebacba1eb9> a ECO:0000315,
         owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241575" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001364/a754b594-6e36-4871-9ad6-24744cc8d4cb> a GO:0002064,
+<http://model.geneontology.org/WB_WBGene00001364/0a525098-aa2d-4bc0-8d6c-21553644b869> a ECO:0000315,
         owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241570" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001364/ca9fd083-ca50-4f52-8080-3904158ff078> a WB:WBGene00001364,
+<http://model.geneontology.org/WB_WBGene00001364/1ad0ab14-dfc8-43e8-a95a-8c815415dd0c> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241581" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/27fe5d52-0322-40ac-858a-e9563fab08b7> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241575" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/466d3af9-c9f7-41cf-af5b-226e05f2da88> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278482" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/4eb20792-d56e-4efc-bfeb-0bbce9b5d8e4> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241581" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/565d2813-ed26-438d-be4c-f480c68a5d3f> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241575" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/6233a84c-d38a-4e48-abf7-c65c12673962> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278482" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/63a7b767-bc24-4ce1-93cf-baeb592124e6> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278487" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/6db8ebc0-2494-4c34-b146-1cc2861042a3> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278487" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/7f5385dd-6503-4680-8301-85c36638624e> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278482" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/a463f11e-e586-4ce1-aaf1-a813bff597ac> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241581" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/a858fa0c-e85b-4239-b3ae-3b7a16c7d683> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241570" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/af5fb8b1-77c3-498e-9dcd-088882d87542> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278487" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/bfc5a81d-bf64-42e3-941e-7ce452a60f31> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278482" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/cd855503-a27f-4567-9509-e626b02dd7fd> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241570" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/d39a0fce-1419-4d87-90c0-baa3ef2a2262> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241570" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/ebae4247-c5c1-419f-889d-379a16d6b66a> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00241581" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/f0bb9b65-cebb-44a2-a029-c34ca8f88d65> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278487" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10491271" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/1d5f10db-2153-48e3-b799-d9a2387695eb> a GO:0035150,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001364/ee173614-250d-4758-9734-ad1c76633880> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001364/256089cf-5bea-4cbc-aa1c-28ed537d02a9> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001364/ca9fd083-ca50-4f52-8080-3904158ff078> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001364/a754b594-6e36-4871-9ad6-24744cc8d4cb> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001364/6e1b4e44-26fa-4a3b-8f38-eb5daf31a4b8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001364/b185fbea-4cd6-48f6-92c7-9fdfa193331c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001364/f0a8f505-5052-40f8-86da-2951aefc49d8> a WB:WBGene00001364,
+<http://model.geneontology.org/WB_WBGene00001364/6e1b4e44-26fa-4a3b-8f38-eb5daf31a4b8> a WB:WBGene00001364,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/877307af-7e2c-4d11-bc89-df9a7c08465b> a WB:WBGene00001364,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/95dfa23f-26d0-415c-9717-9f445d78363b> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001364/877307af-7e2c-4d11-bc89-df9a7c08465b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001364/1d5f10db-2153-48e3-b799-d9a2387695eb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001364/b185fbea-4cd6-48f6-92c7-9fdfa193331c> a GO:0002064,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -256,55 +276,15 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001364/05fffeb0-8906-4474-8fc2-21d30ebfa689>,
-        <http://model.geneontology.org/WB_WBGene00001364/1b4939e8-558a-4ef0-9cea-efc0b1431209>,
-        <http://model.geneontology.org/WB_WBGene00001364/2bbea168-807b-4009-8a2f-7511be0d8395>,
-        <http://model.geneontology.org/WB_WBGene00001364/7a4e16de-59c0-415e-979e-14cae26dd6ac>,
-        <http://model.geneontology.org/WB_WBGene00001364/d90dfaad-9f4c-41ef-8f58-c85994367624> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001364/1ad0ab14-dfc8-43e8-a95a-8c815415dd0c>,
+        <http://model.geneontology.org/WB_WBGene00001364/565d2813-ed26-438d-be4c-f480c68a5d3f>,
+        <http://model.geneontology.org/WB_WBGene00001364/6233a84c-d38a-4e48-abf7-c65c12673962>,
+        <http://model.geneontology.org/WB_WBGene00001364/63a7b767-bc24-4ce1-93cf-baeb592124e6>,
+        <http://model.geneontology.org/WB_WBGene00001364/cd855503-a27f-4567-9509-e626b02dd7fd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241570  2021-03-12 WB  id=WBOA:8065|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241575  2021-03-12 WB  id=WBOA:89575|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241581  2021-03-12 WB  id=WBOA:89576|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278482  2021-03-12 WB  id=WBOA:89577|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278487  2021-03-12 WB  id=WBOA:89582|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/ee173614-250d-4758-9734-ad1c76633880> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/ca9fd083-ca50-4f52-8080-3904158ff078> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001364/0b371357-1736-4c47-ac20-af9758559e65>,
-        <http://model.geneontology.org/WB_WBGene00001364/3520f552-1a64-4c74-a69f-caae4e823c58>,
-        <http://model.geneontology.org/WB_WBGene00001364/57eb9e3e-73ec-43ad-abd2-231c73f84381>,
-        <http://model.geneontology.org/WB_WBGene00001364/be930e10-6d19-4aa2-ae11-a97f4baacf21>,
-        <http://model.geneontology.org/WB_WBGene00001364/d507a4bb-c7ab-4fa0-a337-0d9bbe2fafc9> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241570  2021-03-12 WB  id=WBOA:8066|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241575  2021-03-12 WB  id=WBOA:89578|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241581  2021-03-12 WB  id=WBOA:89579|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278482  2021-03-12 WB  id=WBOA:89580|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278487  2021-03-12 WB  id=WBOA:89581|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/1551c535-8d12-4767-8770-c77502e748c3> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/4486988c-97cb-41ee-ba84-21be6de603f8> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001364/01b468a9-ee3a-4384-bdd3-8aece7f5fe66>,
-        <http://model.geneontology.org/WB_WBGene00001364/5c07ea96-36ff-4def-8e28-cb34744b0d44>,
-        <http://model.geneontology.org/WB_WBGene00001364/72aa3d37-5e59-4fb2-ab3a-9a9983582577>,
-        <http://model.geneontology.org/WB_WBGene00001364/ca9d87dc-194f-410b-84d7-82009e25ea33>,
-        <http://model.geneontology.org/WB_WBGene00001364/fca2f1db-1e8d-42b9-8505-c37cb1c23619> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241570  2021-03-12 WB  id=WBOA:8066|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241575  2021-03-12 WB  id=WBOA:89578|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
@@ -312,19 +292,59 @@ obo:RO_0002418 a owl:ObjectProperty .
         "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278482  2021-03-12 WB  id=WBOA:89580|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278487  2021-03-12 WB  id=WBOA:89581|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/1551c535-8d12-4767-8770-c77502e748c3> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/f0a8f505-5052-40f8-86da-2951aefc49d8> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/95dfa23f-26d0-415c-9717-9f445d78363b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/877307af-7e2c-4d11-bc89-df9a7c08465b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001364/00c31215-5f75-4706-8faa-c7065acd4a39>,
-        <http://model.geneontology.org/WB_WBGene00001364/08781e86-3239-4802-92a2-5e4cd58b2283>,
-        <http://model.geneontology.org/WB_WBGene00001364/4b30fe50-8bcb-4a81-8963-883a01f8c45f>,
-        <http://model.geneontology.org/WB_WBGene00001364/704f8f23-a216-4b3c-9247-67deca21e85d>,
-        <http://model.geneontology.org/WB_WBGene00001364/88631aab-dd32-4d0b-9180-8d53d3abfe13> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001364/093daa8c-a0d8-4e6f-8d2f-71ebacba1eb9>,
+        <http://model.geneontology.org/WB_WBGene00001364/466d3af9-c9f7-41cf-af5b-226e05f2da88>,
+        <http://model.geneontology.org/WB_WBGene00001364/6db8ebc0-2494-4c34-b146-1cc2861042a3>,
+        <http://model.geneontology.org/WB_WBGene00001364/a858fa0c-e85b-4239-b3ae-3b7a16c7d683>,
+        <http://model.geneontology.org/WB_WBGene00001364/ebae4247-c5c1-419f-889d-379a16d6b66a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241570  2021-03-12 WB  id=WBOA:8066|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241575  2021-03-12 WB  id=WBOA:89578|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241581  2021-03-12 WB  id=WBOA:89579|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278482  2021-03-12 WB  id=WBOA:89580|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278487  2021-03-12 WB  id=WBOA:89581|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/95dfa23f-26d0-415c-9717-9f445d78363b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/1d5f10db-2153-48e3-b799-d9a2387695eb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001364/0a525098-aa2d-4bc0-8d6c-21553644b869>,
+        <http://model.geneontology.org/WB_WBGene00001364/27fe5d52-0322-40ac-858a-e9563fab08b7>,
+        <http://model.geneontology.org/WB_WBGene00001364/7f5385dd-6503-4680-8301-85c36638624e>,
+        <http://model.geneontology.org/WB_WBGene00001364/a463f11e-e586-4ce1-aaf1-a813bff597ac>,
+        <http://model.geneontology.org/WB_WBGene00001364/f0bb9b65-cebb-44a2-a029-c34ca8f88d65> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241570  2021-03-12 WB  id=WBOA:8065|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241575  2021-03-12 WB  id=WBOA:89575|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241581  2021-03-12 WB  id=WBOA:89576|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278482  2021-03-12 WB  id=WBOA:89577|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278487  2021-03-12 WB  id=WBOA:89582|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/256089cf-5bea-4cbc-aa1c-28ed537d02a9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/6e1b4e44-26fa-4a3b-8f38-eb5daf31a4b8> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001364/04d1a665-c25d-427e-840a-8b7eafb9ee0b>,
+        <http://model.geneontology.org/WB_WBGene00001364/4eb20792-d56e-4efc-bfeb-0bbce9b5d8e4>,
+        <http://model.geneontology.org/WB_WBGene00001364/af5fb8b1-77c3-498e-9dcd-088882d87542>,
+        <http://model.geneontology.org/WB_WBGene00001364/bfc5a81d-bf64-42e3-941e-7ce452a60f31>,
+        <http://model.geneontology.org/WB_WBGene00001364/d39a0fce-1419-4d87-90c0-baa3ef2a2262> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241570  2021-03-12 WB  id=WBOA:8065|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241575  2021-03-12 WB  id=WBOA:89575|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
@@ -332,6 +352,6 @@ obo:RO_0002418 a owl:ObjectProperty .
         "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278482  2021-03-12 WB  id=WBOA:89577|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00001364  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00278487  2021-03-12 WB  id=WBOA:89582|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/ee173614-250d-4758-9734-ad1c76633880> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/a754b594-6e36-4871-9ad6-24744cc8d4cb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001364/256089cf-5bea-4cbc-aa1c-28ed537d02a9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001364/b185fbea-4cd6-48f6-92c7-9fdfa193331c> .
 

--- a/models/WB_WBGene00001369.ttl
+++ b/models/WB_WBGene00001369.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001369> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "exc-8 (WB:WBGene00001369)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001369> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001369/27784ab1-4e92-4115-81ad-143f452db149> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001369/0ca0a625-8735-43e7-af59-2408632f9e44> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241582" ;
+    ns1:evidence-with "WB:WBVar00241582" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/30ad8145-934a-433e-8636-2858296d38cf> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001369/16d2e90f-f89f-4b22-86d3-4dd8eaf21a9b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241582" ;
+    ns1:evidence-with "WB:WBVar00241582" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/450bb458-74f5-4a68-b0f1-babc4c146158> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001369/c727de80-0c55-4344-87af-b8d14b9334f2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241582" ;
+    ns1:evidence-with "WB:WBVar00241582" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/ea7ddac2-2c86-4b68-b403-b984d456d345> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001369/f63794f5-8b58-43f0-a147-5f53364ea916> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241582" ;
+    ns1:evidence-with "WB:WBVar00241582" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:10491271" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/009df896-4712-4af5-8991-fe40a7cadf85> a GO:0002064,
+<http://model.geneontology.org/WB_WBGene00001369/08c1610f-f495-4647-8d25-57603154cadf> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001369/c46e151f-73b5-4110-b977-4eb7b1bca8d2> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001369/7c9137e1-aca9-4b39-9432-1be459ebdd84> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001369/0faa9d18-af42-47d0-805a-ad0650b17910> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001369/ce86668d-5df2-4d15-bbb2-e1dfedaf3c2c> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001369/f2e05ed8-beb3-4f7a-891b-a0a6332c4a5b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001369/7c9137e1-aca9-4b39-9432-1be459ebdd84> a GO:0002064,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/2f8c8184-8864-4f75-8dd8-7f1462cecc16> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001369/83ddbe30-d022-4429-a05d-762e6c6bde13> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001369/009df896-4712-4af5-8991-fe40a7cadf85> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001369/63f1bc19-e48c-4f7f-a2c0-2e81ce174c59> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001369/e8e949ac-5332-47e9-ab37-91988057bbbf> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001369/bbc4fcf2-2e05-4dcc-ab37-d950552bcea9> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001369/83ddbe30-d022-4429-a05d-762e6c6bde13> a WB:WBGene00001369,
+<http://model.geneontology.org/WB_WBGene00001369/c46e151f-73b5-4110-b977-4eb7b1bca8d2> a WB:WBGene00001369,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/bbc4fcf2-2e05-4dcc-ab37-d950552bcea9> a GO:0035150,
+<http://model.geneontology.org/WB_WBGene00001369/ce86668d-5df2-4d15-bbb2-e1dfedaf3c2c> a WB:WBGene00001369,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001369/e8e949ac-5332-47e9-ab37-91988057bbbf> a WB:WBGene00001369,
+<http://model.geneontology.org/WB_WBGene00001369/f2e05ed8-beb3-4f7a-891b-a0a6332c4a5b> a GO:0035150,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001369/ea7ddac2-2c86-4b68-b403-b984d456d345> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001369/0ca0a625-8735-43e7-af59-2408632f9e44> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8076|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/63f1bc19-e48c-4f7f-a2c0-2e81ce174c59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/e8e949ac-5332-47e9-ab37-91988057bbbf> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001369/27784ab1-4e92-4115-81ad-143f452db149> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8076|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/63f1bc19-e48c-4f7f-a2c0-2e81ce174c59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/bbc4fcf2-2e05-4dcc-ab37-d950552bcea9> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001369/30ad8145-934a-433e-8636-2858296d38cf> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8075|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/2f8c8184-8864-4f75-8dd8-7f1462cecc16> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/009df896-4712-4af5-8991-fe40a7cadf85> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001369/450bb458-74f5-4a68-b0f1-babc4c146158> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8075|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/2f8c8184-8864-4f75-8dd8-7f1462cecc16> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/83ddbe30-d022-4429-a05d-762e6c6bde13> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/08c1610f-f495-4647-8d25-57603154cadf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/c46e151f-73b5-4110-b977-4eb7b1bca8d2> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001369/c727de80-0c55-4344-87af-b8d14b9334f2> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8076|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/0faa9d18-af42-47d0-805a-ad0650b17910> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/f2e05ed8-beb3-4f7a-891b-a0a6332c4a5b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001369/f63794f5-8b58-43f0-a147-5f53364ea916> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0002064 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8075|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/08c1610f-f495-4647-8d25-57603154cadf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/7c9137e1-aca9-4b39-9432-1be459ebdd84> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001369/16d2e90f-f89f-4b22-86d3-4dd8eaf21a9b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001369  RO:0002264 GO:0035150 WB:WBPaper00003721|PMID:10491271 ECO:0000315 WB:WBVar00241582  2021-05-13 WB  id=WBOA:8076|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001369/0faa9d18-af42-47d0-805a-ad0650b17910> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001369/ce86668d-5df2-4d15-bbb2-e1dfedaf3c2c> .
 

--- a/models/WB_WBGene00001845.ttl
+++ b/models/WB_WBGene00001845.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001845> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "hid-2 (WB:WBGene00001845)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001845> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001845/2f8450cf-0472-4f51-abe3-31a0fd1bad20> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001845/21fed11f-7641-4ae3-a310-30a067de21a3> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242608" ;
+    ns1:evidence-with "WB:WBVar00242608" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/318e5146-1597-4ca8-a5ed-342b62f243ef> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001845/a01d4abd-f903-4d3e-b2cb-6314ce007264> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242608" ;
+    ns1:evidence-with "WB:WBVar00242608" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/3a9b8ef1-f665-42f7-bd33-262849654e28> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001845/d9145779-d746-4071-96f7-66f4ea0680a3> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242608" ;
+    ns1:evidence-with "WB:WBVar00242608" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/6786bd3d-1c25-4b96-bfab-5cdcfae79a02> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001845/dc1b86f3-0a93-48da-851d-a87eaf26b445> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242608" ;
+    ns1:evidence-with "WB:WBVar00242608" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/15868189-344d-40e9-abec-5f4eab6cef93> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001845/0afe45ca-1fd5-484b-b3ef-19677ec6a7eb> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001845/c1e051da-84b2-4b5c-ba97-2495af1c7154> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001845/b0762a80-1801-4691-af70-3a459ebb60dd> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001845/a700e38a-fc2e-4ceb-ba76-bcc6798c1859> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001845/eec554c4-dc4a-4065-9bbc-340b5849e566> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/9a08fcec-7919-498b-9727-b1b8a689de40> a WB:WBGene00001845,
+<http://model.geneontology.org/WB_WBGene00001845/74374ff3-27c3-43b9-8415-f06a3b4269bf> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001845/a7964b56-bec4-4e74-9e0a-45a0f7851cec> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001845/8e274a5c-c7d0-4f16-8dec-27886dfd5ef8> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/b0762a80-1801-4691-af70-3a459ebb60dd> a GO:0040024,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001845/b3bff37d-6d22-4a67-8009-9b8eedbfd1ed> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001845/9a08fcec-7919-498b-9727-b1b8a689de40> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001845/d27d8f34-24ce-4fc6-a735-43fae975f14b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001845/c1e051da-84b2-4b5c-ba97-2495af1c7154> a WB:WBGene00001845,
+<http://model.geneontology.org/WB_WBGene00001845/8e274a5c-c7d0-4f16-8dec-27886dfd5ef8> a GO:0040024,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001845/d27d8f34-24ce-4fc6-a735-43fae975f14b> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00001845/a700e38a-fc2e-4ceb-ba76-bcc6798c1859> a WB:WBGene00001845,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001845/a7964b56-bec4-4e74-9e0a-45a0f7851cec> a WB:WBGene00001845,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001845/eec554c4-dc4a-4065-9bbc-340b5849e566> a GO:0009408,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001845/6786bd3d-1c25-4b96-bfab-5cdcfae79a02> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001845/a01d4abd-f903-4d3e-b2cb-6314ce007264> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001845  RO:0002264 GO:0040024 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242608  2021-05-13 WB  id=WBOA:7729|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/15868189-344d-40e9-abec-5f4eab6cef93> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/c1e051da-84b2-4b5c-ba97-2495af1c7154> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/74374ff3-27c3-43b9-8415-f06a3b4269bf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/a7964b56-bec4-4e74-9e0a-45a0f7851cec> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001845/318e5146-1597-4ca8-a5ed-342b62f243ef> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001845/21fed11f-7641-4ae3-a310-30a067de21a3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001845  RO:0002264 GO:0009408 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242608  2021-05-13 WB  id=WBOA:7730|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/b3bff37d-6d22-4a67-8009-9b8eedbfd1ed> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/9a08fcec-7919-498b-9727-b1b8a689de40> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/0afe45ca-1fd5-484b-b3ef-19677ec6a7eb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/a700e38a-fc2e-4ceb-ba76-bcc6798c1859> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001845/2f8450cf-0472-4f51-abe3-31a0fd1bad20> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001845/d9145779-d746-4071-96f7-66f4ea0680a3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001845  RO:0002264 GO:0009408 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242608  2021-05-13 WB  id=WBOA:7730|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/b3bff37d-6d22-4a67-8009-9b8eedbfd1ed> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/d27d8f34-24ce-4fc6-a735-43fae975f14b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/0afe45ca-1fd5-484b-b3ef-19677ec6a7eb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/eec554c4-dc4a-4065-9bbc-340b5849e566> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001845/3a9b8ef1-f665-42f7-bd33-262849654e28> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001845/dc1b86f3-0a93-48da-851d-a87eaf26b445> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001845  RO:0002264 GO:0040024 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242608  2021-05-13 WB  id=WBOA:7729|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/15868189-344d-40e9-abec-5f4eab6cef93> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/b0762a80-1801-4691-af70-3a459ebb60dd> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001845/74374ff3-27c3-43b9-8415-f06a3b4269bf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001845/8e274a5c-c7d0-4f16-8dec-27886dfd5ef8> .
 

--- a/models/WB_WBGene00001847.ttl
+++ b/models/WB_WBGene00001847.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001847> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "hid-4 (WB:WBGene00001847)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001847> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001847/387a1148-2c91-42be-9a7a-52412b5238d6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001847/12e24a7a-459a-42cb-928c-02b18e9e0cfe> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242603" ;
+    ns1:evidence-with "WB:WBVar00242603" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/3f661a13-9eb5-4a8c-a761-12ab4e0e4c07> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001847/c37b2da7-d25e-4c24-a9da-500138109033> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242603" ;
+    ns1:evidence-with "WB:WBVar00242603" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/5282616c-70d0-4509-87f3-b385eb0756c3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001847/de4249ce-9edb-405e-80c5-2332a93740bb> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242603" ;
+    ns1:evidence-with "WB:WBVar00242603" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/858f88d9-cddf-4be9-8685-e4fc8bcaca30> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001847/e09aa9b1-ea11-464d-95e2-d1b5bb2ad845> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00242603" ;
+    ns1:evidence-with "WB:WBVar00242603" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:14504222" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/2577ef40-0e7c-422d-a476-6fc22ea0678b> a WB:WBGene00001847,
+<http://model.geneontology.org/WB_WBGene00001847/05a70eef-5a2c-4eed-b0e7-912a8898ed46> a WB:WBGene00001847,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/29c02077-2ba7-44f7-8357-1637ab3c2c10> a WB:WBGene00001847,
+<http://model.geneontology.org/WB_WBGene00001847/175e0eeb-d32e-455f-9db2-ed5a8378815f> a WB:WBGene00001847,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/664d2763-1d3c-46c1-b120-b16d83e3d00d> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001847/2577ef40-0e7c-422d-a476-6fc22ea0678b> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001847/d951f4c4-acdd-442c-a213-a74608e0966c> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001847/90b99d64-744d-44f4-a49a-ded6dc5d1d08> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001847/29c02077-2ba7-44f7-8357-1637ab3c2c10> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001847/df663532-a569-4ae8-a638-2e9d8b971ce6> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001847/d951f4c4-acdd-442c-a213-a74608e0966c> a GO:0040024,
+<http://model.geneontology.org/WB_WBGene00001847/4b6752da-0e8f-4db9-92ee-0e865f7444c4> a GO:0009408,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001847/df663532-a569-4ae8-a638-2e9d8b971ce6> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00001847/70fc50d9-ac06-4558-890c-6b6e1bdd9a72> a GO:0040024,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001847/9337adda-fd1e-4f62-ae37-9ab7845b23eb> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001847/05a70eef-5a2c-4eed-b0e7-912a8898ed46> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001847/70fc50d9-ac06-4558-890c-6b6e1bdd9a72> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001847/cd832ece-1f8b-4755-9dc0-773334548421> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001847/175e0eeb-d32e-455f-9db2-ed5a8378815f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00001847/4b6752da-0e8f-4db9-92ee-0e865f7444c4> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001847/387a1148-2c91-42be-9a7a-52412b5238d6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001847/de4249ce-9edb-405e-80c5-2332a93740bb> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0009408 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7728|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/90b99d64-744d-44f4-a49a-ded6dc5d1d08> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/df663532-a569-4ae8-a638-2e9d8b971ce6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001847/3f661a13-9eb5-4a8c-a761-12ab4e0e4c07> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0009408 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7728|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/90b99d64-744d-44f4-a49a-ded6dc5d1d08> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/29c02077-2ba7-44f7-8357-1637ab3c2c10> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001847/858f88d9-cddf-4be9-8685-e4fc8bcaca30> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0040024 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7727|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/664d2763-1d3c-46c1-b120-b16d83e3d00d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/2577ef40-0e7c-422d-a476-6fc22ea0678b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001847/5282616c-70d0-4509-87f3-b385eb0756c3> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0040024 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7727|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/664d2763-1d3c-46c1-b120-b16d83e3d00d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/d951f4c4-acdd-442c-a213-a74608e0966c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/9337adda-fd1e-4f62-ae37-9ab7845b23eb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/70fc50d9-ac06-4558-890c-6b6e1bdd9a72> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001847/e09aa9b1-ea11-464d-95e2-d1b5bb2ad845> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0040024 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7727|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/9337adda-fd1e-4f62-ae37-9ab7845b23eb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/05a70eef-5a2c-4eed-b0e7-912a8898ed46> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001847/12e24a7a-459a-42cb-928c-02b18e9e0cfe> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0009408 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7728|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/cd832ece-1f8b-4755-9dc0-773334548421> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/4b6752da-0e8f-4db9-92ee-0e865f7444c4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001847/c37b2da7-d25e-4c24-a9da-500138109033> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001847  RO:0002264 GO:0009408 WB:WBPaper00006103|PMID:14504222 ECO:0000315 WB:WBVar00242603  2021-05-13 WB  id=WBOA:7728|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001847/cd832ece-1f8b-4755-9dc0-773334548421> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001847/175e0eeb-d32e-455f-9db2-ed5a8378815f> .
 

--- a/models/WB_WBGene00001884.ttl
+++ b/models/WB_WBGene00001884.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,108 +29,114 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001884> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:title "his-10 (WB:WBGene00001884)" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001884> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001884/00a46cad-e55a-4d75-a136-d58598421e14> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001884/2729e4a2-66bb-4462-b45f-54942cbf20d8> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/1dd560db-337d-4892-a81f-d80ebf681370> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001884/2accacdd-a16d-4af5-9e5c-a5f1fbfe369e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/286a8655-6e35-4df4-8aed-7044c3390f79> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001884/3db1137b-d9ca-40ee-947e-eb69656fd7bb> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/366d0e6b-9eae-4fb2-9f62-e26f8f484d4e> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001884/90aa3ae7-0e2f-40ee-a6e4-b24e6c1880c1> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/a9907d51-0249-4511-b6d0-a9bcd2f42564> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001884/f56a1d91-055c-436d-b04d-0c32cc282acf> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/ff33e353-31a9-4d44-a2c6-47570966a51f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001884/fb91f05f-f68e-4ad2-951e-d109036b3272> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dc:source "PMID:16968778" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001884/06a6d7c7-c9d3-4a12-af1c-44775b287808> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001884/822d0df4-e879-472e-bea3-9def208d75b0> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001884/bcd85a85-e527-4287-87af-d3bc12c8781f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/08a056fa-6735-4fe4-baf0-adacf50b8506> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001884/0ce1acc5-4e4a-4fb9-adc5-dd79fe360d35> a WB:WBGene00001884,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/58db30a6-0348-4475-b95b-bdf9dc89d629> a WB:WBGene00001884,
+<http://model.geneontology.org/WB_WBGene00001884/6ea45dd9-b502-49c4-bfdf-ff2af04a155f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001884/b80904f9-0f31-47ef-8d2b-46b84053bc27> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001884/c559071e-f38f-45a6-87fb-0686a89062dd> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-02" ;
+    dct:created "2014-05-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001884/b80904f9-0f31-47ef-8d2b-46b84053bc27> a GO:0050829,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/822d0df4-e879-472e-bea3-9def208d75b0> a GO:0050829,
+<http://model.geneontology.org/WB_WBGene00001884/c559071e-f38f-45a6-87fb-0686a89062dd> a WB:WBGene00001884,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001884/9f7303ef-6566-4dcb-83bc-c95099d4bca1> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001884/08a056fa-6735-4fe4-baf0-adacf50b8506> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001884/58db30a6-0348-4475-b95b-bdf9dc89d629> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-02" ;
-    dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001884/bcd85a85-e527-4287-87af-d3bc12c8781f> a WB:WBGene00001884,
+<http://model.geneontology.org/WB_WBGene00001884/cb9780bd-09b0-4f53-9312-f157b100ef3a> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001884/e3fd9a7e-37b5-489b-9958-cb6cac8d6621> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001884/cb9780bd-09b0-4f53-9312-f157b100ef3a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001884/0ce1acc5-4e4a-4fb9-adc5-dd79fe360d35> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-02" ;
+    dct:created "2014-05-02" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -138,54 +144,54 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001884/00a46cad-e55a-4d75-a136-d58598421e14>,
-        <http://model.geneontology.org/WB_WBGene00001884/a9907d51-0249-4511-b6d0-a9bcd2f42564> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001884/90aa3ae7-0e2f-40ee-a6e4-b24e6c1880c1> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001884  RO:0002331 GO:0050829 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-02 WB  id=WBOA:14240|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/6ea45dd9-b502-49c4-bfdf-ff2af04a155f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/b80904f9-0f31-47ef-8d2b-46b84053bc27> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001884/2accacdd-a16d-4af5-9e5c-a5f1fbfe369e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-02" ;
+    dct:created "2014-05-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001884  RO:0002331 GO:0050829 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-02 WB  id=WBOA:14240|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/6ea45dd9-b502-49c4-bfdf-ff2af04a155f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/c559071e-f38f-45a6-87fb-0686a89062dd> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001884/2729e4a2-66bb-4462-b45f-54942cbf20d8>,
+        <http://model.geneontology.org/WB_WBGene00001884/3db1137b-d9ca-40ee-947e-eb69656fd7bb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-02" ;
+    dct:created "2014-05-02" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001884  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-02 WB  id=WBOA:14241|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46",
         "WB:WBGene00001884  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-02 WB  id=WBOA:14239|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/9f7303ef-6566-4dcb-83bc-c95099d4bca1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/58db30a6-0348-4475-b95b-bdf9dc89d629> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/e3fd9a7e-37b5-489b-9958-cb6cac8d6621> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/0ce1acc5-4e4a-4fb9-adc5-dd79fe360d35> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001884/ff33e353-31a9-4d44-a2c6-47570966a51f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001884/f56a1d91-055c-436d-b04d-0c32cc282acf>,
+        <http://model.geneontology.org/WB_WBGene00001884/fb91f05f-f68e-4ad2-951e-d109036b3272> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-02" ;
     dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001884  RO:0002331 GO:0050829 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-02 WB  id=WBOA:14240|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/06a6d7c7-c9d3-4a12-af1c-44775b287808> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/bcd85a85-e527-4287-87af-d3bc12c8781f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001884/1dd560db-337d-4892-a81f-d80ebf681370> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-02" ;
-    dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001884  RO:0002331 GO:0050829 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-02 WB  id=WBOA:14240|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/06a6d7c7-c9d3-4a12-af1c-44775b287808> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/822d0df4-e879-472e-bea3-9def208d75b0> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001884/286a8655-6e35-4df4-8aed-7044c3390f79>,
-        <http://model.geneontology.org/WB_WBGene00001884/366d0e6b-9eae-4fb2-9f62-e26f8f484d4e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-02" ;
-    dct:created "2014-05-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001884  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-02 WB  id=WBOA:14241|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46",
         "WB:WBGene00001884  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-02 WB  id=WBOA:14239|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-02T7:46|modification-date=2014-05-02T7:46" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/9f7303ef-6566-4dcb-83bc-c95099d4bca1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/08a056fa-6735-4fe4-baf0-adacf50b8506> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001884/e3fd9a7e-37b5-489b-9958-cb6cac8d6621> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001884/cb9780bd-09b0-4f53-9312-f157b100ef3a> .
 

--- a/models/WB_WBGene00001885.ttl
+++ b/models/WB_WBGene00001885.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,44 +29,47 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001885> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "his-11 (WB:WBGene00001885)" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001885> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001885/1115d9a6-dd0e-43da-b6a6-f62ad5125983> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001885/3fee0517-6e37-4a49-b179-7e9219616821> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-08" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001885/a59a687c-9c1c-478a-a6a8-25c84f6a3e91> a WB:WBGene00001885,
+<http://model.geneontology.org/WB_WBGene00001885/86d0db9c-395b-4e16-a515-a7be3bbde6b3> a WB:WBGene00001885,
         owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00001885/07d7efbe-e351-4879-b926-5f8806b23a9a> ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00001885/0ca4a051-1042-4633-b3a5-ada4b719a67d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001885/b8be142e-8880-42cf-99c3-da0016e54e00> a ECO:0000270,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-08" ;
-    dc:source "PMID:16968778" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001885/c25b01a7-54d3-41ea-8b32-0607759ca107> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00001885/945d4099-7e6c-489f-9a2b-04d0c295326a> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:14697201" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001885/dc145d12-e58a-413f-be89-b39aa503259d> a ECO:0000270,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-08" ;
+    dc:source "PMID:16968778" ;
+    dct:created "2014-05-08" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -75,73 +78,73 @@ obo:RO_0001025 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001885/07d7efbe-e351-4879-b926-5f8806b23a9a> a GO:0000785,
+<http://model.geneontology.org/WB_WBGene00001885/0ca4a051-1042-4633-b3a5-ada4b719a67d> a GO:0000785,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001885/38bc6a71-bdfc-4082-b2d2-89a0e38ab047> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001885/3a6a4ba9-cf07-499b-8d16-f104a445aba2> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001885/f78b76b1-1237-4620-9614-dd58b8524462> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001885/bb61d92b-accc-4df7-b434-51299717debd> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-08" ;
+    dct:created "2014-05-08" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001885/bb61d92b-accc-4df7-b434-51299717debd> a WB:WBGene00001885,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001885/d24a6f93-1b46-4c95-a7ea-0a6aeae52a34> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001885/38bc6a71-bdfc-4082-b2d2-89a0e38ab047> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001885/e7313258-c03a-419b-81a8-4bbe5999fcf8> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-08" ;
-    dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001885/e7313258-c03a-419b-81a8-4bbe5999fcf8> a WB:WBGene00001885,
+<http://model.geneontology.org/WB_WBGene00001885/f78b76b1-1237-4620-9614-dd58b8524462> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001885/b8be142e-8880-42cf-99c3-da0016e54e00> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001885/dc145d12-e58a-413f-be89-b39aa503259d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001885  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-08 WB  id=WBOA:14242|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-08|modification-date=2014-05-08" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001885/d24a6f93-1b46-4c95-a7ea-0a6aeae52a34> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001885/38bc6a71-bdfc-4082-b2d2-89a0e38ab047> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001885/1115d9a6-dd0e-43da-b6a6-f62ad5125983> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-08" ;
-    dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001885  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-08 WB  id=WBOA:14242|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-08|modification-date=2014-05-08" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001885/d24a6f93-1b46-4c95-a7ea-0a6aeae52a34> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001885/e7313258-c03a-419b-81a8-4bbe5999fcf8> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001885/3a6a4ba9-cf07-499b-8d16-f104a445aba2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001885/bb61d92b-accc-4df7-b434-51299717debd> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001885/c25b01a7-54d3-41ea-8b32-0607759ca107> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001885/945d4099-7e6c-489f-9a2b-04d0c295326a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001885  RO:0001025 GO:0000785 WB:WBPaper00006310|PMID:14697201 ECO:0000314   2020-05-13 WB  id=WBOA:2546|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001885/a59a687c-9c1c-478a-a6a8-25c84f6a3e91> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001885/07d7efbe-e351-4879-b926-5f8806b23a9a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001885/86d0db9c-395b-4e16-a515-a7be3bbde6b3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001885/0ca4a051-1042-4633-b3a5-ada4b719a67d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001885/3fee0517-6e37-4a49-b179-7e9219616821> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-08" ;
+    dct:created "2014-05-08" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001885  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-08 WB  id=WBOA:14242|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-08|modification-date=2014-05-08" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001885/3a6a4ba9-cf07-499b-8d16-f104a445aba2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001885/f78b76b1-1237-4620-9614-dd58b8524462> .
 

--- a/models/WB_WBGene00001889.ttl
+++ b/models/WB_WBGene00001889.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001889> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dc:title "his-15 (WB:WBGene00001889)" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001889> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001889/55699d2d-b106-4853-94df-75f3050a55e7> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001889/48f31ef5-2d95-4281-8800-0d9869393acd> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-08" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001889/f93f7e24-cc73-4d3b-9b21-73c433d2aba1> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001889/e5cfc4ca-9a65-4620-8003-77980a38891a> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-08" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001889/2e585078-c34c-49dd-9b55-f653b3b2368a> a WB:WBGene00001889,
+<http://model.geneontology.org/WB_WBGene00001889/20245f02-e8f2-4043-a321-cf2f80deb604> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001889/7068c550-28dc-4b3b-8436-8a1335b42a7e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001889/569d18af-f414-48e4-af7e-3f960df97a91> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001889/565301f2-0501-450f-b3a0-71bf14aecd12> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001889/569d18af-f414-48e4-af7e-3f960df97a91> a WB:WBGene00001889,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001889/d51ccd01-7582-4c53-914d-b42b9db2a56f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001889/7068c550-28dc-4b3b-8436-8a1335b42a7e> a GO:0045087,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001889/565301f2-0501-450f-b3a0-71bf14aecd12> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001889/2e585078-c34c-49dd-9b55-f653b3b2368a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001889/f93f7e24-cc73-4d3b-9b21-73c433d2aba1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001889/e5cfc4ca-9a65-4620-8003-77980a38891a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001889  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-08 WB  id=WBOA:14243|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-08|modification-date=2014-05-08" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001889/d51ccd01-7582-4c53-914d-b42b9db2a56f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001889/2e585078-c34c-49dd-9b55-f653b3b2368a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001889/20245f02-e8f2-4043-a321-cf2f80deb604> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001889/569d18af-f414-48e4-af7e-3f960df97a91> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001889/55699d2d-b106-4853-94df-75f3050a55e7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001889/48f31ef5-2d95-4281-8800-0d9869393acd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-08" ;
     dct:created "2014-05-08" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001889  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-08 WB  id=WBOA:14243|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-08|modification-date=2014-05-08" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001889/d51ccd01-7582-4c53-914d-b42b9db2a56f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001889/565301f2-0501-450f-b3a0-71bf14aecd12> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001889/20245f02-e8f2-4043-a321-cf2f80deb604> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001889/7068c550-28dc-4b3b-8436-8a1335b42a7e> .
 

--- a/models/WB_WBGene00001890.ttl
+++ b/models/WB_WBGene00001890.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,110 +29,116 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001890> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:title "his-16 (WB:WBGene00001890)" ;
     dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001890> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001890/0b605ef1-72ab-4ffb-a42b-3a2a3ffddb51> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001890/1a0a4490-ee01-4b2d-a5e6-fdd9655a56f7> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-01" ;
     dc:source "PMID:16968778" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/32234d1c-cc4e-41bd-91a0-9af54ca89d35> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-01" ;
-    dc:source "PMID:16968778" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/8b56e20d-dd81-402a-9549-14c735e7e178> a ECO:0000270,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dc:source "PMID:16968778" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/8e1b4763-b1ba-4414-b676-9404e500733f> a ECO:0000270,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dc:source "PMID:16968778" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/e78fc05b-e08d-4aeb-8100-202dc3895474> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-01" ;
-    dc:source "PMID:16968778" ;
+    dct:created "2014-05-01" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Need to add taxon: 652611" .
 
-<http://model.geneontology.org/WB_WBGene00001890/f25d08da-a377-4d62-9a16-d31ac56ced56> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001890/22449b65-0519-43b5-bdaf-0e5104a7c358> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-01" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-01" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/4243fe64-c032-46b8-a4ca-f0014cb3027a> a ECO:0000270,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/a4ed9237-83e0-4de9-9d4d-cbc6aade0c55> a ECO:0000270,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/cdbf44db-d212-45ed-a3ab-d6fb041c683c> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-01" ;
+    dc:source "PMID:16968778" ;
+    dct:created "2014-05-01" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/ec13cfae-b1cf-4eea-9ed7-092ef26c79bd> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-01" ;
+    dc:source "PMID:16968778" ;
+    dct:created "2014-05-01" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Need to add taxon: 652611" .
 
-<http://model.geneontology.org/WB_WBGene00001890/0c6d2a3c-118f-4bba-834d-ff9e1fe0bdd0> a GO:0050829,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-01" ;
-    dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/0c7b8eb4-8d31-488b-afb5-95459a799f57> a WB:WBGene00001890,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-01" ;
-    dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/8a54a9c7-ea9b-48f9-88d5-6f2bde6c12f7> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001890/0c6d2a3c-118f-4bba-834d-ff9e1fe0bdd0> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001890/0c7b8eb4-8d31-488b-afb5-95459a799f57> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-01" ;
-    dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/94f376ff-43f8-4596-b7c4-9404fdcaae5c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001890/c9ebae60-53fa-48a1-bc72-d6e41d17c115> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001890/d5699c94-7355-4cca-9de2-6205520650ae> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00001890/c9ebae60-53fa-48a1-bc72-d6e41d17c115> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001890/2464756a-9047-4a1f-bada-be24205815a1> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001890/d5699c94-7355-4cca-9de2-6205520650ae> a WB:WBGene00001890,
+<http://model.geneontology.org/WB_WBGene00001890/2a72ac52-e484-4c43-9960-1315172f6282> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001890/2464756a-9047-4a1f-bada-be24205815a1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001890/bd1f5fbe-f8b2-4287-b71e-17bca60d2b5d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dct:created "2014-05-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/709955d5-cdf7-49db-98df-c9615e5c8be9> a GO:0050829,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-01" ;
+    dct:created "2014-05-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/9289eaed-ae9f-4e86-916d-ed78a7d2bb71> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001890/709955d5-cdf7-49db-98df-c9615e5c8be9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001890/c759be58-ec88-4990-b94a-6217ff9bc33d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-01" ;
+    dct:created "2014-05-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/bd1f5fbe-f8b2-4287-b71e-17bca60d2b5d> a WB:WBGene00001890,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00001890/c759be58-ec88-4990-b94a-6217ff9bc33d> a WB:WBGene00001890,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-01" ;
+    dct:created "2014-05-01" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -140,54 +146,54 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001890/f25d08da-a377-4d62-9a16-d31ac56ced56> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001890/ec13cfae-b1cf-4eea-9ed7-092ef26c79bd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-01" ;
     dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001890  RO:0002331 GO:0050829 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-01 WB  id=WBOA:14237|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Need to add taxon: 652611|creation-date=2014-05-01T11:45|modification-date=2014-05-01T11:45" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/8a54a9c7-ea9b-48f9-88d5-6f2bde6c12f7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/0c7b8eb4-8d31-488b-afb5-95459a799f57> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/9289eaed-ae9f-4e86-916d-ed78a7d2bb71> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/c759be58-ec88-4990-b94a-6217ff9bc33d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001890/e78fc05b-e08d-4aeb-8100-202dc3895474> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001890/1a0a4490-ee01-4b2d-a5e6-fdd9655a56f7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-01" ;
     dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001890  RO:0002331 GO:0050829 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-01 WB  id=WBOA:14237|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Need to add taxon: 652611|creation-date=2014-05-01T11:45|modification-date=2014-05-01T11:45" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/8a54a9c7-ea9b-48f9-88d5-6f2bde6c12f7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/0c6d2a3c-118f-4bba-834d-ff9e1fe0bdd0> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/9289eaed-ae9f-4e86-916d-ed78a7d2bb71> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/709955d5-cdf7-49db-98df-c9615e5c8be9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001890/0b605ef1-72ab-4ffb-a42b-3a2a3ffddb51>,
-        <http://model.geneontology.org/WB_WBGene00001890/8e1b4763-b1ba-4414-b676-9404e500733f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001890/4243fe64-c032-46b8-a4ca-f0014cb3027a>,
+        <http://model.geneontology.org/WB_WBGene00001890/cdbf44db-d212-45ed-a3ab-d6fb041c683c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001890  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14244|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09",
-        "WB:WBGene00001890  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-01 WB  id=WBOA:14238|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-01T11:45|modification-date=2014-05-01T11:45" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/94f376ff-43f8-4596-b7c4-9404fdcaae5c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/c9ebae60-53fa-48a1-bc72-d6e41d17c115> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001890/32234d1c-cc4e-41bd-91a0-9af54ca89d35>,
-        <http://model.geneontology.org/WB_WBGene00001890/8b56e20d-dd81-402a-9549-14c735e7e178> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dct:created "2014-05-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001890  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14244|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09",
         "WB:WBGene00001890  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-01 WB  id=WBOA:14238|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-01T11:45|modification-date=2014-05-01T11:45" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/94f376ff-43f8-4596-b7c4-9404fdcaae5c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/d5699c94-7355-4cca-9de2-6205520650ae> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/2a72ac52-e484-4c43-9960-1315172f6282> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/bd1f5fbe-f8b2-4287-b71e-17bca60d2b5d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001890/22449b65-0519-43b5-bdaf-0e5104a7c358>,
+        <http://model.geneontology.org/WB_WBGene00001890/a4ed9237-83e0-4de9-9d4d-cbc6aade0c55> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dct:created "2014-05-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001890  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14244|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09",
+        "WB:WBGene00001890  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000315   2014-05-01 WB  id=WBOA:14238|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-01T11:45|modification-date=2014-05-01T11:45" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001890/2a72ac52-e484-4c43-9960-1315172f6282> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001890/2464756a-9047-4a1f-bada-be24205815a1> .
 

--- a/models/WB_WBGene00001900.ttl
+++ b/models/WB_WBGene00001900.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,42 +29,46 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001900> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:title "his-26 (WB:WBGene00001900)" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001900> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001900/5f28c717-ea4a-4903-8f11-5d5023a3bc7f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001900/0ce2770c-1fbd-4429-a930-39ce1cf29f73> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/bb904962-6cfb-42c5-9a7f-988325d93902> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001900/2a94559e-82bf-4768-b054-bb1b5a0d5f35> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/ceaee11a-0210-4b68-88c4-e7962585024a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001900/3f1ba4e9-dc73-4a68-b02b-00f16dbcc818> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/f48ecffc-b1b2-4c25-935d-5867528c699c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001900/be169939-63cc-4773-a5f3-d67ee81d396a> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -75,95 +79,95 @@ obo:RO_0002233 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001900/0b977f62-f7d2-4bf5-8ebe-8c3457f72627> a GO:0001666,
+<http://model.geneontology.org/WB_WBGene00001900/0a6f7989-b062-42f5-ae38-5b0f77c78a87> a WB:WBGene00001900,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/bd9582b8-be51-4fcd-a560-44069c8e72c8> a WB:WBGene00001900,
+<http://model.geneontology.org/WB_WBGene00001900/582aae74-bd91-4cdd-8351-eb1da11a4435> a GO:0001666,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/c5024ca9-5128-47e3-91d2-ee19db1b2ae9> a WB:WBGene00002015,
+<http://model.geneontology.org/WB_WBGene00001900/c0e11149-1884-4a35-bd7b-840dd97dfc31> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001900/054c0622-e763-4363-871c-5f385fcffa0c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001900/0a6f7989-b062-42f5-ae38-5b0f77c78a87> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/fa304626-0f20-4f49-9403-d2aa25d4ae1d> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001900/d5877fb5-5530-4f9d-8218-235497e5dcaf> a WB:WBGene00002015,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001900/b062003c-2c0f-4282-8347-76067e13df85> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001900/bd9582b8-be51-4fcd-a560-44069c8e72c8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001900/b062003c-2c0f-4282-8347-76067e13df85> a GO:0045944,
+<http://model.geneontology.org/WB_WBGene00001900/054c0622-e763-4363-871c-5f385fcffa0c> a GO:0045944,
         owl:NamedIndividual ;
-    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001900/0b977f62-f7d2-4bf5-8ebe-8c3457f72627> ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001900/c5024ca9-5128-47e3-91d2-ee19db1b2ae9> ;
+    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001900/582aae74-bd91-4cdd-8351-eb1da11a4435> ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001900/d5877fb5-5530-4f9d-8218-235497e5dcaf> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001900/5f28c717-ea4a-4903-8f11-5d5023a3bc7f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001900/3f1ba4e9-dc73-4a68-b02b-00f16dbcc818> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001900  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14233|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002092 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/b062003c-2c0f-4282-8347-76067e13df85> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/0b977f62-f7d2-4bf5-8ebe-8c3457f72627> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001900/f48ecffc-b1b2-4c25-935d-5867528c699c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001900  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14233|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/b062003c-2c0f-4282-8347-76067e13df85> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/c5024ca9-5128-47e3-91d2-ee19db1b2ae9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/054c0622-e763-4363-871c-5f385fcffa0c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/d5877fb5-5530-4f9d-8218-235497e5dcaf> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001900/ceaee11a-0210-4b68-88c4-e7962585024a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001900/be169939-63cc-4773-a5f3-d67ee81d396a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001900  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14233|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/fa304626-0f20-4f49-9403-d2aa25d4ae1d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/bd9582b8-be51-4fcd-a560-44069c8e72c8> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/c0e11149-1884-4a35-bd7b-840dd97dfc31> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/0a6f7989-b062-42f5-ae38-5b0f77c78a87> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001900/bb904962-6cfb-42c5-9a7f-988325d93902> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001900/2a94559e-82bf-4768-b054-bb1b5a0d5f35> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001900  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14233|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/fa304626-0f20-4f49-9403-d2aa25d4ae1d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/b062003c-2c0f-4282-8347-76067e13df85> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/c0e11149-1884-4a35-bd7b-840dd97dfc31> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/054c0622-e763-4363-871c-5f385fcffa0c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001900/0ce2770c-1fbd-4429-a930-39ce1cf29f73> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001900  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14233|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002092 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001900/054c0622-e763-4363-871c-5f385fcffa0c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001900/582aae74-bd91-4cdd-8351-eb1da11a4435> .
 

--- a/models/WB_WBGene00001908.ttl
+++ b/models/WB_WBGene00001908.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001908> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:title "his-34 (WB:WBGene00001908)" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001908> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001908/2da5667e-8b91-41db-8b11-48c99c392b27> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001908/938890f6-e600-4f2d-9e9b-f97b48e534d5> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001908/b87c9cd8-cec6-4c89-9748-fd55fcfbb8e9> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001908/d7c5091b-1bf5-434d-af20-d12e98b6d2a7> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001908/1461b8dd-14a5-48f1-92c7-9ed3bc914098> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001908/16755303-89c5-4e52-9872-5a05a297345f> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001908/b1898dc0-2c98-437e-9041-7d875a15208b> a WB:WBGene00001908,
+<http://model.geneontology.org/WB_WBGene00001908/8c436c51-c7f8-485a-a824-dbb5b1bfff24> a WB:WBGene00001908,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001908/d8adfbdf-a432-4ccf-97e2-cf2cb87f21d1> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001908/a8d3e2bc-cf59-48d6-9090-8e12c453a41e> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001908/1461b8dd-14a5-48f1-92c7-9ed3bc914098> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001908/b1898dc0-2c98-437e-9041-7d875a15208b> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001908/16755303-89c5-4e52-9872-5a05a297345f> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001908/8c436c51-c7f8-485a-a824-dbb5b1bfff24> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001908/2da5667e-8b91-41db-8b11-48c99c392b27> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001908/d7c5091b-1bf5-434d-af20-d12e98b6d2a7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001908  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14245|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001908/d8adfbdf-a432-4ccf-97e2-cf2cb87f21d1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001908/b1898dc0-2c98-437e-9041-7d875a15208b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001908/b87c9cd8-cec6-4c89-9748-fd55fcfbb8e9> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001908  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14245|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001908/d8adfbdf-a432-4ccf-97e2-cf2cb87f21d1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001908/1461b8dd-14a5-48f1-92c7-9ed3bc914098> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001908/a8d3e2bc-cf59-48d6-9090-8e12c453a41e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001908/16755303-89c5-4e52-9872-5a05a297345f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001908/938890f6-e600-4f2d-9e9b-f97b48e534d5> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dct:created "2014-05-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001908  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14245|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001908/a8d3e2bc-cf59-48d6-9090-8e12c453a41e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001908/8c436c51-c7f8-485a-a824-dbb5b1bfff24> .
 

--- a/models/WB_WBGene00001912.ttl
+++ b/models/WB_WBGene00001912.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,42 +29,46 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001912> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:title "his-38 (WB:WBGene00001912)" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001912> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001912/03782d5e-9021-44a6-81c4-b24444203b44> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001912/0d59d907-592f-4b83-892e-d6585e656911> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/0ac277ca-3b99-4fd3-a469-ad71f5d16c25> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001912/552ab89f-c29a-45f1-a70b-ddc28bd6ee60> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/5281e30d-ccd3-48e4-b88e-871063b5ad14> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001912/9a0ef40e-5a73-4067-aa22-b52730db6236> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/5520db5c-ab83-411c-8073-b53373b7799d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001912/a2a0ffef-8721-45a3-b6c2-d0cbd207f814> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -75,95 +79,95 @@ obo:RO_0002233 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001912/8a877337-8530-4d1b-8cf4-ffedd16ed7d6> a GO:0001666,
+<http://model.geneontology.org/WB_WBGene00001912/0b79c1f9-a343-4861-89c9-b8300fa914d7> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001912/8fcb3f24-8248-4b0e-aac6-0db80b2b577c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001912/baf1d7d2-47b5-4f51-9d5e-39dd52b14d68> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/a73f345d-f5f7-4bff-ba15-76bbe24bb812> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001912/34883037-18d4-49d0-b0ba-8573d490413e> a WB:WBGene00002015,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001912/9b2d6ef7-9c2e-4bff-a1bf-c8952cb1af40> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001912/ddec11f3-5f92-4753-9741-2f8f3deab798> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/b6cf3d40-bf4c-4092-a787-194e819e82c9> a WB:WBGene00002015,
+<http://model.geneontology.org/WB_WBGene00001912/ae376bf2-2b29-43be-8a99-9d1af9b25bcb> a GO:0001666,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/ddec11f3-5f92-4753-9741-2f8f3deab798> a WB:WBGene00001912,
+<http://model.geneontology.org/WB_WBGene00001912/baf1d7d2-47b5-4f51-9d5e-39dd52b14d68> a WB:WBGene00001912,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001912/9b2d6ef7-9c2e-4bff-a1bf-c8952cb1af40> a GO:0045944,
+<http://model.geneontology.org/WB_WBGene00001912/8fcb3f24-8248-4b0e-aac6-0db80b2b577c> a GO:0045944,
         owl:NamedIndividual ;
-    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001912/8a877337-8530-4d1b-8cf4-ffedd16ed7d6> ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001912/b6cf3d40-bf4c-4092-a787-194e819e82c9> ;
+    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001912/ae376bf2-2b29-43be-8a99-9d1af9b25bcb> ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001912/34883037-18d4-49d0-b0ba-8573d490413e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001912/03782d5e-9021-44a6-81c4-b24444203b44> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001912/a2a0ffef-8721-45a3-b6c2-d0cbd207f814> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/a73f345d-f5f7-4bff-ba15-76bbe24bb812> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/9b2d6ef7-9c2e-4bff-a1bf-c8952cb1af40> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001912/5281e30d-ccd3-48e4-b88e-871063b5ad14> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002092 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/9b2d6ef7-9c2e-4bff-a1bf-c8952cb1af40> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/8a877337-8530-4d1b-8cf4-ffedd16ed7d6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001912/5520db5c-ab83-411c-8073-b53373b7799d> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/9b2d6ef7-9c2e-4bff-a1bf-c8952cb1af40> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/b6cf3d40-bf4c-4092-a787-194e819e82c9> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001912/0ac277ca-3b99-4fd3-a469-ad71f5d16c25> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/a73f345d-f5f7-4bff-ba15-76bbe24bb812> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/ddec11f3-5f92-4753-9741-2f8f3deab798> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/0b79c1f9-a343-4861-89c9-b8300fa914d7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/baf1d7d2-47b5-4f51-9d5e-39dd52b14d68> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001912/552ab89f-c29a-45f1-a70b-ddc28bd6ee60> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002092 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/8fcb3f24-8248-4b0e-aac6-0db80b2b577c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/ae376bf2-2b29-43be-8a99-9d1af9b25bcb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001912/9a0ef40e-5a73-4067-aa22-b52730db6236> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/8fcb3f24-8248-4b0e-aac6-0db80b2b577c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/34883037-18d4-49d0-b0ba-8573d490413e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001912/0d59d907-592f-4b83-892e-d6585e656911> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001912  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14234|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001912/0b79c1f9-a343-4861-89c9-b8300fa914d7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001912/8fcb3f24-8248-4b0e-aac6-0db80b2b577c> .
 

--- a/models/WB_WBGene00001917.ttl
+++ b/models/WB_WBGene00001917.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001917> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:title "his-43 (WB:WBGene00001917)" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001917> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001917/239e5022-90cd-4a80-8297-14308ed156aa> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001917/414470e9-ac04-4df2-9081-b8c8c64f7490> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001917/9603e13a-450b-4263-ab8a-c6ab5a84353f> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001917/9d893e65-9396-4617-8a1c-c3edd3112eb5> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001917/351b60e4-81bc-4383-987c-927cf2a8d9c4> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001917/59d022ed-892a-401b-b90a-a0ac26a038b6> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001917/55414d70-8a06-45d6-9a4f-9184ffff2aad> a WB:WBGene00001917,
+<http://model.geneontology.org/WB_WBGene00001917/63f5df43-652e-453d-91f5-c3832610c568> a WB:WBGene00001917,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001917/acb8d265-2af7-4630-8bde-0519d5661e9c> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001917/fe6cdafa-b46f-44f2-bcaf-709316a7103d> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001917/351b60e4-81bc-4383-987c-927cf2a8d9c4> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001917/55414d70-8a06-45d6-9a4f-9184ffff2aad> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001917/59d022ed-892a-401b-b90a-a0ac26a038b6> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001917/63f5df43-652e-453d-91f5-c3832610c568> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001917/239e5022-90cd-4a80-8297-14308ed156aa> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001917/9d893e65-9396-4617-8a1c-c3edd3112eb5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001917  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14246|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001917/acb8d265-2af7-4630-8bde-0519d5661e9c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001917/351b60e4-81bc-4383-987c-927cf2a8d9c4> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001917/fe6cdafa-b46f-44f2-bcaf-709316a7103d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001917/59d022ed-892a-401b-b90a-a0ac26a038b6> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001917/9603e13a-450b-4263-ab8a-c6ab5a84353f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001917/414470e9-ac04-4df2-9081-b8c8c64f7490> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001917  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14246|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001917/acb8d265-2af7-4630-8bde-0519d5661e9c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001917/55414d70-8a06-45d6-9a4f-9184ffff2aad> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001917/fe6cdafa-b46f-44f2-bcaf-709316a7103d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001917/63f5df43-652e-453d-91f5-c3832610c568> .
 

--- a/models/WB_WBGene00001918.ttl
+++ b/models/WB_WBGene00001918.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001918> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:title "his-44 (WB:WBGene00001918)" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001918> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001918/64e5467f-ac3d-44c1-8133-62acfad6fc60> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001918/71d4ec94-d2db-43c3-93c5-54ded4280901> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001918/7ebe66f7-18a9-4f9d-b694-c266f44b7615> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001918/81b890ad-b185-4a16-b12c-08b0752e5b30> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001918/2e899d88-7136-4aa5-ae29-1f371ac281f9> a WB:WBGene00001918,
+<http://model.geneontology.org/WB_WBGene00001918/1a46f814-36e4-43f5-8e34-8a3bbcfbc589> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001918/fdfb244e-c242-4d6f-b0f8-fd509b3650c1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001918/80bf1256-a50f-473b-9299-732ae394a556> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001918/4aee8e71-5f3b-46a8-9f87-f8c32852e313> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001918/80bf1256-a50f-473b-9299-732ae394a556> a WB:WBGene00001918,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001918/a9133254-f803-4b85-bcde-e90c2c21140e> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001918/fdfb244e-c242-4d6f-b0f8-fd509b3650c1> a GO:0045087,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001918/4aee8e71-5f3b-46a8-9f87-f8c32852e313> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001918/2e899d88-7136-4aa5-ae29-1f371ac281f9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001918/7ebe66f7-18a9-4f9d-b694-c266f44b7615> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001918/81b890ad-b185-4a16-b12c-08b0752e5b30> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001918  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14247|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001918/a9133254-f803-4b85-bcde-e90c2c21140e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001918/4aee8e71-5f3b-46a8-9f87-f8c32852e313> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001918/64e5467f-ac3d-44c1-8133-62acfad6fc60> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001918  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14247|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001918/a9133254-f803-4b85-bcde-e90c2c21140e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001918/2e899d88-7136-4aa5-ae29-1f371ac281f9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001918/1a46f814-36e4-43f5-8e34-8a3bbcfbc589> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001918/80bf1256-a50f-473b-9299-732ae394a556> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001918/71d4ec94-d2db-43c3-93c5-54ded4280901> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dct:created "2014-05-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001918  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14247|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001918/1a46f814-36e4-43f5-8e34-8a3bbcfbc589> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001918/fdfb244e-c242-4d6f-b0f8-fd509b3650c1> .
 

--- a/models/WB_WBGene00001922.ttl
+++ b/models/WB_WBGene00001922.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001922> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:title "his-48 (WB:WBGene00001922)" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001922> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001922/00b91dfc-038f-43f9-973e-f74e0849dc0e> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001922/5e226fda-4450-4848-a43c-48db7cfd9179> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001922/8c7a2bac-e6aa-4c32-aada-ebfd4ba8b6c6> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00001922/d62d07f6-0613-4bb3-8445-c9bd78db6c38> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dc:source "PMID:16968778" ;
+    dct:created "2014-05-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001922/59d52d63-65b9-4e89-9b4d-37de272463ce> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001922/0ee9070a-6631-4ca6-8280-541d86e0dff5> a GO:0045087,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001922/80b93b48-4dcd-49e4-beb3-c807856827e1> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001922/b1719ca8-3c39-4f54-9847-823604277cb2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001922/80b93b48-4dcd-49e4-beb3-c807856827e1> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00001922/a8eeb202-592f-4665-a77d-ddc26caab54d> a WB:WBGene00001922,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001922/b1719ca8-3c39-4f54-9847-823604277cb2> a WB:WBGene00001922,
+<http://model.geneontology.org/WB_WBGene00001922/e2164f17-e3d0-46fc-9ae0-afc02f7c4d6a> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001922/0ee9070a-6631-4ca6-8280-541d86e0dff5> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001922/a8eeb202-592f-4665-a77d-ddc26caab54d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001922/8c7a2bac-e6aa-4c32-aada-ebfd4ba8b6c6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001922/d62d07f6-0613-4bb3-8445-c9bd78db6c38> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-05-09" ;
     dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001922  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14248|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001922/59d52d63-65b9-4e89-9b4d-37de272463ce> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001922/80b93b48-4dcd-49e4-beb3-c807856827e1> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001922/00b91dfc-038f-43f9-973e-f74e0849dc0e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-05-09" ;
-    dct:created "2014-05-09" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001922  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14248|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001922/59d52d63-65b9-4e89-9b4d-37de272463ce> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001922/b1719ca8-3c39-4f54-9847-823604277cb2> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001922/e2164f17-e3d0-46fc-9ae0-afc02f7c4d6a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001922/a8eeb202-592f-4665-a77d-ddc26caab54d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001922/5e226fda-4450-4848-a43c-48db7cfd9179> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-05-09" ;
+    dct:created "2014-05-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001922  RO:0002331 GO:0045087 WB:WBPaper00028482|PMID:16968778 ECO:0000270   2014-05-09 WB  id=WBOA:14248|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-05-09|modification-date=2014-05-09" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001922/e2164f17-e3d0-46fc-9ae0-afc02f7c4d6a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001922/0ee9070a-6631-4ca6-8280-541d86e0dff5> .
 

--- a/models/WB_WBGene00001938.ttl
+++ b/models/WB_WBGene00001938.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,42 +29,46 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001938> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:title "his-64 (WB:WBGene00001938)" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001938> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001938/1033fa97-8f9c-4380-8745-e7f595ece7cc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001938/24130100-646d-4adc-9b9e-2d00e776c478> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/3a77deb0-30fe-4dfc-9ddd-f6444e4e6a2e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001938/7874a445-2399-4399-ba14-282a2446e5c8> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/45316a16-7d75-460e-9912-3f62cf29a94e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001938/8506aca3-c3fd-4b22-a7ed-463eecf8beb0> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/5a1eeb35-5758-4352-879d-2c12a5ee41f1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001938/fd5b9a74-05ff-4d9f-9abe-42ae41d31ffd> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -75,95 +79,95 @@ obo:RO_0002233 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001938/1e6d6057-aa75-4bd7-92a5-a6a1ebc7179e> a GO:0001666,
+<http://model.geneontology.org/WB_WBGene00001938/120a758a-9b3b-4772-b7c7-b57ddeafe538> a GO:0001666,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/281da897-a4b0-49c7-b284-47ccc5ca1a89> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001938/4eec4ffa-bd22-45ce-9702-5abdc5fb3967> a WB:WBGene00002015,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001938/0abd2ddb-f6ae-4fa0-9c01-c2256dc8ad1c> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001938/33205ca8-e87e-4539-b7dc-c744740ce6eb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/33205ca8-e87e-4539-b7dc-c744740ce6eb> a WB:WBGene00001938,
+<http://model.geneontology.org/WB_WBGene00001938/bc70630f-0dac-43fa-a475-903cacb4157d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001938/07a79f37-3148-4644-94d9-c8cf3bf76ee7> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001938/c61d0018-cc45-4693-864a-833fd1a59fc9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/6f1c43b8-812a-4c45-bc04-a3d6e6842fd9> a WB:WBGene00002015,
+<http://model.geneontology.org/WB_WBGene00001938/c61d0018-cc45-4693-864a-833fd1a59fc9> a WB:WBGene00001938,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001938/0abd2ddb-f6ae-4fa0-9c01-c2256dc8ad1c> a GO:0045944,
+<http://model.geneontology.org/WB_WBGene00001938/07a79f37-3148-4644-94d9-c8cf3bf76ee7> a GO:0045944,
         owl:NamedIndividual ;
-    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001938/1e6d6057-aa75-4bd7-92a5-a6a1ebc7179e> ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001938/6f1c43b8-812a-4c45-bc04-a3d6e6842fd9> ;
+    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001938/120a758a-9b3b-4772-b7c7-b57ddeafe538> ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001938/4eec4ffa-bd22-45ce-9702-5abdc5fb3967> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001938/1033fa97-8f9c-4380-8745-e7f595ece7cc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001938/7874a445-2399-4399-ba14-282a2446e5c8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001938  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14235|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/0abd2ddb-f6ae-4fa0-9c01-c2256dc8ad1c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/6f1c43b8-812a-4c45-bc04-a3d6e6842fd9> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001938/5a1eeb35-5758-4352-879d-2c12a5ee41f1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001938  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14235|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002092 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/0abd2ddb-f6ae-4fa0-9c01-c2256dc8ad1c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/1e6d6057-aa75-4bd7-92a5-a6a1ebc7179e> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001938/3a77deb0-30fe-4dfc-9ddd-f6444e4e6a2e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001938  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14235|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/281da897-a4b0-49c7-b284-47ccc5ca1a89> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/0abd2ddb-f6ae-4fa0-9c01-c2256dc8ad1c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/bc70630f-0dac-43fa-a475-903cacb4157d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/07a79f37-3148-4644-94d9-c8cf3bf76ee7> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001938/45316a16-7d75-460e-9912-3f62cf29a94e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001938/fd5b9a74-05ff-4d9f-9abe-42ae41d31ffd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001938  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14235|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/07a79f37-3148-4644-94d9-c8cf3bf76ee7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/4eec4ffa-bd22-45ce-9702-5abdc5fb3967> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001938/24130100-646d-4adc-9b9e-2d00e776c478> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001938  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14235|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002092 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/07a79f37-3148-4644-94d9-c8cf3bf76ee7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/120a758a-9b3b-4772-b7c7-b57ddeafe538> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001938/8506aca3-c3fd-4b22-a7ed-463eecf8beb0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001938  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14235|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/281da897-a4b0-49c7-b284-47ccc5ca1a89> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/33205ca8-e87e-4539-b7dc-c744740ce6eb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001938/bc70630f-0dac-43fa-a475-903cacb4157d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001938/c61d0018-cc45-4693-864a-833fd1a59fc9> .
 

--- a/models/WB_WBGene00001941.ttl
+++ b/models/WB_WBGene00001941.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,42 +29,46 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00001941> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:title "his-67 (WB:WBGene00001941)" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00001941> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00001941/0570f9d1-bf8f-484f-b566-f1636b025316> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001941/0b29aedf-6124-49dd-b87b-4ee6ae103036> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/18ccb3d2-5649-4077-9fbe-e3c384f57853> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001941/81c7ff2b-c4a4-4699-816f-5f897a5ece6a> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/6580cebd-49bb-446e-890d-32dfa14c47c3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001941/b6a81f14-4e94-4f05-b276-69c38cbda5b0> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/7a02af11-efba-44d7-a38e-d0f863f921ab> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00001941/dc968472-659c-4123-8691-30af4d9003f9> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:23229554" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -75,95 +79,95 @@ obo:RO_0002233 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00001941/39990fe9-742d-4bdb-afa0-91c3f79d50fd> a WB:WBGene00001941,
+<http://model.geneontology.org/WB_WBGene00001941/2350ac93-1a9c-4f7d-ad97-01d7aba4b41d> a WB:WBGene00002015,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/66422f48-0c89-44ee-9f1f-5e6bf61cfe2e> a WB:WBGene00002015,
+<http://model.geneontology.org/WB_WBGene00001941/85bd787b-709a-4c43-94eb-0a7aee6fc122> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001941/31e83a5e-a897-4908-ab12-76a2ff9380c1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001941/e6e33d88-5daf-4766-8260-2714458c0960> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/85bf11d6-5b02-45fd-a3dc-1b476e32396d> a GO:0001666,
+<http://model.geneontology.org/WB_WBGene00001941/b93ce5af-0b43-4ba0-b21e-21236ae93060> a GO:0001666,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/b1ca8641-5fa9-421b-8283-b7db0f988ce8> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00001941/e6e33d88-5daf-4766-8260-2714458c0960> a WB:WBGene00001941,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00001941/c48123b0-6f0e-40e0-9fcd-a0bcb7bc41ee> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00001941/39990fe9-742d-4bdb-afa0-91c3f79d50fd> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00001941/c48123b0-6f0e-40e0-9fcd-a0bcb7bc41ee> a GO:0045944,
+<http://model.geneontology.org/WB_WBGene00001941/31e83a5e-a897-4908-ab12-76a2ff9380c1> a GO:0045944,
         owl:NamedIndividual ;
-    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001941/85bf11d6-5b02-45fd-a3dc-1b476e32396d> ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001941/66422f48-0c89-44ee-9f1f-5e6bf61cfe2e> ;
+    obo:RO_0002092 <http://model.geneontology.org/WB_WBGene00001941/b93ce5af-0b43-4ba0-b21e-21236ae93060> ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00001941/2350ac93-1a9c-4f7d-ad97-01d7aba4b41d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001941/0570f9d1-bf8f-484f-b566-f1636b025316> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001941/dc968472-659c-4123-8691-30af4d9003f9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001941  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14236|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/b1ca8641-5fa9-421b-8283-b7db0f988ce8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/39990fe9-742d-4bdb-afa0-91c3f79d50fd> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001941/18ccb3d2-5649-4077-9fbe-e3c384f57853> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001941  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14236|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/c48123b0-6f0e-40e0-9fcd-a0bcb7bc41ee> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/66422f48-0c89-44ee-9f1f-5e6bf61cfe2e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/31e83a5e-a897-4908-ab12-76a2ff9380c1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/2350ac93-1a9c-4f7d-ad97-01d7aba4b41d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001941/7a02af11-efba-44d7-a38e-d0f863f921ab> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001941/0b29aedf-6124-49dd-b87b-4ee6ae103036> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00001941  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14236|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002092 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/c48123b0-6f0e-40e0-9fcd-a0bcb7bc41ee> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/85bf11d6-5b02-45fd-a3dc-1b476e32396d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00001941/6580cebd-49bb-446e-890d-32dfa14c47c3> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00001941  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14236|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/b1ca8641-5fa9-421b-8283-b7db0f988ce8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/c48123b0-6f0e-40e0-9fcd-a0bcb7bc41ee> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/85bd787b-709a-4c43-94eb-0a7aee6fc122> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/31e83a5e-a897-4908-ab12-76a2ff9380c1> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001941/81c7ff2b-c4a4-4699-816f-5f897a5ece6a> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001941  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14236|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002092 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/31e83a5e-a897-4908-ab12-76a2ff9380c1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/b93ce5af-0b43-4ba0-b21e-21236ae93060> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00001941/b6a81f14-4e94-4f05-b276-69c38cbda5b0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00001941  RO:0002331 GO:0045944 WB:WBPaper00041799|PMID:23229554 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00002015),RO:0002092(GO:0001666) id=WBOA:14236|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00001941/85bd787b-709a-4c43-94eb-0a7aee6fc122> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00001941/e6e33d88-5daf-4766-8260-2714458c0960> .
 

--- a/models/WB_WBGene00002015.ttl
+++ b/models/WB_WBGene00002015.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,46 +29,49 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002015> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:title "hsp-16.1 (WB:WBGene00002015)" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002015> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002015/1d6ac03b-da58-4f06-b86f-6f5ff4d64885> a WB:WBGene00002015,
-        owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00002015/1880f84b-627a-432d-a1ad-568385be3123> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002015/3ccdbd8b-f738-43fc-a9ab-cb5561c2d1b2> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002015/2cbb1fed-e2bc-4454-9809-1ea82b98262d> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:1550963" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
 
-<http://model.geneontology.org/WB_WBGene00002015/4f0f2863-810d-4881-8ec8-975e23886bed> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00002015/6128dc72-902a-4c79-8665-ffbe5575e4a6> a WB:WBGene00002015,
+        owl:NamedIndividual ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00002015/f66cf9fc-3ab5-4d1d-92cd-e774d8cdd457> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002015/acf6dce6-b2f3-4005-94a1-31ece64b27bc> a ECO:0000270,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dc:source "PMID:1550963" ;
+    dct:created "2021-05-11" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
+
+<http://model.geneontology.org/WB_WBGene00002015/f4d4dfa8-7794-410a-b508-857361288f4f> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:22972192" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
-
-<http://model.geneontology.org/WB_WBGene00002015/c4e562bf-0c40-49da-8bde-2626a6ee5205> a ECO:0000270,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dc:source "PMID:1550963" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
 
@@ -78,73 +81,73 @@ obo:RO_0001025 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002015/086b1463-988b-4e63-a481-0b413293077c> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00002015/22ddbd3f-e686-498a-a017-dfc2e214a6c0> a GO:0009408,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002015/1880f84b-627a-432d-a1ad-568385be3123> a GO:0005797,
+<http://model.geneontology.org/WB_WBGene00002015/7c3c4c2e-a79c-46ef-8b8e-3f1f07f00142> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002015/22ddbd3f-e686-498a-a017-dfc2e214a6c0> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002015/b3b12024-03fd-4bc9-9867-76f06efe9b48> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002015/1c74bd6e-d7a5-4588-b859-392ec07d6dcd> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002015/b3b12024-03fd-4bc9-9867-76f06efe9b48> a WB:WBGene00002015,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002015/086b1463-988b-4e63-a481-0b413293077c> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002015/32abf061-0677-4e98-960a-895cc9290279> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002015/32abf061-0677-4e98-960a-895cc9290279> a WB:WBGene00002015,
+<http://model.geneontology.org/WB_WBGene00002015/f66cf9fc-3ab5-4d1d-92cd-e774d8cdd457> a GO:0005797,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002015/4f0f2863-810d-4881-8ec8-975e23886bed> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002015/acf6dce6-b2f3-4005-94a1-31ece64b27bc> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002015  RO:0001025 GO:0005797 WB:WBPaper00041564|PMID:22972192 ECO:0000314   2021-05-11 WB  id=WBOA:89588|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
-    owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002015/1d6ac03b-da58-4f06-b86f-6f5ff4d64885> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002015/1880f84b-627a-432d-a1ad-568385be3123> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002015/c4e562bf-0c40-49da-8bde-2626a6ee5205> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002015  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89586|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002015/1c74bd6e-d7a5-4588-b859-392ec07d6dcd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002015/32abf061-0677-4e98-960a-895cc9290279> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002015/3ccdbd8b-f738-43fc-a9ab-cb5561c2d1b2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002015  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89586|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002015/1c74bd6e-d7a5-4588-b859-392ec07d6dcd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002015/086b1463-988b-4e63-a481-0b413293077c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002015/7c3c4c2e-a79c-46ef-8b8e-3f1f07f00142> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002015/22ddbd3f-e686-498a-a017-dfc2e214a6c0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002015/f4d4dfa8-7794-410a-b508-857361288f4f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002015  RO:0001025 GO:0005797 WB:WBPaper00041564|PMID:22972192 ECO:0000314   2021-05-11 WB  id=WBOA:89588|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
+    owl:annotatedProperty obo:RO_0001025 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002015/6128dc72-902a-4c79-8665-ffbe5575e4a6> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002015/f66cf9fc-3ab5-4d1d-92cd-e774d8cdd457> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002015/2cbb1fed-e2bc-4454-9809-1ea82b98262d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002015  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89586|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002015/7c3c4c2e-a79c-46ef-8b8e-3f1f07f00142> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002015/b3b12024-03fd-4bc9-9867-76f06efe9b48> .
 

--- a/models/WB_WBGene00002017.ttl
+++ b/models/WB_WBGene00002017.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002017> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:title "hsp-16.11 (WB:WBGene00002017)" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002017> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002017/43e497fe-53c4-4524-9abb-7cbec8c406d0> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002017/60cc1cdb-b709-4bcc-a134-f1c25dfbd09b> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:12186849" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002017/6eda3a78-2fb2-4d0b-bb98-6b27c64f0697> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002017/a424e13a-ddaf-4be5-9cf2-20fe5845c601> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:12186849" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002017/b2a0e8ed-3c9a-4760-ab36-3c6ced728743> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002017/85b98ef9-014e-4a5b-8ad1-779e17d0c5a3> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002017/f2c071da-ffd7-45cb-9398-e9d919549261> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002017/ea514e1a-ee7b-4198-8fd1-59bd61488fd3> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002017/ef987273-1149-4663-bcc0-3259d184a405> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002017/fb7b1519-3ec6-4268-bc7f-d1632bab57db> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002017/ea514e1a-ee7b-4198-8fd1-59bd61488fd3> a WB:WBGene00002017,
+<http://model.geneontology.org/WB_WBGene00002017/ef987273-1149-4663-bcc0-3259d184a405> a GO:0030968,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002017/f2c071da-ffd7-45cb-9398-e9d919549261> a GO:0030968,
+<http://model.geneontology.org/WB_WBGene00002017/fb7b1519-3ec6-4268-bc7f-d1632bab57db> a WB:WBGene00002017,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002017/43e497fe-53c4-4524-9abb-7cbec8c406d0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002017/a424e13a-ddaf-4be5-9cf2-20fe5845c601> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002017  RO:0002331 GO:0030968 WB:WBPaper00005432|PMID:12186849 ECO:0000270   2021-04-14 WB  id=WBOA:2723|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002017/b2a0e8ed-3c9a-4760-ab36-3c6ced728743> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002017/f2c071da-ffd7-45cb-9398-e9d919549261> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002017/85b98ef9-014e-4a5b-8ad1-779e17d0c5a3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002017/ef987273-1149-4663-bcc0-3259d184a405> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002017/6eda3a78-2fb2-4d0b-bb98-6b27c64f0697> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002017/60cc1cdb-b709-4bcc-a134-f1c25dfbd09b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002017  RO:0002331 GO:0030968 WB:WBPaper00005432|PMID:12186849 ECO:0000270   2021-04-14 WB  id=WBOA:2723|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002017/b2a0e8ed-3c9a-4760-ab36-3c6ced728743> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002017/ea514e1a-ee7b-4198-8fd1-59bd61488fd3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002017/85b98ef9-014e-4a5b-8ad1-779e17d0c5a3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002017/fb7b1519-3ec6-4268-bc7f-d1632bab57db> .
 

--- a/models/WB_WBGene00002019.ttl
+++ b/models/WB_WBGene00002019.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,100 +29,104 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002019> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:title "hsp-16.48 (WB:WBGene00002019)" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002019> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002019/1aa932ee-7965-4606-963a-b0d41dc07f65> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002019/541e0adb-2785-465c-871c-cca0822ea1c7> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:1550963" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
 
-<http://model.geneontology.org/WB_WBGene00002019/44cd0823-f54c-47c0-ab80-8f7b456a3eff> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002019/61c2008b-afc5-45fe-b03e-ce27f78d3d19> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000090" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dc:source "PMID:14668486" ;
+    dct:created "2021-05-11" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
+
+<http://model.geneontology.org/WB_WBGene00002019/736e72ee-c6a8-437e-9664-565d062d3c60> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:1550963" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
 
-<http://model.geneontology.org/WB_WBGene00002019/b2063efd-876f-4186-bbf7-4811bbbec90a> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00002019/ce6c3ac8-e146-4488-99b2-72acafc12777> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000090" ;
+    ns1:evidence-with "WB:WBGene00000090" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:14668486" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
 
-<http://model.geneontology.org/WB_WBGene00002019/cc05b40b-e372-415c-86cc-6badbb056aa7> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00002019/04cc6542-5a4b-4783-a935-220ed1d55796> a WB:WBGene00002019,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000090" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dc:source "PMID:14668486" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Moved from Protein2GO because of lack of a 1:1 mapping." .
-
-<http://model.geneontology.org/WB_WBGene00002019/12171728-91bb-494a-b1a0-b2028b0abbe0> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002019/90a7f40b-eb96-46ec-83ab-ae6b64a9733e> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002019/1bf22140-0204-4d40-89c3-cd580f2e4559> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002019/12678ace-de37-4c07-9c63-49f901e07996> a WB:WBGene00002019,
+<http://model.geneontology.org/WB_WBGene00002019/281a7e15-fbd7-417b-81a6-979675b3fa6f> a GO:0009408,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002019/1bf22140-0204-4d40-89c3-cd580f2e4559> a WB:WBGene00002019,
+<http://model.geneontology.org/WB_WBGene00002019/464d2da3-a95b-4b42-b68f-3c18f74cf170> a GO:0008340,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002019/90a7f40b-eb96-46ec-83ab-ae6b64a9733e> a GO:0008340,
+<http://model.geneontology.org/WB_WBGene00002019/7085fd47-cf72-454f-87da-1979711db45f> a WB:WBGene00002019,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002019/a1c9c790-3466-4010-9b09-549cf823f87f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002019/81e81d00-982b-4fb9-b20a-7db888e5e8ca> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002019/bd164ecf-d00f-4837-b718-6988c9495774> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002019/12678ace-de37-4c07-9c63-49f901e07996> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002019/281a7e15-fbd7-417b-81a6-979675b3fa6f> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002019/7085fd47-cf72-454f-87da-1979711db45f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002019/bd164ecf-d00f-4837-b718-6988c9495774> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00002019/dd0c6b94-53b7-4337-957f-81a0df4b588a> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002019/464d2da3-a95b-4b42-b68f-3c18f74cf170> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002019/04cc6542-5a4b-4783-a935-220ed1d55796> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -130,50 +134,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002019/cc05b40b-e372-415c-86cc-6badbb056aa7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002019/61c2008b-afc5-45fe-b03e-ce27f78d3d19> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0008340 WB:WBPaper00006377|PMID:14668486 ECO:0000316 WB:WBGene00000090  2021-05-11 WB  id=WBOA:89589|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/12171728-91bb-494a-b1a0-b2028b0abbe0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/1bf22140-0204-4d40-89c3-cd580f2e4559> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002019/44cd0823-f54c-47c0-ab80-8f7b456a3eff> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89587|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/a1c9c790-3466-4010-9b09-549cf823f87f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/12678ace-de37-4c07-9c63-49f901e07996> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002019/1aa932ee-7965-4606-963a-b0d41dc07f65> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89587|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/a1c9c790-3466-4010-9b09-549cf823f87f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/bd164ecf-d00f-4837-b718-6988c9495774> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002019/b2063efd-876f-4186-bbf7-4811bbbec90a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0008340 WB:WBPaper00006377|PMID:14668486 ECO:0000316 WB:WBGene00000090  2021-05-11 WB  id=WBOA:89589|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/12171728-91bb-494a-b1a0-b2028b0abbe0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/90a7f40b-eb96-46ec-83ab-ae6b64a9733e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/dd0c6b94-53b7-4337-957f-81a0df4b588a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/464d2da3-a95b-4b42-b68f-3c18f74cf170> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002019/736e72ee-c6a8-437e-9664-565d062d3c60> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89587|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/81e81d00-982b-4fb9-b20a-7db888e5e8ca> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/7085fd47-cf72-454f-87da-1979711db45f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002019/541e0adb-2785-465c-871c-cca0822ea1c7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0009408 WB:WBPaper00001497|PMID:1550963 ECO:0000270   2021-05-11 WB  id=WBOA:89587|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/81e81d00-982b-4fb9-b20a-7db888e5e8ca> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/281a7e15-fbd7-417b-81a6-979675b3fa6f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002019/ce6c3ac8-e146-4488-99b2-72acafc12777> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002019  RO:0002331 GO:0008340 WB:WBPaper00006377|PMID:14668486 ECO:0000316 WB:WBGene00000090  2021-05-11 WB  id=WBOA:89589|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Moved from Protein2GO because of lack of a 1:1 mapping.|creation-date=2021-05-11T7:46|modification-date=2021-05-11T7:46" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002019/dd0c6b94-53b7-4337-957f-81a0df4b588a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002019/04cc6542-5a4b-4783-a935-220ed1d55796> .
 

--- a/models/WB_WBGene00002020.ttl
+++ b/models/WB_WBGene00002020.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002020> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dc:title "hsp-16.49 (WB:WBGene00002020)" ;
     dct:created "2006-03-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002020> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002020/7b36be65-6b91-45d9-9c95-5ba2ae683dca> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002020/18b570cf-cee7-4ee1-87dc-f8b98926b105> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dc:source "PMID:12186849" ;
+    dct:created "2006-03-07" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002020/95b6db69-4410-4cec-82b2-2195fb100b8c> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00002020/28b21d58-c685-4059-8395-bae517037552> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dc:source "PMID:12186849" ;
+    dct:created "2006-03-07" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002020/2a0b2d3c-3014-4460-83fb-5fa8c1d5e35f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002020/76d42eaa-0060-4e3a-a72a-d7f4e1a22b61> a WB:WBGene00002020,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002020/647ad924-aff8-4166-a65b-d1a020233a37> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002020/44006aea-9462-4222-a989-31f231a449d4> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dct:created "2006-03-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002020/44006aea-9462-4222-a989-31f231a449d4> a WB:WBGene00002020,
+<http://model.geneontology.org/WB_WBGene00002020/7e2f6980-d893-423e-8b54-3e7bc6cb0455> a GO:0030968,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dct:created "2006-03-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002020/647ad924-aff8-4166-a65b-d1a020233a37> a GO:0030968,
+<http://model.geneontology.org/WB_WBGene00002020/ff600a9d-9a17-48f8-9155-5163e1161821> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002020/7e2f6980-d893-423e-8b54-3e7bc6cb0455> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002020/76d42eaa-0060-4e3a-a72a-d7f4e1a22b61> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dct:created "2006-03-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002020/7b36be65-6b91-45d9-9c95-5ba2ae683dca> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002020/18b570cf-cee7-4ee1-87dc-f8b98926b105> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-03-07" ;
     dct:created "2006-03-07" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002020  RO:0002331 GO:0030968 WB:WBPaper00005432|PMID:12186849 ECO:0000270   2006-03-07 WB  id=WBOA:2726|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-03-07T17:46|modification-date=2006-03-07T17:46" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002020/2a0b2d3c-3014-4460-83fb-5fa8c1d5e35f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002020/647ad924-aff8-4166-a65b-d1a020233a37> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002020/95b6db69-4410-4cec-82b2-2195fb100b8c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-03-07" ;
-    dct:created "2006-03-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002020  RO:0002331 GO:0030968 WB:WBPaper00005432|PMID:12186849 ECO:0000270   2006-03-07 WB  id=WBOA:2726|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-03-07T17:46|modification-date=2006-03-07T17:46" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002020/2a0b2d3c-3014-4460-83fb-5fa8c1d5e35f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002020/44006aea-9462-4222-a989-31f231a449d4> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002020/ff600a9d-9a17-48f8-9155-5163e1161821> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002020/76d42eaa-0060-4e3a-a72a-d7f4e1a22b61> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002020/28b21d58-c685-4059-8395-bae517037552> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-03-07" ;
+    dct:created "2006-03-07" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002020  RO:0002331 GO:0030968 WB:WBPaper00005432|PMID:12186849 ECO:0000270   2006-03-07 WB  id=WBOA:2726|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-03-07T17:46|modification-date=2006-03-07T17:46" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002020/ff600a9d-9a17-48f8-9155-5163e1161821> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002020/7e2f6980-d893-423e-8b54-3e7bc6cb0455> .
 

--- a/models/WB_WBGene00002049.ttl
+++ b/models/WB_WBGene00002049.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,100 +29,104 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002049> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "idf-1 (WB:WBGene00002049)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002049> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002049/82835805-7434-4361-b22b-c3c7869c7731> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002049/106488e5-ea56-4e50-8497-3116c6e59bb8> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275541" ;
+    ns1:evidence-with "WB:WBVar00275541" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17229888" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002049/17a5bffc-be8c-4ee6-877c-97f22952f079> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00275541" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17229888" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated tail morphogenesis term." .
 
-<http://model.geneontology.org/WB_WBGene00002049/958f4c21-e153-4c73-bf83-16fc963c90e8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002049/2f651e4e-e5a8-4c1a-8030-0a0b4f0d8473> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275541" ;
+    ns1:evidence-with "WB:WBVar00275541" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17229888" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002049/a2490d36-4ae4-4204-9823-01d00aef1cd9> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275541" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17229888" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated tail morphogenesis term." .
 
-<http://model.geneontology.org/WB_WBGene00002049/b17df438-4e23-4911-b88e-2e4c5bed4d12> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002049/5ec0ee17-0a49-4344-82bf-e5e50b3fd77f> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275541" ;
+    ns1:evidence-with "WB:WBVar00275541" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17229888" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002049/1fc664b5-5348-471f-a4d7-82af8b91d05e> a GO:0010171,
+<http://model.geneontology.org/WB_WBGene00002049/30b9c57e-69b6-4847-90d1-2c9c8d26c0e9> a WB:WBGene00002049,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002049/3876b5dc-427d-41b8-8f1b-6f680d03724d> a WB:WBGene00002049,
+<http://model.geneontology.org/WB_WBGene00002049/5583c905-332f-46e1-bab5-14a2d301b093> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002049/f7280dbd-bf7a-489f-b00d-f3512e4fe580> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002049/7a5d3898-bded-4db9-8f64-b596f440fb1d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002049/7a5d3898-bded-4db9-8f64-b596f440fb1d> a GO:0010171,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002049/81b4386a-a851-413f-8662-1d1fdfface67> a GO:0000768,
+<http://model.geneontology.org/WB_WBGene00002049/a5debcac-af7d-403d-a5f3-05ec694686e4> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002049/30b9c57e-69b6-4847-90d1-2c9c8d26c0e9> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002049/e77422a6-7571-4c67-b9b0-a7aa801a2f8c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002049/e77422a6-7571-4c67-b9b0-a7aa801a2f8c> a GO:0000768,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002049/a61dbcd2-8421-4610-90bf-a7544c302b2e> a WB:WBGene00002049,
+<http://model.geneontology.org/WB_WBGene00002049/f7280dbd-bf7a-489f-b00d-f3512e4fe580> a WB:WBGene00002049,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002049/bb43dad7-136f-484a-8e70-41a9dfb50d14> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002049/3876b5dc-427d-41b8-8f1b-6f680d03724d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002049/1fc664b5-5348-471f-a4d7-82af8b91d05e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002049/c289dea2-5942-4a87-bb60-839840c8e64b> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002049/a61dbcd2-8421-4610-90bf-a7544c302b2e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002049/81b4386a-a851-413f-8662-1d1fdfface67> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -130,50 +134,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002049/958f4c21-e153-4c73-bf83-16fc963c90e8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002049/106488e5-ea56-4e50-8497-3116c6e59bb8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002049  RO:0002264 GO:0000768 WB:WBPaper00029040|PMID:17229888 ECO:0000315 WB:WBVar00275541  2021-05-13 WB  id=WBOA:2761|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/c289dea2-5942-4a87-bb60-839840c8e64b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/a61dbcd2-8421-4610-90bf-a7544c302b2e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/a5debcac-af7d-403d-a5f3-05ec694686e4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/30b9c57e-69b6-4847-90d1-2c9c8d26c0e9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002049/a2490d36-4ae4-4204-9823-01d00aef1cd9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002049/17a5bffc-be8c-4ee6-877c-97f22952f079> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002049  RO:0002264 GO:0010171 WB:WBPaper00029040|PMID:17229888 ECO:0000315 WB:WBVar00275541  2021-05-13 WB  id=WBOA:2762|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Updated tail morphogenesis term.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/bb43dad7-136f-484a-8e70-41a9dfb50d14> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/1fc664b5-5348-471f-a4d7-82af8b91d05e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/5583c905-332f-46e1-bab5-14a2d301b093> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/7a5d3898-bded-4db9-8f64-b596f440fb1d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002049/b17df438-4e23-4911-b88e-2e4c5bed4d12> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002049/2f651e4e-e5a8-4c1a-8030-0a0b4f0d8473> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002049  RO:0002264 GO:0000768 WB:WBPaper00029040|PMID:17229888 ECO:0000315 WB:WBVar00275541  2021-05-13 WB  id=WBOA:2761|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/c289dea2-5942-4a87-bb60-839840c8e64b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/81b4386a-a851-413f-8662-1d1fdfface67> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002049/82835805-7434-4361-b22b-c3c7869c7731> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002049  RO:0002264 GO:0010171 WB:WBPaper00029040|PMID:17229888 ECO:0000315 WB:WBVar00275541  2021-05-13 WB  id=WBOA:2762|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Updated tail morphogenesis term.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/bb43dad7-136f-484a-8e70-41a9dfb50d14> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/3876b5dc-427d-41b8-8f1b-6f680d03724d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/5583c905-332f-46e1-bab5-14a2d301b093> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/f7280dbd-bf7a-489f-b00d-f3512e4fe580> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002049/5ec0ee17-0a49-4344-82bf-e5e50b3fd77f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002049  RO:0002264 GO:0000768 WB:WBPaper00029040|PMID:17229888 ECO:0000315 WB:WBVar00275541  2021-05-13 WB  id=WBOA:2761|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002049/a5debcac-af7d-403d-a5f3-05ec694686e4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002049/e77422a6-7571-4c67-b9b0-a7aa801a2f8c> .
 

--- a/models/WB_WBGene00002279.ttl
+++ b/models/WB_WBGene00002279.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,114 +29,120 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002279> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "let-1 (WB:WBGene00002279)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002279> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002279/087c1964-d0c5-488d-98a6-759d7209c4d3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002279/126bf716-ef4b-43f7-8109-73cc91e77c08> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089043" ;
+    ns1:evidence-with "WB:WBVar00089043" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/3a7a17fb-7853-421d-98c6-2ad53fd1ae79> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089026" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:574105" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/46dac33d-f003-4699-8ef9-471e7749bc04> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089026" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:574105" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/8ec908f2-a30c-4a53-b294-f298816b899c> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089043" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:574105" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/cd6fb42d-21cb-427b-a758-a1b9de94fb14> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089039" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:574105" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/fcf0c7fe-40f0-404f-a3a4-380e968efeed> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089039" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:574105" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/22ed0de3-70a3-4452-8bbb-857d4718260c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002279/a1f72afb-3667-447c-9f89-bc68b6a097ff> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002279/e313b089-1c97-4c73-87e9-57e498e16305> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002279/3aa39978-5531-4c03-9cf0-19d9a83ffdf7> a GO:0002119,
+<http://model.geneontology.org/WB_WBGene00002279/21dbfecb-c31e-41e8-bf8e-d473f16f5ffb> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089026" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/2b0cf71b-dd71-42cf-a601-f6e5d11e6ec5> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089043" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/55312f49-2a9b-474a-9fc1-9da7c5d55504> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089039" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/73d1cb0f-a60b-4a6d-bb6c-b6e14df01f11> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089026" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/9de9123b-f5c2-482a-97cf-d97e38cfe707> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089039" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/5fd4d209-b01f-4ca7-b65e-06afd76067bf> a GO:0002119,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002279/a1f72afb-3667-447c-9f89-bc68b6a097ff> a WB:WBGene00002279,
+<http://model.geneontology.org/WB_WBGene00002279/6921eee3-e61b-471c-a19c-e10e07031427> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002279/bd47d273-69fc-433a-9f5e-f6aeab3aab09> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002279/c14c029b-9a3d-4895-acc2-dd44cfacc3bc> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/82e1d011-ba93-48e9-ace2-15bff4b9e823> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002279/8a92e169-1a94-4219-97d3-8f72699c979b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002279/5fd4d209-b01f-4ca7-b65e-06afd76067bf> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002279/8a92e169-1a94-4219-97d3-8f72699c979b> a WB:WBGene00002279,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002279/c2e869bd-a3c4-4528-8991-55c401991b82> a WB:WBGene00002279,
+<http://model.geneontology.org/WB_WBGene00002279/bd47d273-69fc-433a-9f5e-f6aeab3aab09> a WB:WBGene00002279,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002279/e313b089-1c97-4c73-87e9-57e498e16305> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00002279/c14c029b-9a3d-4895-acc2-dd44cfacc3bc> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002279/f637dcb5-3e14-4d7f-822b-73ceefd0f9e2> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002279/c2e869bd-a3c4-4528-8991-55c401991b82> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002279/3aa39978-5531-4c03-9cf0-19d9a83ffdf7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -144,54 +150,54 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002279/fcf0c7fe-40f0-404f-a3a4-380e968efeed> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002279/2b0cf71b-dd71-42cf-a601-f6e5d11e6ec5>,
+        <http://model.geneontology.org/WB_WBGene00002279/73d1cb0f-a60b-4a6d-bb6c-b6e14df01f11> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002279  RO:0002264 GO:0009792 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089039  2021-03-12 WB  id=WBOA:3029|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/22ed0de3-70a3-4452-8bbb-857d4718260c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/a1f72afb-3667-447c-9f89-bc68b6a097ff> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002279/cd6fb42d-21cb-427b-a758-a1b9de94fb14> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002279  RO:0002264 GO:0009792 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089039  2021-03-12 WB  id=WBOA:3029|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/22ed0de3-70a3-4452-8bbb-857d4718260c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/e313b089-1c97-4c73-87e9-57e498e16305> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002279/46dac33d-f003-4699-8ef9-471e7749bc04>,
-        <http://model.geneontology.org/WB_WBGene00002279/8ec908f2-a30c-4a53-b294-f298816b899c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002279  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089026  2021-03-12 WB  id=WBOA:89554|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00002279  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089043  2021-03-12 WB  id=WBOA:3028|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/f637dcb5-3e14-4d7f-822b-73ceefd0f9e2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/3aa39978-5531-4c03-9cf0-19d9a83ffdf7> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/82e1d011-ba93-48e9-ace2-15bff4b9e823> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/5fd4d209-b01f-4ca7-b65e-06afd76067bf> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002279/087c1964-d0c5-488d-98a6-759d7209c4d3>,
-        <http://model.geneontology.org/WB_WBGene00002279/3a7a17fb-7853-421d-98c6-2ad53fd1ae79> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002279/9de9123b-f5c2-482a-97cf-d97e38cfe707> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002279  RO:0002264 GO:0009792 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089039  2021-03-12 WB  id=WBOA:3029|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/6921eee3-e61b-471c-a19c-e10e07031427> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/c14c029b-9a3d-4895-acc2-dd44cfacc3bc> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002279/55312f49-2a9b-474a-9fc1-9da7c5d55504> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002279  RO:0002264 GO:0009792 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089039  2021-03-12 WB  id=WBOA:3029|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/6921eee3-e61b-471c-a19c-e10e07031427> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/bd47d273-69fc-433a-9f5e-f6aeab3aab09> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002279/126bf716-ef4b-43f7-8109-73cc91e77c08>,
+        <http://model.geneontology.org/WB_WBGene00002279/21dbfecb-c31e-41e8-bf8e-d473f16f5ffb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002279  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089026  2021-03-12 WB  id=WBOA:89554|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00002279  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089043  2021-03-12 WB  id=WBOA:3028|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/f637dcb5-3e14-4d7f-822b-73ceefd0f9e2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/c2e869bd-a3c4-4528-8991-55c401991b82> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002279/82e1d011-ba93-48e9-ace2-15bff4b9e823> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002279/8a92e169-1a94-4219-97d3-8f72699c979b> .
 

--- a/models/WB_WBGene00002281.ttl
+++ b/models/WB_WBGene00002281.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002281> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "let-3 (WB:WBGene00002281)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002281> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002281/a1d07194-2716-4838-84cb-ae2e035ae1d9> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002281/1484dc05-ef3d-4669-b599-8525d1b35e23> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089028" ;
+    ns1:evidence-with "WB:WBVar00089028" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002281/e46fa0db-8779-4e1b-a62b-58e4b1ff05cd> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002281/789958e3-00b7-400f-95b5-c274de653b9f> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089028" ;
+    ns1:evidence-with "WB:WBVar00089028" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002281/5aca73da-fc81-4edc-89d9-64a3291f7a14> a GO:0002119,
+<http://model.geneontology.org/WB_WBGene00002281/18cc1bfb-52ad-4de4-9c22-c25611c19d82> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002281/dea8ca79-06e1-4bc1-adcb-af61710c5d6e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002281/cdcb35f4-dfba-4680-87f8-03277e2299e9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002281/a81c1e9e-02c9-44f5-b0fc-c3682b18fc82> a WB:WBGene00002281,
+<http://model.geneontology.org/WB_WBGene00002281/cdcb35f4-dfba-4680-87f8-03277e2299e9> a GO:0002119,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002281/e10b7457-1a4d-4889-8494-9f08a51cdac6> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002281/dea8ca79-06e1-4bc1-adcb-af61710c5d6e> a WB:WBGene00002281,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002281/a81c1e9e-02c9-44f5-b0fc-c3682b18fc82> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002281/5aca73da-fc81-4edc-89d9-64a3291f7a14> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002281/a1d07194-2716-4838-84cb-ae2e035ae1d9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002281/789958e3-00b7-400f-95b5-c274de653b9f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002281  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089028  2021-03-12 WB  id=WBOA:3033|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002281/e10b7457-1a4d-4889-8494-9f08a51cdac6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002281/a81c1e9e-02c9-44f5-b0fc-c3682b18fc82> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002281/18cc1bfb-52ad-4de4-9c22-c25611c19d82> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002281/dea8ca79-06e1-4bc1-adcb-af61710c5d6e> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002281/e46fa0db-8779-4e1b-a62b-58e4b1ff05cd> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002281/1484dc05-ef3d-4669-b599-8525d1b35e23> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002281  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089028  2021-03-12 WB  id=WBOA:3033|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002281/e10b7457-1a4d-4889-8494-9f08a51cdac6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002281/5aca73da-fc81-4edc-89d9-64a3291f7a14> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002281/18cc1bfb-52ad-4de4-9c22-c25611c19d82> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002281/cdcb35f4-dfba-4680-87f8-03277e2299e9> .
 

--- a/models/WB_WBGene00002283.ttl
+++ b/models/WB_WBGene00002283.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002283> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "let-5 (WB:WBGene00002283)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002283> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002283/17f5b70a-9232-41b7-97ec-89ba0630d54f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002283/66c39263-55e4-4741-972a-adfb910bdd8b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089030" ;
+    ns1:evidence-with "WB:WBVar00089030" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002283/f8641925-d608-4dd3-924c-b7350f44886a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002283/81ac2f22-b09b-4ba0-b099-9683d471baa8> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089030" ;
+    ns1:evidence-with "WB:WBVar00089030" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002283/a144cdb7-4469-4bbc-8b09-8cbb0af54c7d> a WB:WBGene00002283,
+<http://model.geneontology.org/WB_WBGene00002283/4aeb0ced-43cb-43d4-8186-d06f11a2a650> a GO:0002119,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002283/c4b8fb0b-8883-4cfb-8b92-bb428f06581c> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002283/b79a985c-5a0f-44cb-85ec-3e8208809b93> a WB:WBGene00002283,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002283/a144cdb7-4469-4bbc-8b09-8cbb0af54c7d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002283/e79da38b-2878-465d-961e-34801a89e2da> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002283/e79da38b-2878-465d-961e-34801a89e2da> a GO:0002119,
+<http://model.geneontology.org/WB_WBGene00002283/f51e01df-0586-4a80-aa1b-fa5d11f47f47> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002283/b79a985c-5a0f-44cb-85ec-3e8208809b93> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002283/4aeb0ced-43cb-43d4-8186-d06f11a2a650> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002283/17f5b70a-9232-41b7-97ec-89ba0630d54f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002283/66c39263-55e4-4741-972a-adfb910bdd8b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002283  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089030  2021-03-12 WB  id=WBOA:3035|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002283/c4b8fb0b-8883-4cfb-8b92-bb428f06581c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002283/e79da38b-2878-465d-961e-34801a89e2da> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002283/f8641925-d608-4dd3-924c-b7350f44886a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002283  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089030  2021-03-12 WB  id=WBOA:3035|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002283/c4b8fb0b-8883-4cfb-8b92-bb428f06581c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002283/a144cdb7-4469-4bbc-8b09-8cbb0af54c7d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002283/f51e01df-0586-4a80-aa1b-fa5d11f47f47> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002283/b79a985c-5a0f-44cb-85ec-3e8208809b93> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002283/81ac2f22-b09b-4ba0-b099-9683d471baa8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002283  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089030  2021-03-12 WB  id=WBOA:3035|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002283/f51e01df-0586-4a80-aa1b-fa5d11f47f47> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002283/4aeb0ced-43cb-43d4-8186-d06f11a2a650> .
 

--- a/models/WB_WBGene00002284.ttl
+++ b/models/WB_WBGene00002284.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002284> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "let-6 (WB:WBGene00002284)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002284> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002284/397ab9fc-ee39-4627-ad5b-97732a65d992> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002284/5e135a2d-dcdb-4a09-8cc4-bbcbac3854f3> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089034" ;
+    ns1:evidence-with "WB:WBVar00089034" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002284/4a956d21-a808-479e-ab82-ec10cca08107> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002284/ada8d9cc-28ef-494f-a4b9-af7a8616a848> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089032" ;
+    ns1:evidence-with "WB:WBVar00089032" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002284/806a754b-7034-47f5-bc69-85b977f8019e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002284/c1a821ad-c67e-4557-9693-72fb37e08532> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089032" ;
+    ns1:evidence-with "WB:WBVar00089034" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002284/d6da3c2b-e82c-4d02-87bc-62311c4cfac5> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002284/df48b174-8fe3-4232-b48d-7d0323b9d463> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089034" ;
+    ns1:evidence-with "WB:WBVar00089032" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:574105" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002284/0ff7f928-9999-46b7-b691-618489b5d45e> a WB:WBGene00002284,
+<http://model.geneontology.org/WB_WBGene00002284/6b2a815f-6420-4e86-ba73-b0b5cb453824> a GO:0002119,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002284/aa4fe489-5907-41a7-ae36-2fb76fa72436> a GO:0002119,
+<http://model.geneontology.org/WB_WBGene00002284/c33956e0-216e-4e75-a6e4-5766eb1f6a4f> a WB:WBGene00002284,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002284/bb449596-f785-493f-bb9f-eeb2e81b6859> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002284/f668787b-dd42-446c-81f3-1fd35bc869de> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002284/0ff7f928-9999-46b7-b691-618489b5d45e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002284/aa4fe489-5907-41a7-ae36-2fb76fa72436> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002284/c33956e0-216e-4e75-a6e4-5766eb1f6a4f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002284/6b2a815f-6420-4e86-ba73-b0b5cb453824> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002284/4a956d21-a808-479e-ab82-ec10cca08107>,
-        <http://model.geneontology.org/WB_WBGene00002284/d6da3c2b-e82c-4d02-87bc-62311c4cfac5> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002284/5e135a2d-dcdb-4a09-8cc4-bbcbac3854f3>,
+        <http://model.geneontology.org/WB_WBGene00002284/ada8d9cc-28ef-494f-a4b9-af7a8616a848> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002284  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089032  2021-03-12 WB  id=WBOA:89555|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00002284  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089034  2021-03-12 WB  id=WBOA:3036|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002284/bb449596-f785-493f-bb9f-eeb2e81b6859> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002284/aa4fe489-5907-41a7-ae36-2fb76fa72436> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002284/f668787b-dd42-446c-81f3-1fd35bc869de> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002284/6b2a815f-6420-4e86-ba73-b0b5cb453824> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002284/397ab9fc-ee39-4627-ad5b-97732a65d992>,
-        <http://model.geneontology.org/WB_WBGene00002284/806a754b-7034-47f5-bc69-85b977f8019e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002284/c1a821ad-c67e-4557-9693-72fb37e08532>,
+        <http://model.geneontology.org/WB_WBGene00002284/df48b174-8fe3-4232-b48d-7d0323b9d463> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002284  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089032  2021-03-12 WB  id=WBOA:89555|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00002284  RO:0002264 GO:0002119 WB:WBPaper00000241|PMID:574105 ECO:0000315 WB:WBVar00089034  2021-03-12 WB  id=WBOA:3036|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002284/bb449596-f785-493f-bb9f-eeb2e81b6859> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002284/0ff7f928-9999-46b7-b691-618489b5d45e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002284/f668787b-dd42-446c-81f3-1fd35bc869de> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002284/c33956e0-216e-4e75-a6e4-5766eb1f6a4f> .
 

--- a/models/WB_WBGene00002285.ttl
+++ b/models/WB_WBGene00002285.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,444 +29,470 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002285> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "let-7 (WB:WBGene00002285)" ;
     dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002285> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002285/01093fcb-ecad-4989-b2d3-5736361e831f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/047fa977-0481-4bca-acf1-13f2a2f56dd8> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-03" ;
     dc:source "PMID:14729570" ;
+    dct:created "2006-02-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/05aedce3-ee54-4108-9429-038029c88e51> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/0ae97a20-b01c-47dd-82e1-adbc81377008> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088922" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10706289" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/244ec7be-bfca-42cc-a88c-64fa9a0098ba> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/0f451ec4-8442-493d-915b-6b67a5399ca2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088922" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10706289" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/2873a113-24ce-4d76-86dc-18bb5cff3140> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dc:source "PMID:15766527" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/51e30b5b-6053-4ad7-a26c-50bde9086ef7> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-03" ;
     dc:source "PMID:14729570" ;
+    dct:created "2006-02-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/55df2a88-eaac-4568-a320-d52140525ca9> a ECO:0000353,
+<http://model.geneontology.org/WB_WBGene00002285/2a74a96c-6116-4ee6-9886-39cd0350b8f9> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006924" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:14508492" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/6eb246cc-1bf7-48fd-bf77-f25d4f06f862> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002335" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dc:source "PMID:15766527" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/77e57d69-8fd7-40e4-963f-8a010ce07b6a> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002335" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dc:source "PMID:15766527" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/7a9dbcbe-8dc2-475c-8dfc-dd5b1102a9a0> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00089036" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10706289" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/81026b80-4d34-468e-8511-aed80288b2e2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/35cf62aa-481f-4883-8320-97a6f19e4604> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: daf-12 and lin-41" .
-
-<http://model.geneontology.org/WB_WBGene00002285/87672c0d-3615-47c6-862c-9748fc2ec49d> a ECO:0000353,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006626" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:14508492" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/8df3c7d9-5a50-49d2-a857-3e396c6a65f9> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dc:source "PMID:15766527" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/96254d6c-5e8e-4fd0-b5ca-0fbf5a25b486> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-04-06" ;
     dc:source "PMID:17199042" ;
+    dct:created "2007-04-06" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/9f5fc3b6-499c-481a-b594-532a7bca5b3b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/4a7c8294-11fe-429e-bca3-190a2d362a29> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: daf-12 and lin-41" .
-
-<http://model.geneontology.org/WB_WBGene00002285/a0f046b5-8c7f-4e2b-96a3-2abce5a6b53a> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003312" ;
+    ns1:evidence-with "WB:WBGene00003312" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dc:source "PMID:17065234" ;
+    dct:created "2007-12-04" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/a6b376d4-8df9-42d1-9bbe-5a3d0b43a782> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/61bc9d11-a52e-4ec6-ba92-d7475ba2aba7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10706289" ;
-    ns2:providedBy "http://www.wormbase.org" .
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: daf-12 and lin-41" .
 
-<http://model.geneontology.org/WB_WBGene00002285/a6d4001c-ea4d-4444-b6ab-ced2f1ab728c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/6ac5fc56-9d67-46fa-a66b-4017c732a7f0> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089036" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:10706289" ;
-    ns2:providedBy "http://www.wormbase.org" .
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: daf-12 and lin-41" .
 
-<http://model.geneontology.org/WB_WBGene00002285/a9afd6ff-6429-4970-9659-d901af464675> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/6df88d89-4276-4aac-8644-b3477064273c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dc:source "PMID:14729570" ;
+    dc:date "2007-04-06" ;
+    dc:source "PMID:17199042" ;
+    dct:created "2007-04-06" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/b3eafeed-2932-4bd9-a1be-a2c9504c8bf8> a ECO:0000353,
+<http://model.geneontology.org/WB_WBGene00002285/7a3c1044-8ec8-4ef1-88fd-582926f5e5c8> a ECO:0000353,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000105,WB:WBGene00000106" ;
+    ns1:evidence-with "WB:WBGene00000105,WB:WBGene00000106" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15024405" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/d29b5626-f268-47f9-9ade-c84368f73db3> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00002285/7dbbd4a1-1861-4854-8b58-326453d9dfe2> a GO:0003730,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003312" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dc:source "PMID:17065234" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/d4d44780-c120-4e5a-9777-dcaaf8e3f085> a GO:0003730,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/a362efc4-cd68-441b-bdbc-bd23f4bbec54> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/0bcf2506-9913-4ce6-8448-9d25ed45949e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-03" ;
     dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/d7bd8908-830d-4ac5-8120-0a1a968927bf> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002285/7f24e9c5-fc2b-43ff-b100-8d2258c02914> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: daf-12 and lin-41" .
-
-<http://model.geneontology.org/WB_WBGene00002285/e6e7f9c9-84bf-43d2-8491-38f456a6d920> a ECO:0000353,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003026" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-21" ;
-    dc:source "PMID:14729570" ;
+    dc:date "2007-12-04" ;
+    dc:source "PMID:15766527" ;
+    dct:created "2007-12-04" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/ea0f7311-2011-48d1-b70e-92d3ea4a26f7> a ECO:0000353,
+<http://model.geneontology.org/WB_WBGene00002285/7f8558bd-102c-478d-8978-ac80654a2ba0> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003026" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-21" ;
-    dc:source "PMID:14729570" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/ead87548-bf7e-4f26-8446-f77f45307b47> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: daf-12 and lin-41" .
-
-<http://model.geneontology.org/WB_WBGene00002285/efb14f63-57cc-401b-a8b5-34fb7b1417be> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090602" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-04-06" ;
-    dc:source "PMID:17199042" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/f983fd5d-bb1b-4e9c-bf18-9a014f04d6f2> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089036" ;
+    ns1:evidence-with "WB:WBVar00090602" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:10706289" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/fbf23705-8657-4d29-bdd6-5b66fea4d100> a WB:WBGene00002285,
+<http://model.geneontology.org/WB_WBGene00002285/8bec0c44-8102-46a9-bd5d-59919406200e> a WB:WBGene00002285,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/73894b75-542c-4eb2-acb3-7a23a9ffe19e> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/dfcba44d-f1d5-4f0a-a26f-5109a29a967b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/92454a69-dbdd-40b7-8c8f-d93c17c08d8b> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00089036" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10706289" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/acadc06b-2699-49e9-98ae-6296a9e63ae6> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090602" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: daf-12 and lin-41" .
+
+<http://model.geneontology.org/WB_WBGene00002285/b07895e7-b791-4346-88a3-bbfc985d870e> a ECO:0000353,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003026" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-21" ;
+    dc:source "PMID:14729570" ;
+    dct:created "2020-04-21" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/be9e4235-ed7f-4cd8-969c-7e3a349fb5d2> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090602" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dc:source "PMID:14729570" ;
+    dct:created "2006-02-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/c06aa6d2-1157-460d-8997-f408f666ffb6> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003312" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dc:source "PMID:17065234" ;
+    dct:created "2007-12-04" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/c67acf6b-c100-41dc-85c1-8cf3f21cab9e> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090602" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: daf-12 and lin-41" .
+
+<http://model.geneontology.org/WB_WBGene00002285/da264c7f-4122-4446-9186-bcf061128efb> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00002335" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dc:source "PMID:15766527" ;
+    dct:created "2007-12-04" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/db0e8af0-a251-4f49-a8d0-5f1ba53ebf9c> a ECO:0000353,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003026" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-21" ;
+    dc:source "PMID:14729570" ;
+    dct:created "2020-04-21" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/e11a1596-0c96-4e01-b464-49967b720c10> a ECO:0000353,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00006924" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:14508492" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/f071e287-4897-47c8-9ef5-2e88ce2fb982> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00002335" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dc:source "PMID:15766527" ;
+    dct:created "2007-12-04" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/f6062272-e146-40b3-8935-a4e4f68a2645> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088922" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10706289" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/f6495d2e-02a6-4a18-9eee-bc175ee4e9ab> a ECO:0000353,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00006626" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:14508492" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/fb61839b-8d7e-43e6-a4cd-d3ed8c880262> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088922" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:10706289" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/fdd3d6aa-fd21-4ed1-97a3-979287d22202> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090602" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dc:source "PMID:15766527" ;
+    dct:created "2007-12-04" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002233 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002285/1b304ef8-e1e1-4d1c-a9b1-bb67f835774b> a WB:WBGene00002285,
+<http://model.geneontology.org/WB_WBGene00002285/04bdc3d2-81c0-4192-a165-f3f5542a0013> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/d87769ba-0213-4687-9a6a-1ab226f82b94> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/7a01ac49-4b2d-4019-8f88-8955a9dcfc55> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/2558779b-2599-4874-95f6-7093cb9d8d4a> a GO:0040034,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2007-04-06" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/2628c8fc-5b3a-4167-91f3-6ad5e1c3b185> a WB:WBGene00002285,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2007-04-06" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/27070c47-cea2-4d2f-8583-fe0b09ff6b23> a WB:WBGene00003026,
+<http://model.geneontology.org/WB_WBGene00002285/055c6a53-86c8-4c04-8626-cd1257547f2b> a WB:WBGene00002285,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-21" ;
     dct:created "2020-04-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/2c1c298c-3152-4296-a663-0cb250b8c990> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002285/0bcf2506-9913-4ce6-8448-9d25ed45949e> a WB:WBGene00002285,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/ddc09d50-394e-47e5-b7d5-fc1ff4ee155f> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/1b304ef8-e1e1-4d1c-a9b1-bb67f835774b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/2d386572-a60a-4408-b770-dce7a5ecebf7> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/e90bb1ac-d70a-4af6-a642-5bdd5feaea11> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/3d3f4780-a49b-4d7d-b550-6fdca7d8388b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/2c33e810-1169-4db7-a9d3-08bff76963f3> a WB:WBGene00002285,
+<http://model.geneontology.org/WB_WBGene00002285/35e9a071-bf63-4fc1-af67-f0aad137414c> a GO:0018996,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dct:created "2007-12-04" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/3beee8b1-5b01-4369-986b-0ffb3c4779cd> a GO:0000956,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-07-15" ;
     dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/4ad78e1a-2837-45a4-b5cb-ef10c7cd2783> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002285/3d3f4780-a49b-4d7d-b550-6fdca7d8388b> a WB:WBGene00002285,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/5ac68262-41ae-41eb-86da-c75a679a53f3> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/79c5dc18-4e55-4847-bc41-abf39a7ec3c7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/553e6dd7-5bca-425a-b0e9-af0f343cfc4a> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002285/3e3ff795-ad1c-4f96-8dc3-25ee5ecca9dc> a WB:WBGene00003026,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/2558779b-2599-4874-95f6-7093cb9d8d4a> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/2628c8fc-5b3a-4167-91f3-6ad5e1c3b185> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-21" ;
+    dct:created "2020-04-21" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/5b14ea54-216b-448e-94f4-bbddfdef49cf> a WB:WBGene00002285,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/5f9eb961-3fa9-4e56-bd28-bd11a922369d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/8ca7a6e4-93ef-4292-870f-02e46949daaa> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/5b14ea54-216b-448e-94f4-bbddfdef49cf> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/6871955a-0803-4b9a-9752-75e71df49241> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/3beee8b1-5b01-4369-986b-0ffb3c4779cd> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/8342524c-5dac-4bb4-b4ae-aeffb209e65a> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/6a0bb1d6-49d8-4a11-a9f0-e32137eccca1> a GO:0040034,
+        owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2007-04-06" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/5ac68262-41ae-41eb-86da-c75a679a53f3> a GO:0018996,
+<http://model.geneontology.org/WB_WBGene00002285/7a01ac49-4b2d-4019-8f88-8955a9dcfc55> a WB:WBGene00002285,
         owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/8342524c-5dac-4bb4-b4ae-aeffb209e65a> a WB:WBGene00002285,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/8360a616-9a99-41b1-8b88-9ad05258258c> a WB:WBGene00002285,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2007-04-06" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/8ca7a6e4-93ef-4292-870f-02e46949daaa> a GO:0035195,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/b1414c76-2feb-44a1-9641-f1f554545328> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/35e9a071-bf63-4fc1-af67-f0aad137414c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/fe7ce533-6db7-44e2-8c76-30baa0bf4124> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/73894b75-542c-4eb2-acb3-7a23a9ffe19e> a GO:0016442,
+<http://model.geneontology.org/WB_WBGene00002285/b7ada4f1-d958-464f-a6bb-4cec4f30b40b> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/6a0bb1d6-49d8-4a11-a9f0-e32137eccca1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/8360a616-9a99-41b1-8b88-9ad05258258c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2007-04-06" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/d87769ba-0213-4687-9a6a-1ab226f82b94> a GO:0045947,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002285/dfcba44d-f1d5-4f0a-a26f-5109a29a967b> a GO:0016442,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/74b830a3-0efb-4104-aaa9-3e5f9af58fa2> a WB:WBGene00002285,
+<http://model.geneontology.org/WB_WBGene00002285/e1340cc1-7819-4998-a73f-88404e50189a> a GO:0003730,
         owl:NamedIndividual ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00002285/3e3ff795-ad1c-4f96-8dc3-25ee5ecca9dc> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/055c6a53-86c8-4c04-8626-cd1257547f2b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-21" ;
     dct:created "2020-04-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/79c5dc18-4e55-4847-bc41-abf39a7ec3c7> a WB:WBGene00002285,
+<http://model.geneontology.org/WB_WBGene00002285/e90bb1ac-d70a-4af6-a642-5bdd5feaea11> a GO:0046580,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002285/7c622bdd-7f3f-49f3-bfa5-55b36f12a9d5> a WB:WBGene00002285,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/8d453bee-7e03-4952-9141-4be4dbe3116c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/b9390f51-ffd6-4728-9483-2914150506b5> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/2c33e810-1169-4db7-a9d3-08bff76963f3> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/95608b6f-6fcb-4e42-b761-fd8e4b0cbe29> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/f097a480-c891-4bbb-904e-4b08f64704ba> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/b0844d0b-5520-4201-8572-6376758cb3b5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/a362efc4-cd68-441b-bdbc-bd23f4bbec54> a WB:WBGene00002285,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/b0844d0b-5520-4201-8572-6376758cb3b5> a WB:WBGene00002285,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/b9390f51-ffd6-4728-9483-2914150506b5> a GO:0045947,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/cefc52ec-0edd-449a-a83e-a295f227a8df> a GO:0003730,
-        owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00002285/27070c47-cea2-4d2f-8583-fe0b09ff6b23> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/74b830a3-0efb-4104-aaa9-3e5f9af58fa2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-21" ;
-    dct:created "2020-04-21" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/ddc09d50-394e-47e5-b7d5-fc1ff4ee155f> a GO:0046580,
+<http://model.geneontology.org/WB_WBGene00002285/fe7ce533-6db7-44e2-8c76-30baa0bf4124> a WB:WBGene00002285,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/ddcdd24c-6f5c-4449-b754-41f987d3259a> a GO:0000956,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/f097a480-c891-4bbb-904e-4b08f64704ba> a GO:0035195,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002285/f3db5668-b588-46d3-a30e-d36105ff119a> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002285/ddcdd24c-6f5c-4449-b754-41f987d3259a> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002285/7c622bdd-7f3f-49f3-bfa5-55b36f12a9d5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -474,214 +500,214 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/d29b5626-f268-47f9-9ade-c84368f73db3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/f071e287-4897-47c8-9ef5-2e88ce2fb982>,
+        <http://model.geneontology.org/WB_WBGene00002285/fdd3d6aa-fd21-4ed1-97a3-979287d22202> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-12-04" ;
     dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00003312  2007-12-04 WB  id=WBOA:3040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/4ad78e1a-2837-45a4-b5cb-ef10c7cd2783> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/5ac68262-41ae-41eb-86da-c75a679a53f3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/01093fcb-ecad-4989-b2d3-5736361e831f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002327 GO:0003730 WB:WBPaper00006376|PMID:14729570 ECO:0000315 WB:WBVar00090602  2006-02-03 WB  id=WBOA:3046|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T12:26|modification-date=2006-02-03T12:26" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000315 WB:WBVar00090602  2007-12-04 WB  id=WBOA:3042|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04",
+        "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2007-12-04 WB  id=WBOA:3043|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/d4d44780-c120-4e5a-9777-dcaaf8e3f085> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/a362efc4-cd68-441b-bdbc-bd23f4bbec54> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/2d386572-a60a-4408-b770-dce7a5ecebf7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/3d3f4780-a49b-4d7d-b550-6fdca7d8388b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/d7bd8908-830d-4ac5-8120-0a1a968927bf> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/c67acf6b-c100-41dc-85c1-8cf3f21cab9e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-07-15" ;
     dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0000956 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00090602  2009-07-15 WB  id=WBOA:8471|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: daf-12 and lin-41|creation-date=2009-07-15|modification-date=2009-07-15" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/f3db5668-b588-46d3-a30e-d36105ff119a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/7c622bdd-7f3f-49f3-bfa5-55b36f12a9d5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/6871955a-0803-4b9a-9752-75e71df49241> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/8342524c-5dac-4bb4-b4ae-aeffb209e65a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/a9afd6ff-6429-4970-9659-d901af464675> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0035195 WB:WBPaper00006376|PMID:14729570 ECO:0000315 WB:WBVar00090602  2006-02-03 WB  id=WBOA:3037|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T12:26|modification-date=2006-02-03T12:26" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/95608b6f-6fcb-4e42-b761-fd8e4b0cbe29> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/f097a480-c891-4bbb-904e-4b08f64704ba> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/e6e7f9c9-84bf-43d2-8491-38f456a6d920> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-21" ;
-    dct:created "2020-04-21" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002327 GO:0003730 WB:WBPaper00006376|PMID:14729570 ECO:0000353 WB:WBGene00003026  2020-04-21 WB  id=WBOA:3044|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-21|modification-date=2020-04-21" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/cefc52ec-0edd-449a-a83e-a295f227a8df> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/74b830a3-0efb-4104-aaa9-3e5f9af58fa2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/05aedce3-ee54-4108-9429-038029c88e51>,
-        <http://model.geneontology.org/WB_WBGene00002285/7a9dbcbe-8dc2-475c-8dfc-dd5b1102a9a0>,
-        <http://model.geneontology.org/WB_WBGene00002285/96254d6c-5e8e-4fd0-b5ca-0fbf5a25b486>,
-        <http://model.geneontology.org/WB_WBGene00002285/f983fd5d-bb1b-4e9c-bf18-9a014f04d6f2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2007-04-06" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00088922  2021-03-12 WB  id=WBOA:89557|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00089036  2021-03-12 WB  id=WBOA:89556|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00090602  2021-03-12 WB  id=WBOA:3041|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00028966|PMID:17199042 ECO:0000315 WB:WBVar00090602  2007-04-06 WB  id=WBOA:3038|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-04-06|modification-date=2007-04-06" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/553e6dd7-5bca-425a-b0e9-af0f343cfc4a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/2558779b-2599-4874-95f6-7093cb9d8d4a> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/244ec7be-bfca-42cc-a88c-64fa9a0098ba>,
-        <http://model.geneontology.org/WB_WBGene00002285/a6b376d4-8df9-42d1-9bbe-5a3d0b43a782>,
-        <http://model.geneontology.org/WB_WBGene00002285/a6d4001c-ea4d-4444-b6ab-ced2f1ab728c>,
-        <http://model.geneontology.org/WB_WBGene00002285/efb14f63-57cc-401b-a8b5-34fb7b1417be> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2007-04-06" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00088922  2021-03-12 WB  id=WBOA:89557|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00089036  2021-03-12 WB  id=WBOA:89556|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00090602  2021-03-12 WB  id=WBOA:3041|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00028966|PMID:17199042 ECO:0000315 WB:WBVar00090602  2007-04-06 WB  id=WBOA:3038|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-04-06|modification-date=2007-04-06" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/553e6dd7-5bca-425a-b0e9-af0f343cfc4a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/2628c8fc-5b3a-4167-91f3-6ad5e1c3b185> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/ea0f7311-2011-48d1-b70e-92d3ea4a26f7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-21" ;
-    dct:created "2020-04-21" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002327 GO:0003730 WB:WBPaper00006376|PMID:14729570 ECO:0000353 WB:WBGene00003026  2020-04-21 WB  id=WBOA:3044|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-21|modification-date=2020-04-21" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/cefc52ec-0edd-449a-a83e-a295f227a8df> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/27070c47-cea2-4d2f-8583-fe0b09ff6b23> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/2873a113-24ce-4d76-86dc-18bb5cff3140>,
-        <http://model.geneontology.org/WB_WBGene00002285/77e57d69-8fd7-40e4-963f-8a010ce07b6a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000315 WB:WBVar00090602  2007-12-04 WB  id=WBOA:3042|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04",
-        "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2007-12-04 WB  id=WBOA:3043|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/2c1c298c-3152-4296-a663-0cb250b8c990> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/1b304ef8-e1e1-4d1c-a9b1-bb67f835774b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/51e30b5b-6053-4ad7-a26c-50bde9086ef7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0035195 WB:WBPaper00006376|PMID:14729570 ECO:0000315 WB:WBVar00090602  2006-02-03 WB  id=WBOA:3037|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T12:26|modification-date=2006-02-03T12:26" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/95608b6f-6fcb-4e42-b761-fd8e4b0cbe29> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/b0844d0b-5520-4201-8572-6376758cb3b5> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/6eb246cc-1bf7-48fd-bf77-f25d4f06f862>,
-        <http://model.geneontology.org/WB_WBGene00002285/8df3c7d9-5a50-49d2-a857-3e396c6a65f9> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000315 WB:WBVar00090602  2007-12-04 WB  id=WBOA:3042|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04",
-        "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2007-12-04 WB  id=WBOA:3043|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/2c1c298c-3152-4296-a663-0cb250b8c990> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/ddc09d50-394e-47e5-b7d5-fc1ff4ee155f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/81026b80-4d34-468e-8511-aed80288b2e2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0045947 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00090602  2009-07-15 WB  id=WBOA:8470|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: daf-12 and lin-41|creation-date=2009-07-15|modification-date=2009-07-15" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/8d453bee-7e03-4952-9141-4be4dbe3116c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/2c33e810-1169-4db7-a9d3-08bff76963f3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/a0f046b5-8c7f-4e2b-96a3-2abce5a6b53a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-12-04" ;
-    dct:created "2007-12-04" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00003312  2007-12-04 WB  id=WBOA:3040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/4ad78e1a-2837-45a4-b5cb-ef10c7cd2783> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/79c5dc18-4e55-4847-bc41-abf39a7ec3c7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/55df2a88-eaac-4568-a320-d52140525ca9>,
-        <http://model.geneontology.org/WB_WBGene00002285/87672c0d-3615-47c6-862c-9748fc2ec49d>,
-        <http://model.geneontology.org/WB_WBGene00002285/b3eafeed-2932-4bd9-a1be-a2c9504c8bf8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/7a3c1044-8ec8-4ef1-88fd-582926f5e5c8>,
+        <http://model.geneontology.org/WB_WBGene00002285/e11a1596-0c96-4e01-b464-49967b720c10>,
+        <http://model.geneontology.org/WB_WBGene00002285/f6495d2e-02a6-4a18-9eee-bc175ee4e9ab> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002285  BFO:0000050 GO:0016442 WB:WBPaper00006077|PMID:14508492 ECO:0000353 WB:WBGene00006626  2020-05-13 WB  id=WBOA:14259|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13",
         "WB:WBGene00002285  BFO:0000050 GO:0016442 WB:WBPaper00006077|PMID:14508492 ECO:0000353 WB:WBGene00006924  2020-05-13 WB  id=WBOA:14258|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13",
         "WB:WBGene00002285  BFO:0000050 GO:0016442 WB:WBPaper00013395|PMID:15024405 ECO:0000353 WB:WBGene00000105,WB:WBGene00000106  2020-05-13 WB  id=WBOA:13755|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/fbf23705-8657-4d29-bdd6-5b66fea4d100> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/73894b75-542c-4eb2-acb3-7a23a9ffe19e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/8bec0c44-8102-46a9-bd5d-59919406200e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/dfcba44d-f1d5-4f0a-a26f-5109a29a967b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/ead87548-bf7e-4f26-8446-f77f45307b47> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/c06aa6d2-1157-460d-8997-f408f666ffb6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2007-12-04" ;
+    dct:created "2007-12-04" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0000956 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00090602  2009-07-15 WB  id=WBOA:8471|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: daf-12 and lin-41|creation-date=2009-07-15|modification-date=2009-07-15" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/f3db5668-b588-46d3-a30e-d36105ff119a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/ddcdd24c-6f5c-4449-b754-41f987d3259a> .
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00003312  2007-12-04 WB  id=WBOA:3040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/b1414c76-2feb-44a1-9641-f1f554545328> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/fe7ce533-6db7-44e2-8c76-30baa0bf4124> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002285/9f5fc3b6-499c-481a-b594-532a7bca5b3b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/7f24e9c5-fc2b-43ff-b100-8d2258c02914>,
+        <http://model.geneontology.org/WB_WBGene00002285/da264c7f-4122-4446-9186-bcf061128efb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dct:created "2007-12-04" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000315 WB:WBVar00090602  2007-12-04 WB  id=WBOA:3042|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04",
+        "WB:WBGene00002285  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2007-12-04 WB  id=WBOA:3043|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/2d386572-a60a-4408-b770-dce7a5ecebf7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/e90bb1ac-d70a-4af6-a642-5bdd5feaea11> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/0f451ec4-8442-493d-915b-6b67a5399ca2> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0035195 WB:WBPaper00006376|PMID:14729570 ECO:0000315 WB:WBVar00090602  2006-02-03 WB  id=WBOA:3037|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T12:26|modification-date=2006-02-03T12:26" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/5f9eb961-3fa9-4e56-bd28-bd11a922369d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/8ca7a6e4-93ef-4292-870f-02e46949daaa> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/be9e4235-ed7f-4cd8-969c-7e3a349fb5d2> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002327 GO:0003730 WB:WBPaper00006376|PMID:14729570 ECO:0000315 WB:WBVar00090602  2006-02-03 WB  id=WBOA:3046|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T12:26|modification-date=2006-02-03T12:26" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/7dbbd4a1-1861-4854-8b58-326453d9dfe2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/0bcf2506-9913-4ce6-8448-9d25ed45949e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/047fa977-0481-4bca-acf1-13f2a2f56dd8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0035195 WB:WBPaper00006376|PMID:14729570 ECO:0000315 WB:WBVar00090602  2006-02-03 WB  id=WBOA:3037|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T12:26|modification-date=2006-02-03T12:26" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/5f9eb961-3fa9-4e56-bd28-bd11a922369d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/5b14ea54-216b-448e-94f4-bbddfdef49cf> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/b07895e7-b791-4346-88a3-bbfc985d870e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-21" ;
+    dct:created "2020-04-21" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002327 GO:0003730 WB:WBPaper00006376|PMID:14729570 ECO:0000353 WB:WBGene00003026  2020-04-21 WB  id=WBOA:3044|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-21|modification-date=2020-04-21" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/e1340cc1-7819-4998-a73f-88404e50189a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/3e3ff795-ad1c-4f96-8dc3-25ee5ecca9dc> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/acadc06b-2699-49e9-98ae-6296a9e63ae6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-07-15" ;
     dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0045947 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00090602  2009-07-15 WB  id=WBOA:8470|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: daf-12 and lin-41|creation-date=2009-07-15|modification-date=2009-07-15" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/04bdc3d2-81c0-4192-a165-f3f5542a0013> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/7a01ac49-4b2d-4019-8f88-8955a9dcfc55> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/6df88d89-4276-4aac-8644-b3477064273c>,
+        <http://model.geneontology.org/WB_WBGene00002285/7f8558bd-102c-478d-8978-ac80654a2ba0>,
+        <http://model.geneontology.org/WB_WBGene00002285/92454a69-dbdd-40b7-8c8f-d93c17c08d8b>,
+        <http://model.geneontology.org/WB_WBGene00002285/fb61839b-8d7e-43e6-a4cd-d3ed8c880262> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2007-04-06" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00088922  2021-03-12 WB  id=WBOA:89557|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00089036  2021-03-12 WB  id=WBOA:89556|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00090602  2021-03-12 WB  id=WBOA:3041|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00028966|PMID:17199042 ECO:0000315 WB:WBVar00090602  2007-04-06 WB  id=WBOA:3038|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-04-06|modification-date=2007-04-06" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/b7ada4f1-d958-464f-a6bb-4cec4f30b40b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/8360a616-9a99-41b1-8b88-9ad05258258c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/6ac5fc56-9d67-46fa-a66b-4017c732a7f0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0045947 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00090602  2009-07-15 WB  id=WBOA:8470|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: daf-12 and lin-41|creation-date=2009-07-15|modification-date=2009-07-15" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/8d453bee-7e03-4952-9141-4be4dbe3116c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/b9390f51-ffd6-4728-9483-2914150506b5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/04bdc3d2-81c0-4192-a165-f3f5542a0013> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/d87769ba-0213-4687-9a6a-1ab226f82b94> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/db0e8af0-a251-4f49-a8d0-5f1ba53ebf9c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-21" ;
+    dct:created "2020-04-21" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002327 GO:0003730 WB:WBPaper00006376|PMID:14729570 ECO:0000353 WB:WBGene00003026  2020-04-21 WB  id=WBOA:3044|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-21|modification-date=2020-04-21" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/e1340cc1-7819-4998-a73f-88404e50189a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/055c6a53-86c8-4c04-8626-cd1257547f2b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/4a7c8294-11fe-429e-bca3-190a2d362a29> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-12-04" ;
+    dct:created "2007-12-04" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00003312  2007-12-04 WB  id=WBOA:3040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-12-04|modification-date=2007-12-04" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/b1414c76-2feb-44a1-9641-f1f554545328> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/35e9a071-bf63-4fc1-af67-f0aad137414c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/61bc9d11-a52e-4ec6-ba92-d7475ba2aba7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0000956 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00090602  2009-07-15 WB  id=WBOA:8471|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: daf-12 and lin-41|creation-date=2009-07-15|modification-date=2009-07-15" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/6871955a-0803-4b9a-9752-75e71df49241> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/3beee8b1-5b01-4369-986b-0ffb3c4779cd> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002285/0ae97a20-b01c-47dd-82e1-adbc81377008>,
+        <http://model.geneontology.org/WB_WBGene00002285/2a74a96c-6116-4ee6-9886-39cd0350b8f9>,
+        <http://model.geneontology.org/WB_WBGene00002285/35cf62aa-481f-4883-8320-97a6f19e4604>,
+        <http://model.geneontology.org/WB_WBGene00002285/f6062272-e146-40b3-8935-a4e4f68a2645> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2007-04-06" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00088922  2021-03-12 WB  id=WBOA:89557|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00089036  2021-03-12 WB  id=WBOA:89556|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00003929|PMID:10706289 ECO:0000315 WB:WBVar00090602  2021-03-12 WB  id=WBOA:3041|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002285  RO:0002331 GO:0040034 WB:WBPaper00028966|PMID:17199042 ECO:0000315 WB:WBVar00090602  2007-04-06 WB  id=WBOA:3038|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-04-06|modification-date=2007-04-06" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002285/b7ada4f1-d958-464f-a6bb-4cec4f30b40b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002285/6a0bb1d6-49d8-4a11-a9f0-e32137eccca1> .
 

--- a/models/WB_WBGene00002466.ttl
+++ b/models/WB_WBGene00002466.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002466> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "let-237 (WB:WBGene00002466)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002466> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002466/472f50c7-ce8f-4002-8bc1-d2cf69b36ef8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002466/21ca3330-1a91-40b5-a97d-dc488fbf8db5> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000384" ;
+    ns1:evidence-with "WB:WBVar00000384" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002466/7c0333a6-610c-49e2-82b6-60bab77f1570> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002466/807b6760-d2eb-4d1f-993c-09172525b1f4> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000384" ;
+    ns1:evidence-with "WB:WBVar00000384" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002466/2d369175-35ba-4b94-be60-2bea5e14ff0a> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00002466/0c1485fe-4c95-408d-969a-88d4ae162f27> a WB:WBGene00002466,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002466/95d2b9ad-bb8e-4a49-b7d5-0b8776c9b34f> a WB:WBGene00002466,
+<http://model.geneontology.org/WB_WBGene00002466/31e7036d-db41-46bd-8035-928810ae596f> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002466/0c1485fe-4c95-408d-969a-88d4ae162f27> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002466/8e534991-63a8-44e5-a9c4-6243b9437fdc> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002466/dbf7bb81-4577-4a62-b1a4-55bdc435e672> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002466/8e534991-63a8-44e5-a9c4-6243b9437fdc> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002466/95d2b9ad-bb8e-4a49-b7d5-0b8776c9b34f> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002466/2d369175-35ba-4b94-be60-2bea5e14ff0a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002466/472f50c7-ce8f-4002-8bc1-d2cf69b36ef8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002466/807b6760-d2eb-4d1f-993c-09172525b1f4> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002466  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000384  2021-05-13 WB  id=WBOA:3088|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002466/dbf7bb81-4577-4a62-b1a4-55bdc435e672> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002466/2d369175-35ba-4b94-be60-2bea5e14ff0a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002466/31e7036d-db41-46bd-8035-928810ae596f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002466/8e534991-63a8-44e5-a9c4-6243b9437fdc> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002466/7c0333a6-610c-49e2-82b6-60bab77f1570> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002466/21ca3330-1a91-40b5-a97d-dc488fbf8db5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002466  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000384  2021-05-13 WB  id=WBOA:3088|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002466/dbf7bb81-4577-4a62-b1a4-55bdc435e672> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002466/95d2b9ad-bb8e-4a49-b7d5-0b8776c9b34f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002466/31e7036d-db41-46bd-8035-928810ae596f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002466/0c1485fe-4c95-408d-969a-88d4ae162f27> .
 

--- a/models/WB_WBGene00002572.ttl
+++ b/models/WB_WBGene00002572.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002572> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "let-350 (WB:WBGene00002572)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002572> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002572/06f7526c-6b5c-48a4-87b4-2040114537f6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002572/1287fd6e-65d5-4b64-9b5d-d79229a2d575> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:1752418" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002572/8dcf45c4-2951-49db-8563-7d9b49eb3d88> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002572/159b3a6e-2679-491b-b240-afe5bed7d6b8> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:1752418" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002572/4570f388-ffb6-41da-834d-b3a876c27882> a GO:0000003,
+<http://model.geneontology.org/WB_WBGene00002572/5b3c0034-29d1-4173-ab87-2c7fe6063008> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002572/a1ac07ad-b74b-4b26-b709-eac90236ec91> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002572/7c2f6ded-4a58-4937-bf9b-097db8bcc5da> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002572/bf07f824-545d-4802-8591-e0510a7aa358> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002572/7c2f6ded-4a58-4937-bf9b-097db8bcc5da> a GO:0000003,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002572/bfc9dea3-2e7d-4cdf-99ee-c4f3a03c862f> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00002572/4570f388-ffb6-41da-834d-b3a876c27882> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002572/bfc9dea3-2e7d-4cdf-99ee-c4f3a03c862f> a WB:WBGene00002572,
+<http://model.geneontology.org/WB_WBGene00002572/a1ac07ad-b74b-4b26-b709-eac90236ec91> a WB:WBGene00002572,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002572/8dcf45c4-2951-49db-8563-7d9b49eb3d88> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002572/1287fd6e-65d5-4b64-9b5d-d79229a2d575> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002572  RO:0002264 GO:0000003 WB:WBPaper00001474|PMID:1752418 ECO:0000315   2021-05-13 WB  id=WBOA:3089|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002572/bf07f824-545d-4802-8591-e0510a7aa358> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002572/bfc9dea3-2e7d-4cdf-99ee-c4f3a03c862f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002572/5b3c0034-29d1-4173-ab87-2c7fe6063008> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002572/a1ac07ad-b74b-4b26-b709-eac90236ec91> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002572/06f7526c-6b5c-48a4-87b4-2040114537f6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002572/159b3a6e-2679-491b-b240-afe5bed7d6b8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002572  RO:0002264 GO:0000003 WB:WBPaper00001474|PMID:1752418 ECO:0000315   2021-05-13 WB  id=WBOA:3089|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002572/bf07f824-545d-4802-8591-e0510a7aa358> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002572/4570f388-ffb6-41da-834d-b3a876c27882> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002572/5b3c0034-29d1-4173-ab87-2c7fe6063008> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002572/7c2f6ded-4a58-4937-bf9b-097db8bcc5da> .
 

--- a/models/WB_WBGene00002993.ttl
+++ b/models/WB_WBGene00002993.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,624 +29,655 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00002993> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "lin-4 (WB:WBGene00002993)" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00002993> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00002993/039d28af-c256-4c55-bbc4-3aadefcdefda> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002993/0407dc11-2bbb-4363-a43d-36cef7b4f0e4> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBGene00003003" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dc:source "PMID:8187641" ;
+    dct:created "2006-02-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/094d644f-ab1b-4bb8-bedb-580eddf8e878> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dc:source "PMID:12871707" ;
+    dct:created "2012-08-28" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Updated heterochronic term. 2012-08-28" .
+
+<http://model.geneontology.org/WB_WBGene00002993/0d444907-5a04-485e-9023-dd86671f19bb> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/11091371-ed80-4173-a172-d875c8149c17> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002993/108b6d71-bf61-4f4a-ba6f-73298a563e9e> a ECO:0000353,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBGene00003003" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2008-08-18" ;
+    dc:source "PMID:8957004" ;
+    dct:created "2008-08-18" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/199b671d-9396-4294-b0b3-3b9bfbe5696e> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/22e5c704-2e04-43f4-8dfd-f0b2b2617c34> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088774" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:8957004" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/2397cb19-c0e3-42a6-ab01-b3a9335d8765> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/25d314a2-6729-4c9f-9eab-6a0408ced50b> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: lin-14 and lin-28" .
+
+<http://model.geneontology.org/WB_WBGene00002993/29dd1f6d-4d09-4953-8f6a-8711639e929e> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/2ebd9b60-09d8-4f07-b09b-8292926f2ebb> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: lin-14 and lin-28" .
+
+<http://model.geneontology.org/WB_WBGene00002993/30efec7f-546b-49f5-bc86-1cf1be3f4dcd> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dc:source "PMID:12871707" ;
+    dct:created "2012-08-28" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Updated heterochronic term. 2012-08-28" .
+
+<http://model.geneontology.org/WB_WBGene00002993/3a8ab6f8-6faf-447b-81ef-f460bdf3dd41> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: lin-14 and lin-28" .
+
+<http://model.geneontology.org/WB_WBGene00002993/3cfb359c-87ff-4591-a11f-394432ed17b9> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:8957004" ;
+    dct:created "2021-03-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/3d661989-3112-4b9f-83bc-16dd24a64dd0> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dc:source "PMID:7262539" ;
+    dct:created "2006-02-01" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/1320f285-51f7-4590-9545-8eb945c0c696> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-01" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/15307177-d82e-4a36-9652-c1912d45fbc4> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00002993/480e1ae0-2e58-4b04-96e1-f1282bd2511f> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:10642801" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/1765259f-8bb6-4769-91fe-f1874cfcd744> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00002993/4955b640-23ab-4e1e-995b-deec9246b64e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003003" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dc:source "PMID:8187641" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/1a0d72c9-c765-493e-966a-295c98ab7c7f> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/1d3b00c0-bf8f-4668-a17f-12dab140b726> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dc:source "PMID:12871707" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Updated heterochronic term. 2012-08-28" .
-
-<http://model.geneontology.org/WB_WBGene00002993/25eefeb5-3461-4332-b06a-e289d045cf01> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/2f627f8f-06ce-4c44-8e11-9e390f2398ce> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/37f98fbd-82bf-457a-9b73-c4b7601dab8c> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dc:source "PMID:12871707" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Updated heterochronic term. 2012-08-28" .
-
-<http://model.geneontology.org/WB_WBGene00002993/4acf75d6-59f8-4ed4-8d4d-596e6f88664e> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dc:source "PMID:8187641" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/4b64bc25-eb74-4b4c-b74e-de7a7f1432df> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: lin-14 and lin-28" .
-
-<http://model.geneontology.org/WB_WBGene00002993/5b648f34-15e0-4cb7-8083-c7d9374d42af> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/6cc5b3c0-5c4c-44cc-bc41-9d93fe6eaee5> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/8126dd30-9083-4c8f-96b7-76d52df7b3f1> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/8a6caabd-9d03-474c-9485-71621bcee1cb> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:8957004" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/8e31328d-916a-4a3c-9cbb-78ced30c2da3> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: lin-14 and lin-28" .
-
-<http://model.geneontology.org/WB_WBGene00002993/a87b7507-eaf1-4c3f-82fc-160d77875a8c> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088774" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:8957004" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/ab05f4ec-6076-4226-808b-1521e39b4cca> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088774" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:8957004" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/b010d79a-cdd2-40e6-8127-184f6aa58bf2> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dc:source "PMID:8957004" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/b63c92d7-3b4f-4e35-b870-64005e607166> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003003" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dc:source "PMID:8187641" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/bee2cd09-52e6-4ee3-8eb2-7d548dec585d> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dc:source "PMID:7262539" ;
+    dct:created "2006-02-01" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/c0e012c4-2aad-4e38-a58d-30c9c631ae10> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002993/4a702d23-7083-4fe6-86d9-d566501e3199> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dc:source "PMID:8187641" ;
+    dc:date "2009-07-15" ;
+    dc:source "PMID:19131968" ;
+    dct:created "2009-07-15" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "Targets: lin-14 and lin-28" .
+
+<http://model.geneontology.org/WB_WBGene00002993/58c94090-1447-4065-ae52-ad1676def82d> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:8957004" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/c28d162f-70be-47ae-a950-ba7da2259e59> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002993/5f21d29a-fead-403a-8ec1-c9308a44bd2c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/c4cb1ff1-0dca-455f-93f3-ecf610bc3dd1> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/63da915d-6e06-440b-b02a-6f2400ab046a> a ECO:0000315,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/4edf2b2e-0158-4e77-8691-44fc13288e31> ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/64417123-b2aa-431f-9a89-a4e1c73b754c> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/6f2385b7-26e8-444e-9265-93f2e5fe8706> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/ac16d3f6-db95-4ae1-b186-0635952cd776> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/ca773512-7fee-48bd-a14f-1bd014947006> a ECO:0000353,
+<http://model.geneontology.org/WB_WBGene00002993/8349e0fd-deda-4e8f-9cce-6baedff63862> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003003" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2008-08-18" ;
-    dc:source "PMID:8957004" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/cc8f0e4b-89df-4521-82ab-f713c8f8a209> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: lin-14 and lin-28" .
-
-<http://model.geneontology.org/WB_WBGene00002993/d7861bb1-5766-444c-8e6e-345d456de6cc> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dc:source "PMID:19131968" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "Targets: lin-14 and lin-28" .
-
-<http://model.geneontology.org/WB_WBGene00002993/dab41b35-2d24-48d5-902f-fa32c8495538> a ECO:0000353,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003003" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2008-08-18" ;
-    dc:source "PMID:8957004" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/e3d028c9-73fc-41d9-a788-f9c7926424ea> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/f57462af-afd6-4b6d-8a73-077d0ddadaf7> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00002993/8e6553d5-dfed-4dec-baa7-50bea09bbab7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dc:source "PMID:7262539" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/fde915d0-815d-44e9-804c-271047080db6> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143592" ;
+    ns1:evidence-with "WB:WBVar00143592" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dc:source "PMID:7262539" ;
+    dct:created "2006-02-01" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/90bf3995-83ff-4cc0-9401-0dbb9d604e71> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/aa1bd56d-019b-466d-9309-230eaf75b781> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003003" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dc:source "PMID:8187641" ;
+    dct:created "2006-02-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/af08327e-3fc1-447a-bc89-5490d7516012> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dc:source "PMID:8187641" ;
+    dct:created "2006-02-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/c7bb4457-5010-40f2-ad53-1c28bdc8edf3> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dc:source "PMID:8187641" ;
+    dct:created "2006-02-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/de0e84d7-cef8-4835-99a0-21786f56df98> a ECO:0000353,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003003" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2008-08-18" ;
+    dc:source "PMID:8957004" ;
+    dct:created "2008-08-18" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/e28070e3-b494-4fb7-91b2-7469a2f90fc0> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2005-09-02" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/e90187ba-44d6-428a-b4fb-1a59d83de903> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00143592" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-01" ;
+    dc:source "PMID:7262539" ;
+    dct:created "2006-02-01" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/fe982371-aa47-4b55-b176-0e6f95f46c5b> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088774" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dc:source "PMID:8957004" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002233 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00002993/0702c602-a1fd-474d-a502-2d7e2ffc27ee> a GO:0090444,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dct:created "2012-08-28" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/0c361b83-3d0b-4845-925d-521667f9e21f> a GO:0040026,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-01" ;
-    dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/109a8246-d9e5-4cff-98c9-448ebcf300f7> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dct:created "2012-08-28" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/14209715-c85a-4b8c-b173-b42898cabc0b> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/4b7960a0-bc7d-42e8-bc75-db3cdd9475eb> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/c32073e2-0a52-42ef-bd67-90922824bdf1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-01" ;
-    dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/17485600-fc4a-4eb0-be62-ef5e993840ae> a GO:0030182,
+<http://model.geneontology.org/WB_WBGene00002993/019e17c8-6638-4e73-afc8-cd6c9c9634b6> a WB:WBGene00002993,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/180d81d0-2606-4de4-abfc-ed24b9aed0d1> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/078226ff-75f9-415f-ad58-e0ee0b3ba3d3> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/873e4ffd-0159-4c4c-bba8-55148bc05f90> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/97b1e543-b385-4975-9533-b020a73dffc8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dct:created "2012-08-28" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/0d446bb1-f75e-430a-b633-a5a838d926cf> a WB:WBGene00002993,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/27b0010e-e30c-496c-a5cf-1a1b4d84b4b8> a GO:0045947,
+<http://model.geneontology.org/WB_WBGene00002993/22d19b34-77fb-4689-97df-843d7e3a5797> a WB:WBGene00002993,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2006-02-01" ;
+    dct:created "2006-02-01" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/28bc25d6-fcf0-42d5-9d9d-20edae7b707e> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/27c30e14-879a-47f8-a8d2-c96fcd69ab2e> a WB:WBGene00003003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2008-08-18" ;
     dct:created "2008-08-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/2e2744cc-e8f1-436a-97bb-8dccb6c911e5> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/31e279d0-2b41-4ad3-a67b-8d4df23fa836> a GO:0048666,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/30cf9bc0-5117-41ac-bcdd-8d8bc799f50f> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/3516142f-225f-4f26-b92d-4b18004836ab> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/4a14305c-3290-4797-8fa5-2d3899285982> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/abfdb2f9-e033-4f19-a4a5-ceb23074f3b3> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/a0a6fec3-5338-44eb-85ed-610f34dab6ae> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/4a1d839c-66a5-490c-b5ae-1f085c749f73> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/27b0010e-e30c-496c-a5cf-1a1b4d84b4b8> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/180d81d0-2606-4de4-abfc-ed24b9aed0d1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/4b7960a0-bc7d-42e8-bc75-db3cdd9475eb> a GO:0009791,
+<http://model.geneontology.org/WB_WBGene00002993/419cd112-6396-423c-a8e5-467591b95b12> a GO:0040026,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/4dbbc9c9-45ad-4386-876f-ad5d8ca66f71> a GO:0003730,
+<http://model.geneontology.org/WB_WBGene00002993/493fc663-b585-49e3-8230-61c5da7df7d8> a WB:WBGene00002993,
         owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00002993/fb2580fc-f53b-4177-9960-81a20ce35761> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/28bc25d6-fcf0-42d5-9d9d-20edae7b707e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/4af35afb-49e7-4660-921a-1a06019b29bc> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/419cd112-6396-423c-a8e5-467591b95b12> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/a089623f-215b-4287-b963-c810b02d366e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-01" ;
+    dct:created "2006-02-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/4e040d73-6a3d-4f2b-aafc-53a8b94cd4d9> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/4ff07982-47e7-4435-9ea1-71657c246b2f> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/9744ba1d-0778-4690-beb3-2e213a9a13f8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/4ff07982-47e7-4435-9ea1-71657c246b2f> a GO:0030182,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/5680adca-9395-4df2-8d3b-98d515feada1> a GO:0003730,
+        owl:NamedIndividual ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00002993/27c30e14-879a-47f8-a8d2-c96fcd69ab2e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/c5fb3b01-48a7-46c1-b07d-da5fb35a9c61> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2008-08-18" ;
     dct:created "2008-08-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/4edf2b2e-0158-4e77-8691-44fc13288e31> a GO:0005844,
+<http://model.geneontology.org/WB_WBGene00002993/597d08db-979e-46fa-9b6a-10e8899fd381> a GO:0010171,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/5b89bc4b-ba75-4f55-96e4-6111f552d812> a GO:0035195,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/6049f29a-8a47-4a9b-8aa3-52a6851ba581> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/b59b25ca-f92c-4b1c-897f-96e79631412a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/019e17c8-6638-4e73-afc8-cd6c9c9634b6> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/6471bca5-a7f3-4fa2-b047-a7137d200817> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/ff870228-1283-4c29-bf58-4d010045e242> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/eca2dbed-2324-4461-a5aa-9fa4fab082c9> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/6fd86908-617a-4c73-b69b-7921bd9d4baa> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/76d75476-2bb3-481c-8186-5222b1bcae01> a GO:0000956,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/873e4ffd-0159-4c4c-bba8-55148bc05f90> a GO:0090444,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dct:created "2012-08-28" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/8d88714a-7287-45e9-a6a9-ac3f4f72b189> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/dae57fb9-3749-4777-91d2-a9ad9f4fc665> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/22d19b34-77fb-4689-97df-843d7e3a5797> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-01" ;
+    dct:created "2006-02-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/9510f510-3e9c-407c-a88a-236512f9aecd> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/31e279d0-2b41-4ad3-a67b-8d4df23fa836> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/6fd86908-617a-4c73-b69b-7921bd9d4baa> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/9744ba1d-0778-4690-beb3-2e213a9a13f8> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/97b1e543-b385-4975-9533-b020a73dffc8> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dct:created "2012-08-28" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/9f605e99-2344-4e7a-b254-77b266f99cec> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/ee443221-145f-45ce-a2f7-4c57df27dc75> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/ffb033a4-db5c-4de7-b668-f8b4dfed8f1b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/a089623f-215b-4287-b963-c810b02d366e> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-01" ;
+    dct:created "2006-02-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/ac16d3f6-db95-4ae1-b186-0635952cd776> a GO:0005844,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/5365d8ae-4e34-425d-a1a7-0af30bff2ffd> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002993/b35e4f20-ef1f-4a4c-82d6-0ebb8df195a3> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/97ffc9b8-6f86-48e5-bcd7-6f254d1b01dd> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/2e2744cc-e8f1-436a-97bb-8dccb6c911e5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/53b78867-746e-452e-a20f-7961eb8ad759> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/d719f1ae-3b6b-4c1a-82cf-326fb4a54d17> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/ca6d4f0f-e149-4bfc-bbef-f52cbb1a99c3> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/6cc835f6-03c5-4417-98b3-020e0c9ee5d6> a GO:0002119,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/94db2ee6-4190-47bf-bf23-9951954b1606> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/6cc835f6-03c5-4417-98b3-020e0c9ee5d6> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/30cf9bc0-5117-41ac-bcdd-8d8bc799f50f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/97ffc9b8-6f86-48e5-bcd7-6f254d1b01dd> a GO:0007618,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/9e36b9b3-c7a4-43db-89c3-c9d1e4a82b0b> a GO:0010171,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/a0a6fec3-5338-44eb-85ed-610f34dab6ae> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/a9fa3905-e42a-45f7-ada3-42191e16c584> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/e019a6b0-5a2d-43d0-a1a2-9976c17cdb16> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/d89444eb-cc5d-4a63-9bc8-1cda96054e49> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/abfdb2f9-e033-4f19-a4a5-ceb23074f3b3> a GO:0000956,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/b4df24a4-a212-4a91-b2fb-0696363af57d> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/bb012e12-9933-4d00-b48c-6cacc3c79690> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/c9b33c91-f096-461b-8b5c-17eb0c481e05> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/5b89bc4b-ba75-4f55-96e4-6111f552d812> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/c635237b-e89d-4913-9f89-87908914fbef> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/b740ed9d-aa85-47d9-9e02-2cca8ed647e0> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/17485600-fc4a-4eb0-be62-ef5e993840ae> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/3516142f-225f-4f26-b92d-4b18004836ab> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/bb012e12-9933-4d00-b48c-6cacc3c79690> a GO:0035195,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/c32073e2-0a52-42ef-bd67-90922824bdf1> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-01" ;
-    dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/c9b33c91-f096-461b-8b5c-17eb0c481e05> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/ca3d77ec-4f6d-47f3-a0da-3ed7c4b7bfe4> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/b59b25ca-f92c-4b1c-897f-96e79631412a> a GO:0007618,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/ca6d4f0f-e149-4bfc-bbef-f52cbb1a99c3> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/b6b77ad6-dc58-4efa-af80-a8ed52a6362d> a WB:WBGene00002993,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/cf3ce961-fa02-4460-af98-9094daa41e73> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/0702c602-a1fd-474d-a502-2d7e2ffc27ee> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/109a8246-d9e5-4cff-98c9-448ebcf300f7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dct:created "2012-08-28" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/d719f1ae-3b6b-4c1a-82cf-326fb4a54d17> a GO:0018991,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/d89444eb-cc5d-4a63-9bc8-1cda96054e49> a WB:WBGene00002993,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/e019a6b0-5a2d-43d0-a1a2-9976c17cdb16> a GO:0048666,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/eb67bba4-3132-4ea3-bafb-af6593fd14f9> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/9e36b9b3-c7a4-43db-89c3-c9d1e4a82b0b> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/ca3d77ec-4f6d-47f3-a0da-3ed7c4b7bfe4> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00002993/fb2580fc-f53b-4177-9960-81a20ce35761> a WB:WBGene00003003,
+<http://model.geneontology.org/WB_WBGene00002993/c5fb3b01-48a7-46c1-b07d-da5fb35a9c61> a WB:WBGene00002993,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2008-08-18" ;
     dct:created "2008-08-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/fd5d6f64-07f0-4a31-a4d5-304b966c11f6> a WB:WBGene00002993,
+<http://model.geneontology.org/WB_WBGene00002993/c635237b-e89d-4913-9f89-87908914fbef> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/ce169ea7-6ab9-4278-b739-75ecc69f480d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/597d08db-979e-46fa-9b6a-10e8899fd381> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/b6b77ad6-dc58-4efa-af80-a8ed52a6362d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/d0548eae-3b90-4fa4-84d1-903b84914cde> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/76d75476-2bb3-481c-8186-5222b1bcae01> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/493fc663-b585-49e3-8230-61c5da7df7d8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/dae57fb9-3749-4777-91d2-a9ad9f4fc665> a GO:0009791,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00002993/ff4cc6ab-d099-48fc-8760-6b5d9e128dac> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00002993/eca2dbed-2324-4461-a5aa-9fa4fab082c9> a WB:WBGene00002993,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/0c361b83-3d0b-4845-925d-521667f9e21f> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/fd5d6f64-07f0-4a31-a4d5-304b966c11f6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-01" ;
-    dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/ee0664c6-2dcb-4f84-ba59-9d8bcf8b3eff> a GO:0018991,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/ee443221-145f-45ce-a2f7-4c57df27dc75> a GO:0002119,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/fe3dcf10-b42b-4efe-a10f-a40473830256> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00002993/ee0664c6-2dcb-4f84-ba59-9d8bcf8b3eff> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00002993/0d446bb1-f75e-430a-b633-a5a838d926cf> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/ff870228-1283-4c29-bf58-4d010045e242> a GO:0045947,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00002993/ffb033a4-db5c-4de7-b668-f8b4dfed8f1b> a WB:WBGene00002993,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -654,334 +685,334 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/8e31328d-916a-4a3c-9cbb-78ced30c2da3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/3a8ab6f8-6faf-447b-81ef-f460bdf3dd41> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-07-15" ;
     dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0045947 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00143592  2009-07-15 WB  id=WBOA:8472|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: lin-14 and lin-28|creation-date=2009-07-15|modification-date=2009-07-15" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/6471bca5-a7f3-4fa2-b047-a7137d200817> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ff870228-1283-4c29-bf58-4d010045e242> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/e90187ba-44d6-428a-b4fb-1a59d83de903> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2006-02-01" ;
+    dct:created "2006-02-01" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0009791 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2006-02-01 WB  id=WBOA:3189|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-01T13:43|modification-date=2006-02-01T13:43" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/8d88714a-7287-45e9-a6a9-ac3f4f72b189> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/22d19b34-77fb-4689-97df-843d7e3a5797> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/2ebd9b60-09d8-4f07-b09b-8292926f2ebb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0000956 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00143592  2009-07-15 WB  id=WBOA:8473|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: lin-14 and lin-28|creation-date=2009-07-15|modification-date=2009-07-15" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4a14305c-3290-4797-8fa5-2d3899285982> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/a0a6fec3-5338-44eb-85ed-610f34dab6ae> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/d0548eae-3b90-4fa4-84d1-903b84914cde> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/493fc663-b585-49e3-8230-61c5da7df7d8> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/1765259f-8bb6-4769-91fe-f1874cfcd744>,
-        <http://model.geneontology.org/WB_WBGene00002993/c0e012c4-2aad-4e38-a58d-30c9c631ae10> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-03" ;
-    dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0048666 WB:WBPaper00001829|PMID:8187641 ECO:0000315 WB:WBVar00143592  2006-02-03 WB  id=WBOA:3187|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T16:55|modification-date=2006-02-03T16:55",
-        "WB:WBGene00002993  RO:0002331 GO:0048666 WB:WBPaper00001829|PMID:8187641 ECO:0000316 WB:WBGene00003003  2006-02-03 WB  id=WBOA:3188|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T16:55|modification-date=2006-02-03T16:55" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/a9fa3905-e42a-45f7-ada3-42191e16c584> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/e019a6b0-5a2d-43d0-a1a2-9976c17cdb16> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/15307177-d82e-4a36-9652-c1912d45fbc4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/480e1ae0-2e58-4b04-96e1-f1282bd2511f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  BFO:0000050 GO:0005844 WB:WBPaper00003838|PMID:10642801 ECO:0000314   2020-05-13 WB  id=WBOA:13114|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/c4cb1ff1-0dca-455f-93f3-ecf610bc3dd1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/4edf2b2e-0158-4e77-8691-44fc13288e31> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/6f2385b7-26e8-444e-9265-93f2e5fe8706> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ac16d3f6-db95-4ae1-b186-0635952cd776> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/f57462af-afd6-4b6d-8a73-077d0ddadaf7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/5f21d29a-fead-403a-8ec1-c9308a44bd2c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0002119 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3185|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/94db2ee6-4190-47bf-bf23-9951954b1606> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/6cc835f6-03c5-4417-98b3-020e0c9ee5d6> .
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0018991 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3179|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/fe3dcf10-b42b-4efe-a10f-a40473830256> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/0d446bb1-f75e-430a-b633-a5a838d926cf> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/e3d028c9-73fc-41d9-a788-f9c7926424ea> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/90bf3995-83ff-4cc0-9401-0dbb9d604e71> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0030182 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3184|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/b740ed9d-aa85-47d9-9e02-2cca8ed647e0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/17485600-fc4a-4eb0-be62-ef5e993840ae> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/1a0d72c9-c765-493e-966a-295c98ab7c7f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0018991 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3179|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/53b78867-746e-452e-a20f-7961eb8ad759> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/d719f1ae-3b6b-4c1a-82cf-326fb4a54d17> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/fe3dcf10-b42b-4efe-a10f-a40473830256> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ee0664c6-2dcb-4f84-ba59-9d8bcf8b3eff> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/1d3b00c0-bf8f-4668-a17f-12dab140b726> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dct:created "2012-08-28" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0090444 WB:WBPaper00005971|PMID:12871707 ECO:0000315 WB:WBVar00143592  2012-08-28 WB  id=WBOA:3186|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Updated heterochronic term. 2012-08-28|creation-date=2012-08-28|modification-date=2012-08-28" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/cf3ce961-fa02-4460-af98-9094daa41e73> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/109a8246-d9e5-4cff-98c9-448ebcf300f7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/c28d162f-70be-47ae-a950-ba7da2259e59> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0010171 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3182|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/eb67bba4-3132-4ea3-bafb-af6593fd14f9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/9e36b9b3-c7a4-43db-89c3-c9d1e4a82b0b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/fde915d0-815d-44e9-804c-271047080db6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/8e6553d5-dfed-4dec-baa7-50bea09bbab7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0040026 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2006-02-01 WB  id=WBOA:3180|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-01T15:00|modification-date=2006-02-01T15:00" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/ff4cc6ab-d099-48fc-8760-6b5d9e128dac> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/fd5d6f64-07f0-4a31-a4d5-304b966c11f6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4af35afb-49e7-4660-921a-1a06019b29bc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/a089623f-215b-4287-b963-c810b02d366e> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/11091371-ed80-4173-a172-d875c8149c17> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/de0e84d7-cef8-4835-99a0-21786f56df98> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2006-02-01" ;
-    dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2008-08-18" ;
+    dct:created "2008-08-18" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0009791 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2006-02-01 WB  id=WBOA:3189|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-01T13:43|modification-date=2006-02-01T13:43" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/14209715-c85a-4b8c-b173-b42898cabc0b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/4b7960a0-bc7d-42e8-bc75-db3cdd9475eb> .
+    rdfs:comment "WB:WBGene00002993  RO:0002327 GO:0003730 WB:WBPaper00002609|PMID:8957004 ECO:0000353 WB:WBGene00003003  2008-08-18 WB  id=WBOA:7462|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2008-08-18|modification-date=2008-08-18" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/5680adca-9395-4df2-8d3b-98d515feada1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/27c30e14-879a-47f8-a8d2-c96fcd69ab2e> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/039d28af-c256-4c55-bbc4-3aadefcdefda> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0018991 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3179|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/53b78867-746e-452e-a20f-7961eb8ad759> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ca6d4f0f-e149-4bfc-bbef-f52cbb1a99c3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/2f627f8f-06ce-4c44-8e11-9e390f2398ce> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0030182 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3184|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/b740ed9d-aa85-47d9-9e02-2cca8ed647e0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/3516142f-225f-4f26-b92d-4b18004836ab> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/6cc5b3c0-5c4c-44cc-bc41-9d93fe6eaee5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0007618 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3183|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/5365d8ae-4e34-425d-a1a7-0af30bff2ffd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/2e2744cc-e8f1-436a-97bb-8dccb6c911e5> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/37f98fbd-82bf-457a-9b73-c4b7601dab8c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2012-08-28" ;
-    dct:created "2012-08-28" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0090444 WB:WBPaper00005971|PMID:12871707 ECO:0000315 WB:WBVar00143592  2012-08-28 WB  id=WBOA:3186|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Updated heterochronic term. 2012-08-28|creation-date=2012-08-28|modification-date=2012-08-28" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/cf3ce961-fa02-4460-af98-9094daa41e73> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/0702c602-a1fd-474d-a502-2d7e2ffc27ee> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/8a6caabd-9d03-474c-9485-71621bcee1cb>,
-        <http://model.geneontology.org/WB_WBGene00002993/a87b7507-eaf1-4c3f-82fc-160d77875a8c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/22e5c704-2e04-43f4-8dfd-f0b2b2617c34>,
+        <http://model.geneontology.org/WB_WBGene00002993/58c94090-1447-4065-ae52-ad1676def82d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0035195 WB:WBPaper00002609|PMID:8957004 ECO:0000315 WB:WBVar00088774  2021-03-12 WB  id=WBOA:7463|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00002993  RO:0002331 GO:0035195 WB:WBPaper00002609|PMID:8957004 ECO:0000315 WB:WBVar00143592  2021-03-12 WB  id=WBOA:89568|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/b4df24a4-a212-4a91-b2fb-0696363af57d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/c9b33c91-f096-461b-8b5c-17eb0c481e05> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/b35e4f20-ef1f-4a4c-82d6-0ebb8df195a3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/c635237b-e89d-4913-9f89-87908914fbef> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/cc8f0e4b-89df-4521-82ab-f713c8f8a209> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0045947 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00143592  2009-07-15 WB  id=WBOA:8472|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: lin-14 and lin-28|creation-date=2009-07-15|modification-date=2009-07-15" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4a1d839c-66a5-490c-b5ae-1f085c749f73> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/27b0010e-e30c-496c-a5cf-1a1b4d84b4b8> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/dab41b35-2d24-48d5-902f-fa32c8495538> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2008-08-18" ;
-    dct:created "2008-08-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002327 GO:0003730 WB:WBPaper00002609|PMID:8957004 ECO:0000353 WB:WBGene00003003  2008-08-18 WB  id=WBOA:7462|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2008-08-18|modification-date=2008-08-18" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4dbbc9c9-45ad-4386-876f-ad5d8ca66f71> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/fb2580fc-f53b-4177-9960-81a20ce35761> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/8126dd30-9083-4c8f-96b7-76d52df7b3f1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/2397cb19-c0e3-42a6-ab01-b3a9335d8765> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2005-09-02" ;
     dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0010171 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3182|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0030182 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3184|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/eb67bba4-3132-4ea3-bafb-af6593fd14f9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ca3d77ec-4f6d-47f3-a0da-3ed7c4b7bfe4> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4e040d73-6a3d-4f2b-aafc-53a8b94cd4d9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/9744ba1d-0778-4690-beb3-2e213a9a13f8> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/5b648f34-15e0-4cb7-8083-c7d9374d42af> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0002119 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3185|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/94db2ee6-4190-47bf-bf23-9951954b1606> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/30cf9bc0-5117-41ac-bcdd-8d8bc799f50f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/d7861bb1-5766-444c-8e6e-345d456de6cc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/4a702d23-7083-4fe6-86d9-d566501e3199> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-07-15" ;
     dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0000956 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00143592  2009-07-15 WB  id=WBOA:8473|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: lin-14 and lin-28|creation-date=2009-07-15|modification-date=2009-07-15" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4a14305c-3290-4797-8fa5-2d3899285982> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/abfdb2f9-e033-4f19-a4a5-ceb23074f3b3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/25eefeb5-3461-4332-b06a-e289d045cf01> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2005-09-02" ;
-    dct:created "2005-09-02" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0007618 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3183|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/5365d8ae-4e34-425d-a1a7-0af30bff2ffd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/97ffc9b8-6f86-48e5-bcd7-6f254d1b01dd> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/4b64bc25-eb74-4b4c-b74e-de7a7f1432df> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-07-15" ;
-    dct:created "2009-07-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0045947 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00143592  2009-07-15 WB  id=WBOA:8472|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: lin-14 and lin-28|creation-date=2009-07-15|modification-date=2009-07-15" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4a1d839c-66a5-490c-b5ae-1f085c749f73> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/180d81d0-2606-4de4-abfc-ed24b9aed0d1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/6471bca5-a7f3-4fa2-b047-a7137d200817> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/eca2dbed-2324-4461-a5aa-9fa4fab082c9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/bee2cd09-52e6-4ee3-8eb2-7d548dec585d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/3d661989-3112-4b9f-83bc-16dd24a64dd0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0009791 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2006-02-01 WB  id=WBOA:3189|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-01T13:43|modification-date=2006-02-01T13:43" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/14209715-c85a-4b8c-b173-b42898cabc0b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/c32073e2-0a52-42ef-bd67-90922824bdf1> .
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/8d88714a-7287-45e9-a6a9-ac3f4f72b189> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/dae57fb9-3749-4777-91d2-a9ad9f4fc665> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/ca773512-7fee-48bd-a14f-1bd014947006> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/108b6d71-bf61-4f4a-ba6f-73298a563e9e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2008-08-18" ;
     dct:created "2008-08-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002327 GO:0003730 WB:WBPaper00002609|PMID:8957004 ECO:0000353 WB:WBGene00003003  2008-08-18 WB  id=WBOA:7462|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2008-08-18|modification-date=2008-08-18" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4dbbc9c9-45ad-4386-876f-ad5d8ca66f71> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/28bc25d6-fcf0-42d5-9d9d-20edae7b707e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/5680adca-9395-4df2-8d3b-98d515feada1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/c5fb3b01-48a7-46c1-b07d-da5fb35a9c61> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/4acf75d6-59f8-4ed4-8d4d-596e6f88664e>,
-        <http://model.geneontology.org/WB_WBGene00002993/b63c92d7-3b4f-4e35-b870-64005e607166> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/29dd1f6d-4d09-4953-8f6a-8711639e929e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0002119 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3185|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/9f605e99-2344-4e7a-b254-77b266f99cec> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ee443221-145f-45ce-a2f7-4c57df27dc75> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/30efec7f-546b-49f5-bc86-1cf1be3f4dcd> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dct:created "2012-08-28" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0090444 WB:WBPaper00005971|PMID:12871707 ECO:0000315 WB:WBVar00143592  2012-08-28 WB  id=WBOA:3186|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Updated heterochronic term. 2012-08-28|creation-date=2012-08-28|modification-date=2012-08-28" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/078226ff-75f9-415f-ad58-e0ee0b3ba3d3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/97b1e543-b385-4975-9533-b020a73dffc8> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/0d444907-5a04-485e-9023-dd86671f19bb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0030182 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3184|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4e040d73-6a3d-4f2b-aafc-53a8b94cd4d9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/4ff07982-47e7-4435-9ea1-71657c246b2f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/3cfb359c-87ff-4591-a11f-394432ed17b9>,
+        <http://model.geneontology.org/WB_WBGene00002993/fe982371-aa47-4b55-b176-0e6f95f46c5b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0035195 WB:WBPaper00002609|PMID:8957004 ECO:0000315 WB:WBVar00088774  2021-03-12 WB  id=WBOA:7463|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00002993  RO:0002331 GO:0035195 WB:WBPaper00002609|PMID:8957004 ECO:0000315 WB:WBVar00143592  2021-03-12 WB  id=WBOA:89568|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/b35e4f20-ef1f-4a4c-82d6-0ebb8df195a3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/5b89bc4b-ba75-4f55-96e4-6111f552d812> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/aa1bd56d-019b-466d-9309-230eaf75b781>,
+        <http://model.geneontology.org/WB_WBGene00002993/af08327e-3fc1-447a-bc89-5490d7516012> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-03" ;
     dct:created "2006-02-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0048666 WB:WBPaper00001829|PMID:8187641 ECO:0000315 WB:WBVar00143592  2006-02-03 WB  id=WBOA:3187|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T16:55|modification-date=2006-02-03T16:55",
         "WB:WBGene00002993  RO:0002331 GO:0048666 WB:WBPaper00001829|PMID:8187641 ECO:0000316 WB:WBGene00003003  2006-02-03 WB  id=WBOA:3188|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T16:55|modification-date=2006-02-03T16:55" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/a9fa3905-e42a-45f7-ada3-42191e16c584> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/d89444eb-cc5d-4a63-9bc8-1cda96054e49> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/9510f510-3e9c-407c-a88a-236512f9aecd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/6fd86908-617a-4c73-b69b-7921bd9d4baa> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/ab05f4ec-6076-4226-808b-1521e39b4cca>,
-        <http://model.geneontology.org/WB_WBGene00002993/b010d79a-cdd2-40e6-8127-184f6aa58bf2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/0407dc11-2bbb-4363-a43d-36cef7b4f0e4>,
+        <http://model.geneontology.org/WB_WBGene00002993/c7bb4457-5010-40f2-ad53-1c28bdc8edf3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2006-02-03" ;
+    dct:created "2006-02-03" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0035195 WB:WBPaper00002609|PMID:8957004 ECO:0000315 WB:WBVar00088774  2021-03-12 WB  id=WBOA:7463|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00002993  RO:0002331 GO:0035195 WB:WBPaper00002609|PMID:8957004 ECO:0000315 WB:WBVar00143592  2021-03-12 WB  id=WBOA:89568|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0048666 WB:WBPaper00001829|PMID:8187641 ECO:0000315 WB:WBVar00143592  2006-02-03 WB  id=WBOA:3187|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T16:55|modification-date=2006-02-03T16:55",
+        "WB:WBGene00002993  RO:0002331 GO:0048666 WB:WBPaper00001829|PMID:8187641 ECO:0000316 WB:WBGene00003003  2006-02-03 WB  id=WBOA:3188|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-03T16:55|modification-date=2006-02-03T16:55" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/b4df24a4-a212-4a91-b2fb-0696363af57d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/bb012e12-9933-4d00-b48c-6cacc3c79690> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/9510f510-3e9c-407c-a88a-236512f9aecd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/31e279d0-2b41-4ad3-a67b-8d4df23fa836> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00002993/1320f285-51f7-4590-9545-8eb945c0c696> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/8349e0fd-deda-4e8f-9cce-6baedff63862> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0010171 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3182|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/ce169ea7-6ab9-4278-b739-75ecc69f480d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/597d08db-979e-46fa-9b6a-10e8899fd381> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/4955b640-23ab-4e1e-995b-deec9246b64e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2006-02-01" ;
     dct:created "2006-02-01" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0040026 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2006-02-01 WB  id=WBOA:3180|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2006-02-01T15:00|modification-date=2006-02-01T15:00" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/ff4cc6ab-d099-48fc-8760-6b5d9e128dac> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/0c361b83-3d0b-4845-925d-521667f9e21f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/4af35afb-49e7-4660-921a-1a06019b29bc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/419cd112-6396-423c-a8e5-467591b95b12> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/094d644f-ab1b-4bb8-bedb-580eddf8e878> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2012-08-28" ;
+    dct:created "2012-08-28" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0090444 WB:WBPaper00005971|PMID:12871707 ECO:0000315 WB:WBVar00143592  2012-08-28 WB  id=WBOA:3186|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Updated heterochronic term. 2012-08-28|creation-date=2012-08-28|modification-date=2012-08-28" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/078226ff-75f9-415f-ad58-e0ee0b3ba3d3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/873e4ffd-0159-4c4c-bba8-55148bc05f90> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/e28070e3-b494-4fb7-91b2-7469a2f90fc0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0007618 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3183|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/6049f29a-8a47-4a9b-8aa3-52a6851ba581> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/019e17c8-6638-4e73-afc8-cd6c9c9634b6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/63da915d-6e06-440b-b02a-6f2400ab046a> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0010171 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3182|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/ce169ea7-6ab9-4278-b739-75ecc69f480d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/b6b77ad6-dc58-4efa-af80-a8ed52a6362d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/64417123-b2aa-431f-9a89-a4e1c73b754c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0007618 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3183|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/6049f29a-8a47-4a9b-8aa3-52a6851ba581> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/b59b25ca-f92c-4b1c-897f-96e79631412a> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/25d314a2-6729-4c9f-9eab-6a0408ced50b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-07-15" ;
+    dct:created "2009-07-15" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0000956 WB:WBPaper00032489|PMID:19131968 ECO:0000315 WB:WBVar00143592  2009-07-15 WB  id=WBOA:8473|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Targets: lin-14 and lin-28|creation-date=2009-07-15|modification-date=2009-07-15" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/d0548eae-3b90-4fa4-84d1-903b84914cde> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/76d75476-2bb3-481c-8186-5222b1bcae01> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00002993/199b671d-9396-4294-b0b3-3b9bfbe5696e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2005-09-02" ;
+    dct:created "2005-09-02" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00002993  RO:0002331 GO:0002119 WB:WBPaper00000496|PMID:7262539 ECO:0000315 WB:WBVar00143592  2005-09-02 WB  id=WBOA:3185|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2005-09-02T16:37|modification-date=2005-09-02T16:37" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00002993/9f605e99-2344-4e7a-b254-77b266f99cec> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00002993/ffb033a4-db5c-4de7-b668-f8b4dfed8f1b> .
 

--- a/models/WB_WBGene00003039.ttl
+++ b/models/WB_WBGene00003039.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,114 +29,120 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003039> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:title "mir-48 (WB:WBGene00003039)" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003039> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003039/1ad1d32b-d370-4c18-92e0-ac4a31a77acd> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003039/170de6dd-6381-4f41-94bb-a4b4e9ddb75e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003312,WB:WBGene00003335" ;
+    ns1:evidence-with "WB:WBGene00003312,WB:WBGene00003335" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/69c2dd35-10ed-40bd-be5d-95fc29aba896> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090787" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/771d73ba-4b7d-47cc-b9bf-f5c10d1ea505> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003312,WB:WBGene00003335" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/9dd56166-c60f-4102-9d08-61ef17e87920> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090787" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/b5c3e68e-7174-47a3-b910-5a0b1ee2faa3> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003312" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/c11d76a4-0c49-4780-b190-d86d79d865ef> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003312" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/1d382550-856a-43a2-bb1b-0470ef70f613> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003039/26e9a662-236d-428e-ae60-80ab88232589> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003039/763d7365-28ab-4993-a56e-b72769b35a91> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003039/26e9a662-236d-428e-ae60-80ab88232589> a GO:0035278,
+<http://model.geneontology.org/WB_WBGene00003039/60fe203c-c6cf-406a-b9e2-f3a8c0865b12> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090787" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/6f21443c-2508-4e91-b752-d8011084a459> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003312" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/7b920e1d-c0e8-4ea3-9a0c-2594cba44e1b> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090787" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/b6e355f8-8fe5-4fd5-b4f5-c4aa7338af1a> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003312,WB:WBGene00003335" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/e0419164-e420-402c-8197-d53f9030050b> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003312" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/388e47e4-e86f-481a-a5ca-0f1f3e5787bc> a WB:WBGene00003039,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003039/71fd840a-01f0-4503-aad6-2e18e8be1e92> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003039/470359d5-39dd-4cd7-bf68-a7da204f4714> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003039/a06b0f40-87c3-41f7-b2bd-9298542bfc0b> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003039/c3d76c43-22d7-4c1e-af3a-36c95f5dc95d> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003039/50d62cbf-22d8-4929-bfab-4ac0ff6af31c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003039/388e47e4-e86f-481a-a5ca-0f1f3e5787bc> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003039/763d7365-28ab-4993-a56e-b72769b35a91> a WB:WBGene00003039,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003039/a06b0f40-87c3-41f7-b2bd-9298542bfc0b> a GO:0045962,
+<http://model.geneontology.org/WB_WBGene00003039/50d62cbf-22d8-4929-bfab-4ac0ff6af31c> a GO:0045962,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003039/c3d76c43-22d7-4c1e-af3a-36c95f5dc95d> a WB:WBGene00003039,
+<http://model.geneontology.org/WB_WBGene00003039/a8f7a613-861e-4172-9127-76ade80f67d6> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003039/e458527b-6175-495e-9ff5-4d6c603a57cc> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003039/b8f41cad-45a7-474f-95eb-bc9bb357f497> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/b8f41cad-45a7-474f-95eb-bc9bb357f497> a WB:WBGene00003039,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003039/e458527b-6175-495e-9ff5-4d6c603a57cc> a GO:0035278,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -144,54 +150,54 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003039/9dd56166-c60f-4102-9d08-61ef17e87920>,
-        <http://model.geneontology.org/WB_WBGene00003039/c11d76a4-0c49-4780-b190-d86d79d865ef> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003039/6f21443c-2508-4e91-b752-d8011084a459>,
+        <http://model.geneontology.org/WB_WBGene00003039/7b920e1d-c0e8-4ea3-9a0c-2594cba44e1b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003039  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000315 WB:WBVar00090787  2010-03-17 WB  id=WBOA:9443|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17",
         "WB:WBGene00003039  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003312  2010-03-17 WB  id=WBOA:9444|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/71fd840a-01f0-4503-aad6-2e18e8be1e92> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/c3d76c43-22d7-4c1e-af3a-36c95f5dc95d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/470359d5-39dd-4cd7-bf68-a7da204f4714> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/388e47e4-e86f-481a-a5ca-0f1f3e5787bc> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003039/69c2dd35-10ed-40bd-be5d-95fc29aba896>,
-        <http://model.geneontology.org/WB_WBGene00003039/b5c3e68e-7174-47a3-b910-5a0b1ee2faa3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003039/170de6dd-6381-4f41-94bb-a4b4e9ddb75e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003039  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003312,WB:WBGene00003335  2010-03-17 WB  id=WBOA:9450|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/a8f7a613-861e-4172-9127-76ade80f67d6> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/e458527b-6175-495e-9ff5-4d6c603a57cc> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003039/60fe203c-c6cf-406a-b9e2-f3a8c0865b12>,
+        <http://model.geneontology.org/WB_WBGene00003039/e0419164-e420-402c-8197-d53f9030050b> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003039  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000315 WB:WBVar00090787  2010-03-17 WB  id=WBOA:9443|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17",
         "WB:WBGene00003039  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003312  2010-03-17 WB  id=WBOA:9444|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/71fd840a-01f0-4503-aad6-2e18e8be1e92> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/a06b0f40-87c3-41f7-b2bd-9298542bfc0b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/470359d5-39dd-4cd7-bf68-a7da204f4714> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/50d62cbf-22d8-4929-bfab-4ac0ff6af31c> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003039/1ad1d32b-d370-4c18-92e0-ac4a31a77acd> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003039/b6e355f8-8fe5-4fd5-b4f5-c4aa7338af1a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003039  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003312,WB:WBGene00003335  2010-03-17 WB  id=WBOA:9450|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/1d382550-856a-43a2-bb1b-0470ef70f613> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/763d7365-28ab-4993-a56e-b72769b35a91> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003039/771d73ba-4b7d-47cc-b9bf-f5c10d1ea505> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003039  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003312,WB:WBGene00003335  2010-03-17 WB  id=WBOA:9450|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/1d382550-856a-43a2-bb1b-0470ef70f613> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/26e9a662-236d-428e-ae60-80ab88232589> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003039/a8f7a613-861e-4172-9127-76ade80f67d6> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003039/b8f41cad-45a7-474f-95eb-bc9bb357f497> .
 

--- a/models/WB_WBGene00003069.ttl
+++ b/models/WB_WBGene00003069.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,112 +29,118 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003069> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "lrn-1 (WB:WBGene00003069)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003069> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003069/349a41e1-4d5b-4aec-a696-c031599530bc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003069/17b01d17-a721-4f50-b044-326cd7340e8d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088997" ;
+    ns1:evidence-with "WB:WBVar00088997" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/63d988ec-09f3-4f73-87b1-1ee1b771287f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003069/61110d59-5f83-494b-9b69-8758e460b6ef> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088997" ;
+    ns1:evidence-with "WB:WBVar00088997" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/cbe3949c-a04e-4113-83b4-4571e1ba47f1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003069/6a73432e-e8ea-41ab-a94d-a437b477e5b0> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088997" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003069/8cde19bc-6797-40a8-929f-f37e93ddc435> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11439453" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/d1107565-0819-4df2-a252-fcec51d04815> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088997" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9106675" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003069/d3b6effd-0fc4-4b9a-894e-d70d171fd989> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003069/9670fe13-3f28-40f6-be3a-c8bebaee5f4b> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11439453" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/ecad95da-ee0d-4a50-9611-1d5b4bef401e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003069/bb9902b9-a469-42ca-9f33-1ac0d6f4c0e2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088997" ;
+    ns1:evidence-with "WB:WBVar00088997" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9106675" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003069/2cb422e9-20d9-48b4-8568-032ff132c956> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003069/f3051b1a-5765-45e4-b2c6-1d8dd2270f8c> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003069/a8c41537-2037-4752-b04a-6aacd7da0dba> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/46341385-54f4-4372-bc7a-3756aebe18c2> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003069/aa16fdbe-a3c9-44a7-8275-0434984bfad3> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003069/e0df89e6-70a4-453e-a9c5-55d9562bcadb> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003069/a8c41537-2037-4752-b04a-6aacd7da0dba> a GO:0008306,
+<http://model.geneontology.org/WB_WBGene00003069/0a127938-0c41-4884-9a78-b825bb2d772c> a WB:WBGene00003069,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/aa16fdbe-a3c9-44a7-8275-0434984bfad3> a WB:WBGene00003069,
+<http://model.geneontology.org/WB_WBGene00003069/290ddde5-1de0-490b-a2fe-8b95ab443193> a GO:0008306,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/e0df89e6-70a4-453e-a9c5-55d9562bcadb> a GO:0001661,
+<http://model.geneontology.org/WB_WBGene00003069/466fe1a9-501c-449b-8f71-3ea701975ab4> a WB:WBGene00003069,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003069/f3051b1a-5765-45e4-b2c6-1d8dd2270f8c> a WB:WBGene00003069,
+<http://model.geneontology.org/WB_WBGene00003069/57f52357-03f2-47c1-8b89-e620eb705ea3> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003069/0a127938-0c41-4884-9a78-b825bb2d772c> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003069/290ddde5-1de0-490b-a2fe-8b95ab443193> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003069/bf5b6498-5939-4f33-bbb5-d3bb825f4efc> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003069/466fe1a9-501c-449b-8f71-3ea701975ab4> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003069/d642bf6d-4ed8-478f-8f67-f12d207f7913> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003069/d642bf6d-4ed8-478f-8f67-f12d207f7913> a GO:0001661,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -142,54 +148,54 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003069/349a41e1-4d5b-4aec-a696-c031599530bc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003069/9670fe13-3f28-40f6-be3a-c8bebaee5f4b>,
+        <http://model.geneontology.org/WB_WBGene00003069/bb9902b9-a469-42ca-9f33-1ac0d6f4c0e2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003069  RO:0002264 GO:0001661 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088997  2021-05-13 WB  id=WBOA:3547|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/46341385-54f4-4372-bc7a-3756aebe18c2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/aa16fdbe-a3c9-44a7-8275-0434984bfad3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003069/cbe3949c-a04e-4113-83b4-4571e1ba47f1>,
-        <http://model.geneontology.org/WB_WBGene00003069/ecad95da-ee0d-4a50-9611-1d5b4bef401e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003069  RO:0002264 GO:0008306 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088997  2021-05-13 WB  id=WBOA:3546|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00003069  RO:0002264 GO:0008306 WB:WBPaper00004861|PMID:11439453 ECO:0000315   2021-05-13 WB  id=WBOA:51799|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/2cb422e9-20d9-48b4-8568-032ff132c956> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/a8c41537-2037-4752-b04a-6aacd7da0dba> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/57f52357-03f2-47c1-8b89-e620eb705ea3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/290ddde5-1de0-490b-a2fe-8b95ab443193> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003069/63d988ec-09f3-4f73-87b1-1ee1b771287f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003069/17b01d17-a721-4f50-b044-326cd7340e8d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003069  RO:0002264 GO:0001661 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088997  2021-05-13 WB  id=WBOA:3547|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/bf5b6498-5939-4f33-bbb5-d3bb825f4efc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/466fe1a9-501c-449b-8f71-3ea701975ab4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003069/6a73432e-e8ea-41ab-a94d-a437b477e5b0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003069  RO:0002264 GO:0001661 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088997  2021-05-13 WB  id=WBOA:3547|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/46341385-54f4-4372-bc7a-3756aebe18c2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/e0df89e6-70a4-453e-a9c5-55d9562bcadb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/bf5b6498-5939-4f33-bbb5-d3bb825f4efc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/d642bf6d-4ed8-478f-8f67-f12d207f7913> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003069/d1107565-0819-4df2-a252-fcec51d04815>,
-        <http://model.geneontology.org/WB_WBGene00003069/d3b6effd-0fc4-4b9a-894e-d70d171fd989> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003069/61110d59-5f83-494b-9b69-8758e460b6ef>,
+        <http://model.geneontology.org/WB_WBGene00003069/8cde19bc-6797-40a8-929f-f37e93ddc435> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003069  RO:0002264 GO:0008306 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088997  2021-05-13 WB  id=WBOA:3546|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00003069  RO:0002264 GO:0008306 WB:WBPaper00004861|PMID:11439453 ECO:0000315   2021-05-13 WB  id=WBOA:51799|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/2cb422e9-20d9-48b4-8568-032ff132c956> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/f3051b1a-5765-45e4-b2c6-1d8dd2270f8c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003069/57f52357-03f2-47c1-8b89-e620eb705ea3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003069/0a127938-0c41-4884-9a78-b825bb2d772c> .
 

--- a/models/WB_WBGene00003070.ttl
+++ b/models/WB_WBGene00003070.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,112 +29,118 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003070> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "lrn-2 (WB:WBGene00003070)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003070> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003070/214e4583-ee77-43ab-abab-e9999bed00b1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003070/0f0d92ab-38ee-4632-9b4c-be64679e32ef> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088998" ;
+    ns1:evidence-with "WB:WBVar00088998" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/276800c9-ed74-473b-aeda-b366b64b5b83> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003070/48305af6-fe4a-459c-8032-a09180753826> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11439453" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/6722ac94-fac2-4435-8886-efa00e5b7bde> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003070/5b48c457-5bb2-4017-8081-e446203f5276> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088998" ;
+    ns1:evidence-with "WB:WBVar00088998" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/8844a84e-8237-4ecf-9055-2364620ad45c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003070/7e8626f6-34a1-4188-b8ba-a0c849a1473d> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088998" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003070/b02a933b-4cb6-4bdd-b60f-42a69dd6c3c8> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00088998" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9106675" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003070/ed56932a-2644-4239-8030-586b71cd0354> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:11439453" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/b99e723f-b40c-4020-8788-f0f71a3dc380> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088998" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9106675" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003070/f8f86064-d9f2-4517-898a-9e8a5a704b4c> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088998" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9106675" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003070/176ff9ad-5d6d-4f71-97f8-24e1e002cd36> a WB:WBGene00003070,
+<http://model.geneontology.org/WB_WBGene00003070/1bd559b9-4c00-44eb-a1a3-30bfaddb9f3b> a GO:0008306,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/959bd216-3758-40cc-8dc4-c33263ca4f38> a GO:0001661,
+<http://model.geneontology.org/WB_WBGene00003070/27b9a677-ebe6-4fd7-a92c-d4512adb3a9f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003070/caa816f2-35cf-4ca7-ba0e-639af5085eb8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003070/1bd559b9-4c00-44eb-a1a3-30bfaddb9f3b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003070/b949f6e5-766e-42d9-8c5f-96d1bf818896> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003070/d1743c41-c25e-402d-aa05-a21046cd0878> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003070/ed190c9f-725c-4aef-ac49-44d2b401e963> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003070/caa816f2-35cf-4ca7-ba0e-639af5085eb8> a WB:WBGene00003070,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/95d9e33e-c50c-491b-bf72-1a2c89794d85> a GO:0008306,
+<http://model.geneontology.org/WB_WBGene00003070/d1743c41-c25e-402d-aa05-a21046cd0878> a WB:WBGene00003070,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003070/c6b6b96a-fa0e-471c-8125-7cfd4918cf38> a WB:WBGene00003070,
+<http://model.geneontology.org/WB_WBGene00003070/ed190c9f-725c-4aef-ac49-44d2b401e963> a GO:0001661,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003070/f0c377b0-124d-40c3-8dc7-0e9611d5f749> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003070/c6b6b96a-fa0e-471c-8125-7cfd4918cf38> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003070/95d9e33e-c50c-491b-bf72-1a2c89794d85> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003070/fd610547-2cf1-424b-96e0-e060c6a4e9c6> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003070/176ff9ad-5d6d-4f71-97f8-24e1e002cd36> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003070/959bd216-3758-40cc-8dc4-c33263ca4f38> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -142,54 +148,54 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003070/b99e723f-b40c-4020-8788-f0f71a3dc380> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003070/0f0d92ab-38ee-4632-9b4c-be64679e32ef>,
+        <http://model.geneontology.org/WB_WBGene00003070/ed56932a-2644-4239-8030-586b71cd0354> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003070  RO:0002264 GO:0001661 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088998  2021-05-13 WB  id=WBOA:3549|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/fd610547-2cf1-424b-96e0-e060c6a4e9c6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/176ff9ad-5d6d-4f71-97f8-24e1e002cd36> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003070/276800c9-ed74-473b-aeda-b366b64b5b83>,
-        <http://model.geneontology.org/WB_WBGene00003070/f8f86064-d9f2-4517-898a-9e8a5a704b4c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003070  RO:0002264 GO:0008306 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088998  2021-05-13 WB  id=WBOA:3548|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00003070  RO:0002264 GO:0008306 WB:WBPaper00004861|PMID:11439453 ECO:0000315   2021-05-13 WB  id=WBOA:51800|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/f0c377b0-124d-40c3-8dc7-0e9611d5f749> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/95d9e33e-c50c-491b-bf72-1a2c89794d85> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003070/214e4583-ee77-43ab-abab-e9999bed00b1>,
-        <http://model.geneontology.org/WB_WBGene00003070/8844a84e-8237-4ecf-9055-2364620ad45c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003070  RO:0002264 GO:0008306 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088998  2021-05-13 WB  id=WBOA:3548|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00003070  RO:0002264 GO:0008306 WB:WBPaper00004861|PMID:11439453 ECO:0000315   2021-05-13 WB  id=WBOA:51800|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/f0c377b0-124d-40c3-8dc7-0e9611d5f749> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/c6b6b96a-fa0e-471c-8125-7cfd4918cf38> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/27b9a677-ebe6-4fd7-a92c-d4512adb3a9f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/caa816f2-35cf-4ca7-ba0e-639af5085eb8> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003070/6722ac94-fac2-4435-8886-efa00e5b7bde> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003070/48305af6-fe4a-459c-8032-a09180753826>,
+        <http://model.geneontology.org/WB_WBGene00003070/5b48c457-5bb2-4017-8081-e446203f5276> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003070  RO:0002264 GO:0008306 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088998  2021-05-13 WB  id=WBOA:3548|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00003070  RO:0002264 GO:0008306 WB:WBPaper00004861|PMID:11439453 ECO:0000315   2021-05-13 WB  id=WBOA:51800|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/27b9a677-ebe6-4fd7-a92c-d4512adb3a9f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/1bd559b9-4c00-44eb-a1a3-30bfaddb9f3b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003070/7e8626f6-34a1-4188-b8ba-a0c849a1473d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003070  RO:0002264 GO:0001661 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088998  2021-05-13 WB  id=WBOA:3549|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/fd610547-2cf1-424b-96e0-e060c6a4e9c6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/959bd216-3758-40cc-8dc4-c33263ca4f38> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/b949f6e5-766e-42d9-8c5f-96d1bf818896> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/ed190c9f-725c-4aef-ac49-44d2b401e963> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003070/b02a933b-4cb6-4bdd-b60f-42a69dd6c3c8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003070  RO:0002264 GO:0001661 WB:WBPaper00002763|PMID:9106675 ECO:0000315 WB:WBVar00088998  2021-05-13 WB  id=WBOA:3549|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003070/b949f6e5-766e-42d9-8c5f-96d1bf818896> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003070/d1743c41-c25e-402d-aa05-a21046cd0878> .
 

--- a/models/WB_WBGene00003088.ttl
+++ b/models/WB_WBGene00003088.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,137 +29,143 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003088> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dc:title "lsy-6 (WB:WBGene00003088)" ;
     dct:created "2006-07-31" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003088> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003088/02bfef88-efb6-487d-8000-8a9a4d840719> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003088/17a0b9a7-3a77-46ab-b643-b1c8ca0a77c3> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dc:source "PMID:14685240" ;
+    dct:created "2015-03-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003088/6de9c493-2cff-4d52-a0fd-9fbd8efccb4d> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00003088/1eb7e613-a26a-4084-b695-60e08cd53b84> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dc:source "PMID:14685240" ;
+    dct:created "2015-03-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/4796fdbd-8b64-4012-903a-0432b8599015> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dc:source "PMID:14685240" ;
+    dct:created "2015-03-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/a569a0ca-1f0d-4a89-8f89-7fb17ee56260> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2006-07-31" ;
     dc:source "PMID:14685240" ;
+    dct:created "2006-07-31" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003088/8fa9593e-8738-4864-942a-62cd0cb7e435> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003088/e1fe5262-e16c-444f-8738-6061478925b2> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dc:source "PMID:14685240" ;
+    dct:created "2015-03-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003088/92b438cd-0a08-4360-bef2-e7e21088416b> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dc:source "PMID:14685240" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/9e4d8716-1c90-4093-88d9-95679e9b8125> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00003088/f8748a42-df5b-4940-af30-b1b4e3617308> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2006-07-31" ;
     dc:source "PMID:14685240" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/bbef1118-8535-40d5-90df-b7cdcb1ce19b> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dc:source "PMID:14685240" ;
+    dct:created "2006-07-31" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002233 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003088/017513f1-cffc-4078-aaa6-7b46412294f5> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003088/a9cbe136-5ff6-40cc-a42c-52388d1980d2> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003088/6eb9f00b-b491-4bfd-94e9-1f89eed11000> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2006-07-31" ;
-    dct:created "2006-07-31" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/18c220c7-6e4a-4249-8862-40e00938e5dd> a GO:0003730,
-        owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003088/231d1364-21e9-44bd-8f49-489652f38951> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003088/bbc8b8bb-5fb4-4842-8749-5014d6808fec> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/231d1364-21e9-44bd-8f49-489652f38951> a WB:WBGene00000584,
+<http://model.geneontology.org/WB_WBGene00003088/0c75fe72-a69d-4ab5-bdc6-3728dff2807a> a GO:0035545,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003088/46407b19-99bf-401f-affb-33c4860a0ffb> a GO:0035545,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/6eb9f00b-b491-4bfd-94e9-1f89eed11000> a WB:WBGene00003088,
+<http://model.geneontology.org/WB_WBGene00003088/1f58d1d2-f8aa-4024-8f98-ec2cc621fe8c> a WB:WBGene00003088,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2006-07-31" ;
     dct:created "2006-07-31" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003088/72a37e2e-aea5-4610-bf43-01479b3f0415> a WB:WBGene00003088,
+<http://model.geneontology.org/WB_WBGene00003088/32426329-69f6-4b05-919b-b8d8fe5d0f7e> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003088/f1d7659b-6e0c-4b66-9d72-a831fe3adf47> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003088/1f58d1d2-f8aa-4024-8f98-ec2cc621fe8c> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2006-07-31" ;
+    dct:created "2006-07-31" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/41bd408c-3154-479b-9788-bec36a4111c5> a WB:WBGene00003088,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003088/a9cbe136-5ff6-40cc-a42c-52388d1980d2> a GO:0035195,
+<http://model.geneontology.org/WB_WBGene00003088/89013289-6de5-414f-98cb-1adbf0859ffc> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003088/0c75fe72-a69d-4ab5-bdc6-3728dff2807a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003088/e615466d-c932-4784-bdc5-6a7ad4570976> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dct:created "2015-03-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/9e93332d-50ba-4807-8526-119e3a99015d> a GO:0003730,
+        owl:NamedIndividual ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003088/ee25b2b3-3feb-4632-a0e1-ced02f13e07b> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003088/41bd408c-3154-479b-9788-bec36a4111c5> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dct:created "2015-03-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/e615466d-c932-4784-bdc5-6a7ad4570976> a WB:WBGene00003088,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dct:created "2015-03-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/ee25b2b3-3feb-4632-a0e1-ced02f13e07b> a WB:WBGene00000584,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dct:created "2015-03-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003088/f1d7659b-6e0c-4b66-9d72-a831fe3adf47> a GO:0035195,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2006-07-31" ;
     dct:created "2006-07-31" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/bbc8b8bb-5fb4-4842-8749-5014d6808fec> a WB:WBGene00003088,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003088/d8bda404-d096-4540-b00a-a069804101b8> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003088/46407b19-99bf-401f-affb-33c4860a0ffb> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003088/72a37e2e-aea5-4610-bf43-01479b3f0415> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -167,74 +173,74 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003088/6de9c493-2cff-4d52-a0fd-9fbd8efccb4d> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2006-07-31" ;
-    dct:created "2006-07-31" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035195 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2006-07-31 WB  id=WBOA:3562|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2006-07-31T15:49|modification-date=2006-07-31T15:49" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/017513f1-cffc-4078-aaa6-7b46412294f5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/6eb9f00b-b491-4bfd-94e9-1f89eed11000> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003088/bbef1118-8535-40d5-90df-b7cdcb1ce19b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003088/4796fdbd-8b64-4012-903a-0432b8599015> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003088  RO:0002327 GO:0003730 WB:WBPaper00006260|PMID:14685240 ECO:0000315   2015-03-23 WB RO:0002233(WB:WBGene00000584) id=WBOA:3565|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-03-23|modification-date=2015-03-23" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/18c220c7-6e4a-4249-8862-40e00938e5dd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/bbc8b8bb-5fb4-4842-8749-5014d6808fec> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003088/9e4d8716-1c90-4093-88d9-95679e9b8125> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2006-07-31" ;
-    dct:created "2006-07-31" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035195 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2006-07-31 WB  id=WBOA:3562|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2006-07-31T15:49|modification-date=2006-07-31T15:49" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/017513f1-cffc-4078-aaa6-7b46412294f5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/a9cbe136-5ff6-40cc-a42c-52388d1980d2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003088/92b438cd-0a08-4360-bef2-e7e21088416b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035545 WB:WBPaper00006260|PMID:14685240 ECO:0000315   2015-03-23 WB  id=WBOA:3561|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-03-23|modification-date=2015-03-23" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/d8bda404-d096-4540-b00a-a069804101b8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/46407b19-99bf-401f-affb-33c4860a0ffb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/89013289-6de5-414f-98cb-1adbf0859ffc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/0c75fe72-a69d-4ab5-bdc6-3728dff2807a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003088/02bfef88-efb6-487d-8000-8a9a4d840719> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003088/a569a0ca-1f0d-4a89-8f89-7fb17ee56260> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2006-07-31" ;
+    dct:created "2006-07-31" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035195 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2006-07-31 WB  id=WBOA:3562|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2006-07-31T15:49|modification-date=2006-07-31T15:49" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/32426329-69f6-4b05-919b-b8d8fe5d0f7e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/1f58d1d2-f8aa-4024-8f98-ec2cc621fe8c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003088/f8748a42-df5b-4940-af30-b1b4e3617308> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2006-07-31" ;
+    dct:created "2006-07-31" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035195 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2006-07-31 WB  id=WBOA:3562|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2006-07-31T15:49|modification-date=2006-07-31T15:49" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/32426329-69f6-4b05-919b-b8d8fe5d0f7e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/f1d7659b-6e0c-4b66-9d72-a831fe3adf47> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003088/17a0b9a7-3a77-46ab-b643-b1c8ca0a77c3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-03-23" ;
     dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035545 WB:WBPaper00006260|PMID:14685240 ECO:0000315   2015-03-23 WB  id=WBOA:3561|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-03-23|modification-date=2015-03-23" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/89013289-6de5-414f-98cb-1adbf0859ffc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/e615466d-c932-4784-bdc5-6a7ad4570976> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003088/1eb7e613-a26a-4084-b695-60e08cd53b84> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dct:created "2015-03-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003088  RO:0002327 GO:0003730 WB:WBPaper00006260|PMID:14685240 ECO:0000315   2015-03-23 WB RO:0002233(WB:WBGene00000584) id=WBOA:3565|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-03-23|modification-date=2015-03-23" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/9e93332d-50ba-4807-8526-119e3a99015d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/41bd408c-3154-479b-9788-bec36a4111c5> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003088/e1fe5262-e16c-444f-8738-6061478925b2> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-03-23" ;
+    dct:created "2015-03-23" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003088  RO:0002327 GO:0003730 WB:WBPaper00006260|PMID:14685240 ECO:0000315   2015-03-23 WB RO:0002233(WB:WBGene00000584) id=WBOA:3565|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-03-23|modification-date=2015-03-23" ;
     owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/18c220c7-6e4a-4249-8862-40e00938e5dd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/231d1364-21e9-44bd-8f49-489652f38951> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003088/8fa9593e-8738-4864-942a-62cd0cb7e435> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-03-23" ;
-    dct:created "2015-03-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003088  RO:0002331 GO:0035545 WB:WBPaper00006260|PMID:14685240 ECO:0000315   2015-03-23 WB  id=WBOA:3561|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-03-23|modification-date=2015-03-23" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/d8bda404-d096-4540-b00a-a069804101b8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/72a37e2e-aea5-4610-bf43-01479b3f0415> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003088/9e93332d-50ba-4807-8526-119e3a99015d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003088/ee25b2b3-3feb-4632-a0e1-ced02f13e07b> .
 

--- a/models/WB_WBGene00003187.ttl
+++ b/models/WB_WBGene00003187.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003187> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "mel-1 (WB:WBGene00003187)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003187> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003187/0fb0c65d-170c-4e70-88f3-2d8aa90aedcf> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003187/2af881cc-3a32-47eb-969b-457318fa0bde> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088000" ;
+    ns1:evidence-with "WB:WBVar00000402" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003187/21ed6a24-e42d-45c3-ad93-2e351fe42bd8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003187/e97a60fb-ce9e-40d7-aad1-6c2652e12c46> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000402" ;
+    ns1:evidence-with "WB:WBVar00088000" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003187/8a2adbe1-d44c-4384-97bb-adf5cc91898c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003187/ea5740a9-fafc-48e0-9a35-f83791eb07e6> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000402" ;
+    ns1:evidence-with "WB:WBVar00088000" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003187/fb1be220-cfe2-4d59-96f5-31bbf3734ab6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003187/ea6ab63f-a2de-4a77-b630-5fcb71a43b40> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088000" ;
+    ns1:evidence-with "WB:WBVar00000402" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003187/884f2db8-9b56-4cab-a042-cef7467248ab> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003187/11492953-e06d-4440-9712-197f6b395ba5> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003187/d40ef19c-df31-4419-8d01-912d274da2cf> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003187/267cd80b-771c-49cc-a7b7-2cfdc7e9992f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003187/e82e3547-c191-402a-928e-4d3518abade6> a WB:WBGene00003187,
+<http://model.geneontology.org/WB_WBGene00003187/267cd80b-771c-49cc-a7b7-2cfdc7e9992f> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003187/e94bb1ac-61f9-4d3a-b5c5-4bc622314840> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003187/d40ef19c-df31-4419-8d01-912d274da2cf> a WB:WBGene00003187,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003187/e82e3547-c191-402a-928e-4d3518abade6> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003187/884f2db8-9b56-4cab-a042-cef7467248ab> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003187/0fb0c65d-170c-4e70-88f3-2d8aa90aedcf>,
-        <http://model.geneontology.org/WB_WBGene00003187/21ed6a24-e42d-45c3-ad93-2e351fe42bd8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003187/ea5740a9-fafc-48e0-9a35-f83791eb07e6>,
+        <http://model.geneontology.org/WB_WBGene00003187/ea6ab63f-a2de-4a77-b630-5fcb71a43b40> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003187  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000402  2021-03-12 WB  id=WBOA:89558|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003187  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088000  2021-03-12 WB  id=WBOA:3751|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003187/e94bb1ac-61f9-4d3a-b5c5-4bc622314840> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003187/884f2db8-9b56-4cab-a042-cef7467248ab> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003187/11492953-e06d-4440-9712-197f6b395ba5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003187/267cd80b-771c-49cc-a7b7-2cfdc7e9992f> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003187/8a2adbe1-d44c-4384-97bb-adf5cc91898c>,
-        <http://model.geneontology.org/WB_WBGene00003187/fb1be220-cfe2-4d59-96f5-31bbf3734ab6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003187/2af881cc-3a32-47eb-969b-457318fa0bde>,
+        <http://model.geneontology.org/WB_WBGene00003187/e97a60fb-ce9e-40d7-aad1-6c2652e12c46> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003187  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000402  2021-03-12 WB  id=WBOA:89558|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003187  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088000  2021-03-12 WB  id=WBOA:3751|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003187/e94bb1ac-61f9-4d3a-b5c5-4bc622314840> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003187/e82e3547-c191-402a-928e-4d3518abade6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003187/11492953-e06d-4440-9712-197f6b395ba5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003187/d40ef19c-df31-4419-8d01-912d274da2cf> .
 

--- a/models/WB_WBGene00003189.ttl
+++ b/models/WB_WBGene00003189.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003189> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "mel-3 (WB:WBGene00003189)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003189> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003189/02c53d69-ec39-4c5b-8508-018ec2a8165e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003189/8fb871e7-42ed-4f38-9793-44fc57d7892c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000383" ;
+    ns1:evidence-with "WB:WBVar00000383" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003189/7379b1c5-a86c-4657-b839-b7a548c9b0c0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003189/cc1cb7d3-9869-45d9-a074-94953fe394b0> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087994" ;
+    ns1:evidence-with "WB:WBVar00087994" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003189/7840a48c-ca34-4c44-98bd-fb12795fe1a6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003189/f116e1c4-6713-43d4-99dc-835b75aacfbf> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000383" ;
+    ns1:evidence-with "WB:WBVar00087994" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003189/e2063213-d95c-4e67-818f-e3137a5db6e0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003189/f681c09f-b2a8-46b9-bc45-f40a1b405751> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087994" ;
+    ns1:evidence-with "WB:WBVar00000383" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003189/283047a3-2fd3-4b56-8c5f-d4a2a1990d46> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003189/44e0ea24-19fe-4cc7-8654-dac8c83100fe> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003189/2b658bca-bfcb-45b2-9fe5-1bd7c98c8979> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003189/76361394-157b-4b3e-a856-0b5ce8ff89de> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003189/2b658bca-bfcb-45b2-9fe5-1bd7c98c8979> a WB:WBGene00003189,
+<http://model.geneontology.org/WB_WBGene00003189/7807d2ba-e28b-42e1-a35f-122fb898221f> a WB:WBGene00003189,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003189/76361394-157b-4b3e-a856-0b5ce8ff89de> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003189/e45fa789-f57c-49b1-a32e-5c338e363b92> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003189/7807d2ba-e28b-42e1-a35f-122fb898221f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003189/44e0ea24-19fe-4cc7-8654-dac8c83100fe> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003189/7840a48c-ca34-4c44-98bd-fb12795fe1a6>,
-        <http://model.geneontology.org/WB_WBGene00003189/e2063213-d95c-4e67-818f-e3137a5db6e0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003189/f116e1c4-6713-43d4-99dc-835b75aacfbf>,
+        <http://model.geneontology.org/WB_WBGene00003189/f681c09f-b2a8-46b9-bc45-f40a1b405751> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003189  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000383  2021-03-12 WB  id=WBOA:89559|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00003189  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087994  2021-03-12 WB  id=WBOA:3753|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003189/283047a3-2fd3-4b56-8c5f-d4a2a1990d46> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003189/2b658bca-bfcb-45b2-9fe5-1bd7c98c8979> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003189/02c53d69-ec39-4c5b-8508-018ec2a8165e>,
-        <http://model.geneontology.org/WB_WBGene00003189/7379b1c5-a86c-4657-b839-b7a548c9b0c0> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003189  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000383  2021-03-12 WB  id=WBOA:89559|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003189  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087994  2021-03-12 WB  id=WBOA:3753|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003189/283047a3-2fd3-4b56-8c5f-d4a2a1990d46> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003189/76361394-157b-4b3e-a856-0b5ce8ff89de> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003189/e45fa789-f57c-49b1-a32e-5c338e363b92> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003189/44e0ea24-19fe-4cc7-8654-dac8c83100fe> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003189/8fb871e7-42ed-4f38-9793-44fc57d7892c>,
+        <http://model.geneontology.org/WB_WBGene00003189/cc1cb7d3-9869-45d9-a074-94953fe394b0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003189  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000383  2021-03-12 WB  id=WBOA:89559|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00003189  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087994  2021-03-12 WB  id=WBOA:3753|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003189/e45fa789-f57c-49b1-a32e-5c338e363b92> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003189/7807d2ba-e28b-42e1-a35f-122fb898221f> .
 

--- a/models/WB_WBGene00003190.ttl
+++ b/models/WB_WBGene00003190.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003190> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "mel-4 (WB:WBGene00003190)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003190> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003190/31de933c-3d7c-48e6-8388-2f6dbee5839b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003190/129dfbe3-3395-4077-ac8a-dc60690bf6dd> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088020" ;
+    ns1:evidence-with "WB:WBVar00087998" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003190/39511e72-6a15-4bdf-afc5-2a1b85f4c4db> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003190/3cf7c3e0-1b67-4428-96b6-35ec4cd93bf7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087998" ;
+    ns1:evidence-with "WB:WBVar00088020" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003190/482ce6fc-e342-4c73-ac2d-75b6a483b645> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003190/62236330-8222-4990-8e4f-c386a5d0d414> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088020" ;
+    ns1:evidence-with "WB:WBVar00087998" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003190/9ba6f16d-65f3-49e0-8508-983d31132589> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003190/ed9bdb05-1c45-4ec9-acd6-31146479f278> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087998" ;
+    ns1:evidence-with "WB:WBVar00088020" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003190/693a5740-a3e8-4191-8326-d0dba653493d> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003190/0f4091dd-46c4-41be-8f8f-2280db1fcbce> a WB:WBGene00003190,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003190/9cca28df-5f20-4df8-a148-b0dadddbbfa3> a WB:WBGene00003190,
+<http://model.geneontology.org/WB_WBGene00003190/214baa6d-aa9e-4fbc-b2f7-02c6363cd98a> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003190/b03bbbf5-28f8-4619-b50d-6a705e5dcf11> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003190/68982ffd-1884-4437-afe3-5705c0a02b45> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003190/9cca28df-5f20-4df8-a148-b0dadddbbfa3> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003190/693a5740-a3e8-4191-8326-d0dba653493d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003190/0f4091dd-46c4-41be-8f8f-2280db1fcbce> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003190/214baa6d-aa9e-4fbc-b2f7-02c6363cd98a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003190/31de933c-3d7c-48e6-8388-2f6dbee5839b>,
-        <http://model.geneontology.org/WB_WBGene00003190/9ba6f16d-65f3-49e0-8508-983d31132589> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003190/129dfbe3-3395-4077-ac8a-dc60690bf6dd>,
+        <http://model.geneontology.org/WB_WBGene00003190/ed9bdb05-1c45-4ec9-acd6-31146479f278> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003190  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087998  2021-03-12 WB  id=WBOA:89560|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003190  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088020  2021-03-12 WB  id=WBOA:3754|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003190/b03bbbf5-28f8-4619-b50d-6a705e5dcf11> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003190/9cca28df-5f20-4df8-a148-b0dadddbbfa3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003190/68982ffd-1884-4437-afe3-5705c0a02b45> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003190/0f4091dd-46c4-41be-8f8f-2280db1fcbce> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003190/39511e72-6a15-4bdf-afc5-2a1b85f4c4db>,
-        <http://model.geneontology.org/WB_WBGene00003190/482ce6fc-e342-4c73-ac2d-75b6a483b645> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003190/3cf7c3e0-1b67-4428-96b6-35ec4cd93bf7>,
+        <http://model.geneontology.org/WB_WBGene00003190/62236330-8222-4990-8e4f-c386a5d0d414> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003190  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087998  2021-03-12 WB  id=WBOA:89560|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003190  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088020  2021-03-12 WB  id=WBOA:3754|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003190/b03bbbf5-28f8-4619-b50d-6a705e5dcf11> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003190/693a5740-a3e8-4191-8326-d0dba653493d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003190/68982ffd-1884-4437-afe3-5705c0a02b45> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003190/214baa6d-aa9e-4fbc-b2f7-02c6363cd98a> .
 

--- a/models/WB_WBGene00003191.ttl
+++ b/models/WB_WBGene00003191.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003191> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-5 (WB:WBGene00003191)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003191> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003191/154cc3eb-cead-45e4-89e5-f1050c415c41> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003191/2ca4abf1-45d9-4307-bcb4-76d890cb9a41> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000401" ;
+    ns1:evidence-with "WB:WBVar00000401" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003191/51ace561-bfbb-4167-a39b-59dbd94d9f2f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003191/7eff987c-2c37-4914-8bbc-293f5ce79417> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000401" ;
+    ns1:evidence-with "WB:WBVar00000401" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003191/457186cb-a492-45a8-93fe-106fec8a6964> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003191/27b57927-cc89-4460-8069-70a6caa753de> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003191/df50e3c6-8b92-437a-a769-c76916173e05> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003191/4e399814-81a7-4d1e-a45e-221ae88c2a1e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003191/4e399814-81a7-4d1e-a45e-221ae88c2a1e> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003191/2d119a96-1735-4c19-a5a0-134ed233aadd> a WB:WBGene00003191,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003191/df50e3c6-8b92-437a-a769-c76916173e05> a WB:WBGene00003191,
+<http://model.geneontology.org/WB_WBGene00003191/82970a18-3206-4610-8fb8-c835ed26f5ff> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003191/2d119a96-1735-4c19-a5a0-134ed233aadd> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003191/27b57927-cc89-4460-8069-70a6caa753de> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003191/51ace561-bfbb-4167-a39b-59dbd94d9f2f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003191/2ca4abf1-45d9-4307-bcb4-76d890cb9a41> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003191  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000401  2021-05-13 WB  id=WBOA:3755|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003191/457186cb-a492-45a8-93fe-106fec8a6964> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003191/4e399814-81a7-4d1e-a45e-221ae88c2a1e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003191/82970a18-3206-4610-8fb8-c835ed26f5ff> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003191/27b57927-cc89-4460-8069-70a6caa753de> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003191/154cc3eb-cead-45e4-89e5-f1050c415c41> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003191/7eff987c-2c37-4914-8bbc-293f5ce79417> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003191  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000401  2021-05-13 WB  id=WBOA:3755|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003191/457186cb-a492-45a8-93fe-106fec8a6964> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003191/df50e3c6-8b92-437a-a769-c76916173e05> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003191/82970a18-3206-4610-8fb8-c835ed26f5ff> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003191/2d119a96-1735-4c19-a5a0-134ed233aadd> .
 

--- a/models/WB_WBGene00003192.ttl
+++ b/models/WB_WBGene00003192.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003192> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-7 (WB:WBGene00003192)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003192> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003192/067f9715-9245-44dd-bcb2-bc91c7031910> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003192/6308f35a-f0ea-46c3-ac42-8f8009f81b8c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088015" ;
+    ns1:evidence-with "WB:WBVar00088015" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003192/a139ccd5-d87c-4957-8de0-62df16b9ed4a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003192/74d855a3-8e53-406f-939f-3c7cf33c0822> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088015" ;
+    ns1:evidence-with "WB:WBVar00088015" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003192/50f606b6-90ef-45a6-a95f-d60d01d6b33f> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003192/4f0abc4d-1dc8-4120-bd55-65ca8e5ad94b> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003192/a512afc2-3bb7-4c78-bc8c-0bf8322a1e43> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003192/f82c47c7-09ec-446f-ab55-313c7de7b820> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003192/7a18c5f5-3fcf-4220-8ff0-0988d2320161> a WB:WBGene00003192,
+<http://model.geneontology.org/WB_WBGene00003192/a512afc2-3bb7-4c78-bc8c-0bf8322a1e43> a WB:WBGene00003192,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003192/9fcb7d3c-cf3e-4853-85e3-1116880feba8> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003192/f82c47c7-09ec-446f-ab55-313c7de7b820> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003192/7a18c5f5-3fcf-4220-8ff0-0988d2320161> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003192/50f606b6-90ef-45a6-a95f-d60d01d6b33f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003192/067f9715-9245-44dd-bcb2-bc91c7031910> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003192/6308f35a-f0ea-46c3-ac42-8f8009f81b8c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003192  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088015  2021-05-13 WB  id=WBOA:3756|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003192/9fcb7d3c-cf3e-4853-85e3-1116880feba8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003192/7a18c5f5-3fcf-4220-8ff0-0988d2320161> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003192/a139ccd5-d87c-4957-8de0-62df16b9ed4a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003192  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088015  2021-05-13 WB  id=WBOA:3756|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003192/9fcb7d3c-cf3e-4853-85e3-1116880feba8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003192/50f606b6-90ef-45a6-a95f-d60d01d6b33f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003192/4f0abc4d-1dc8-4120-bd55-65ca8e5ad94b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003192/f82c47c7-09ec-446f-ab55-313c7de7b820> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003192/74d855a3-8e53-406f-939f-3c7cf33c0822> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003192  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088015  2021-05-13 WB  id=WBOA:3756|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003192/4f0abc4d-1dc8-4120-bd55-65ca8e5ad94b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003192/a512afc2-3bb7-4c78-bc8c-0bf8322a1e43> .
 

--- a/models/WB_WBGene00003193.ttl
+++ b/models/WB_WBGene00003193.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,143 +29,151 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003193> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "mel-8 (WB:WBGene00003193)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003193> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003193/0710f67d-8987-46d8-8bc8-15207fde1ecc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/45757771-995b-4ff4-886c-31fbe6511fba> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088018" ;
+    ns1:evidence-with "WB:WBVar00088008" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/18b50295-1de8-4f16-b8c4-db59678e41e0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/6869f8e7-dc61-46cc-829e-7e24c157dfda> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000400" ;
+    ns1:evidence-with "WB:WBVar00088018" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/4f4a7da2-1387-4617-a5e9-b682d144efd3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/8d35ffe4-a631-46cf-85ff-63585e1cbc1a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088008" ;
+    ns1:evidence-with "WB:WBVar00000400" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/5d3a3ee5-1385-4855-9d94-fa9cfb26e391> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/aac13d50-9ec2-4702-a9a5-452af3151a4e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088008" ;
+    ns1:evidence-with "WB:WBVar00000398" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/8d62da4c-b99f-42e5-92b4-868ea6115951> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/b029288e-1767-42b6-9cd9-9cad0df3d3cb> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000398" ;
+    ns1:evidence-with "WB:WBVar00088008" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/a446a475-5366-41ee-b4d0-d8a31291ede4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/d4092449-a33e-42ea-9d1e-9fb76ae3684a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088018" ;
+    ns1:evidence-with "WB:WBVar00000400" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/a8136384-f384-4ab2-ad8c-085ecf8f8f56> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/d5cad762-2190-42ea-9e18-b97fd27c357f> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000400" ;
+    ns1:evidence-with "WB:WBVar00088018" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/a9ef1bb4-5b5c-4357-8b18-4d339e2c41a8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003193/d84caf83-05de-4adb-a613-cb0c8933b4f3> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000398" ;
+    ns1:evidence-with "WB:WBVar00000398" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003193/7bddd0d7-8110-4eb5-8808-d59335fe4b40> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003193/0631157d-f9a4-46f9-be2c-da4e86d934b3> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003193/ab300218-8bb0-47eb-bce8-db7d0a05576e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003193/f9c2cc7e-7546-472e-a9c7-76372e61c822> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003193/80abe9e3-b22f-49d3-bbd4-9f5178905a99> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003193/a9ad940b-9f67-4a82-9a7e-8cd5375f4611> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/ab300218-8bb0-47eb-bce8-db7d0a05576e> a WB:WBGene00003193,
+<http://model.geneontology.org/WB_WBGene00003193/80abe9e3-b22f-49d3-bbd4-9f5178905a99> a WB:WBGene00003193,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003193/f9c2cc7e-7546-472e-a9c7-76372e61c822> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003193/a9ad940b-9f67-4a82-9a7e-8cd5375f4611> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003193/18b50295-1de8-4f16-b8c4-db59678e41e0>,
-        <http://model.geneontology.org/WB_WBGene00003193/5d3a3ee5-1385-4855-9d94-fa9cfb26e391>,
-        <http://model.geneontology.org/WB_WBGene00003193/a446a475-5366-41ee-b4d0-d8a31291ede4>,
-        <http://model.geneontology.org/WB_WBGene00003193/a9ef1bb4-5b5c-4357-8b18-4d339e2c41a8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003193/45757771-995b-4ff4-886c-31fbe6511fba>,
+        <http://model.geneontology.org/WB_WBGene00003193/d4092449-a33e-42ea-9d1e-9fb76ae3684a>,
+        <http://model.geneontology.org/WB_WBGene00003193/d5cad762-2190-42ea-9e18-b97fd27c357f>,
+        <http://model.geneontology.org/WB_WBGene00003193/d84caf83-05de-4adb-a613-cb0c8933b4f3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000398  2021-03-12 WB  id=WBOA:89563|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000400  2021-03-12 WB  id=WBOA:89562|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088008  2021-03-12 WB  id=WBOA:89561|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088018  2021-03-12 WB  id=WBOA:3757|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003193/7bddd0d7-8110-4eb5-8808-d59335fe4b40> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003193/ab300218-8bb0-47eb-bce8-db7d0a05576e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003193/0631157d-f9a4-46f9-be2c-da4e86d934b3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003193/80abe9e3-b22f-49d3-bbd4-9f5178905a99> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003193/0710f67d-8987-46d8-8bc8-15207fde1ecc>,
-        <http://model.geneontology.org/WB_WBGene00003193/4f4a7da2-1387-4617-a5e9-b682d144efd3>,
-        <http://model.geneontology.org/WB_WBGene00003193/8d62da4c-b99f-42e5-92b4-868ea6115951>,
-        <http://model.geneontology.org/WB_WBGene00003193/a8136384-f384-4ab2-ad8c-085ecf8f8f56> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003193/6869f8e7-dc61-46cc-829e-7e24c157dfda>,
+        <http://model.geneontology.org/WB_WBGene00003193/8d35ffe4-a631-46cf-85ff-63585e1cbc1a>,
+        <http://model.geneontology.org/WB_WBGene00003193/aac13d50-9ec2-4702-a9a5-452af3151a4e>,
+        <http://model.geneontology.org/WB_WBGene00003193/b029288e-1767-42b6-9cd9-9cad0df3d3cb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000398  2021-03-12 WB  id=WBOA:89563|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000400  2021-03-12 WB  id=WBOA:89562|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088008  2021-03-12 WB  id=WBOA:89561|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003193  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088018  2021-03-12 WB  id=WBOA:3757|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003193/7bddd0d7-8110-4eb5-8808-d59335fe4b40> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003193/f9c2cc7e-7546-472e-a9c7-76372e61c822> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003193/0631157d-f9a4-46f9-be2c-da4e86d934b3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003193/a9ad940b-9f67-4a82-9a7e-8cd5375f4611> .
 

--- a/models/WB_WBGene00003194.ttl
+++ b/models/WB_WBGene00003194.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003194> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-9 (WB:WBGene00003194)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003194> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003194/0bee25c1-2ad5-468e-92c4-f4a9c1f6591e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003194/70a91227-277d-4633-a78a-86b3d44d3ff7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000391" ;
+    ns1:evidence-with "WB:WBVar00000391" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003194/7279f6d7-6646-4a34-a2a5-66f0a3bef28d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003194/a23b5623-46bc-4506-9cc9-866f82384ceb> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000391" ;
+    ns1:evidence-with "WB:WBVar00000391" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003194/18a060d3-d1f5-43c3-bfbe-375f8ee84f21> a WB:WBGene00003194,
+<http://model.geneontology.org/WB_WBGene00003194/19d18b27-3098-41a5-970d-ccd5e3575425> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003194/4b8cca2a-b710-49a8-8607-002b70a8d130> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003194/50200682-fdbd-4db2-aef7-57a06b96bd58> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003194/7a9a0f06-2b65-4aaf-861b-9eb60a90f486> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003194/19d18b27-3098-41a5-970d-ccd5e3575425> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003194/9a9e78e5-2cf7-4f15-8906-f91219431c67> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003194/7a9a0f06-2b65-4aaf-861b-9eb60a90f486> a WB:WBGene00003194,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003194/18a060d3-d1f5-43c3-bfbe-375f8ee84f21> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003194/4b8cca2a-b710-49a8-8607-002b70a8d130> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003194/7279f6d7-6646-4a34-a2a5-66f0a3bef28d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003194/a23b5623-46bc-4506-9cc9-866f82384ceb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003194  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000391  2021-05-13 WB  id=WBOA:3758|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003194/9a9e78e5-2cf7-4f15-8906-f91219431c67> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003194/18a060d3-d1f5-43c3-bfbe-375f8ee84f21> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003194/0bee25c1-2ad5-468e-92c4-f4a9c1f6591e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003194  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000391  2021-05-13 WB  id=WBOA:3758|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003194/9a9e78e5-2cf7-4f15-8906-f91219431c67> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003194/4b8cca2a-b710-49a8-8607-002b70a8d130> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003194/50200682-fdbd-4db2-aef7-57a06b96bd58> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003194/19d18b27-3098-41a5-970d-ccd5e3575425> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003194/70a91227-277d-4633-a78a-86b3d44d3ff7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003194  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000391  2021-05-13 WB  id=WBOA:3758|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003194/50200682-fdbd-4db2-aef7-57a06b96bd58> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003194/7a9a0f06-2b65-4aaf-861b-9eb60a90f486> .
 

--- a/models/WB_WBGene00003195.ttl
+++ b/models/WB_WBGene00003195.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003195> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-10 (WB:WBGene00003195)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003195> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003195/0cf8e5db-26ac-4e62-95bf-c394ab4643f4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003195/44df3f99-1efa-479d-995b-670b7f4ac5b7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087996" ;
+    ns1:evidence-with "WB:WBVar00087996" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003195/9c3596df-1b45-47fd-93d4-40396bb68d92> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003195/86310e61-8ae5-4ab0-bd60-efb7a0db07e2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087996" ;
+    ns1:evidence-with "WB:WBVar00087996" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003195/2658b1ec-f4be-469d-a02d-eaae421a5649> a WB:WBGene00003195,
+<http://model.geneontology.org/WB_WBGene00003195/7dacf411-53cb-4091-9ea1-36e8cb45e74d> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003195/2ce1794f-23d9-4488-9ae8-6bb67692dbb0> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003195/b87f82bd-2c73-4f47-867c-1424e96f4e2d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003195/bedfdb3f-8999-48d7-b451-f5b10e2035bf> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003195/7dacf411-53cb-4091-9ea1-36e8cb45e74d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003195/3a907118-22bd-4bb5-8363-f0e7d5d58afb> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003195/bedfdb3f-8999-48d7-b451-f5b10e2035bf> a WB:WBGene00003195,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003195/2658b1ec-f4be-469d-a02d-eaae421a5649> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003195/2ce1794f-23d9-4488-9ae8-6bb67692dbb0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003195/0cf8e5db-26ac-4e62-95bf-c394ab4643f4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003195/44df3f99-1efa-479d-995b-670b7f4ac5b7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003195  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087996  2021-05-13 WB  id=WBOA:3759|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003195/3a907118-22bd-4bb5-8363-f0e7d5d58afb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003195/2ce1794f-23d9-4488-9ae8-6bb67692dbb0> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003195/b87f82bd-2c73-4f47-867c-1424e96f4e2d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003195/7dacf411-53cb-4091-9ea1-36e8cb45e74d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003195/9c3596df-1b45-47fd-93d4-40396bb68d92> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003195/86310e61-8ae5-4ab0-bd60-efb7a0db07e2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003195  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00087996  2021-05-13 WB  id=WBOA:3759|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003195/3a907118-22bd-4bb5-8363-f0e7d5d58afb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003195/2658b1ec-f4be-469d-a02d-eaae421a5649> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003195/b87f82bd-2c73-4f47-867c-1424e96f4e2d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003195/bedfdb3f-8999-48d7-b451-f5b10e2035bf> .
 

--- a/models/WB_WBGene00003197.ttl
+++ b/models/WB_WBGene00003197.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003197> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-12 (WB:WBGene00003197)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003197> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003197/91938a3e-93f0-4004-bdc1-d096f35f69a4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003197/4f5aac5a-f668-4bfd-a2aa-2e2a8c6b2f79> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088019" ;
+    ns1:evidence-with "WB:WBVar00088019" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003197/ba3507cf-77c9-4aaf-941c-4673158dcd05> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003197/ce873bb3-b8a4-441e-a0c3-6d488b9c134e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088019" ;
+    ns1:evidence-with "WB:WBVar00088019" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003197/52686581-dfde-485a-bf46-90165e4b0f75> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003197/098e3ace-de67-4fe3-a8b0-938228f8445b> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003197/9ad4c695-58bd-432f-b3a3-ff865cbf86a4> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003197/0bf03997-b98c-4329-afac-543b013cb0e2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003197/befaaee5-eb29-4373-86ce-09542a95dd0a> a WB:WBGene00003197,
+<http://model.geneontology.org/WB_WBGene00003197/0bf03997-b98c-4329-afac-543b013cb0e2> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003197/de92c210-f050-45d3-bc49-d1608a061eac> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003197/9ad4c695-58bd-432f-b3a3-ff865cbf86a4> a WB:WBGene00003197,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003197/befaaee5-eb29-4373-86ce-09542a95dd0a> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003197/52686581-dfde-485a-bf46-90165e4b0f75> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003197/ba3507cf-77c9-4aaf-941c-4673158dcd05> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003197/ce873bb3-b8a4-441e-a0c3-6d488b9c134e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003197  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088019  2021-05-13 WB  id=WBOA:3763|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003197/de92c210-f050-45d3-bc49-d1608a061eac> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003197/52686581-dfde-485a-bf46-90165e4b0f75> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003197/91938a3e-93f0-4004-bdc1-d096f35f69a4> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003197  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088019  2021-05-13 WB  id=WBOA:3763|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003197/de92c210-f050-45d3-bc49-d1608a061eac> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003197/befaaee5-eb29-4373-86ce-09542a95dd0a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003197/098e3ace-de67-4fe3-a8b0-938228f8445b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003197/9ad4c695-58bd-432f-b3a3-ff865cbf86a4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003197/4f5aac5a-f668-4bfd-a2aa-2e2a8c6b2f79> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003197  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088019  2021-05-13 WB  id=WBOA:3763|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003197/098e3ace-de67-4fe3-a8b0-938228f8445b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003197/0bf03997-b98c-4329-afac-543b013cb0e2> .
 

--- a/models/WB_WBGene00003198.ttl
+++ b/models/WB_WBGene00003198.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003198> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-13 (WB:WBGene00003198)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003198> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003198/3943895f-45ef-4eca-b740-115b0023240d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003198/7a179098-d624-462b-a4af-ea0a4eda2144> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000396" ;
+    ns1:evidence-with "WB:WBVar00000396" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003198/fefc86b7-270b-4845-bab7-f8ba5f720d79> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003198/c5ea06ff-0083-465a-9ed5-643dc9a9f9e2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000396" ;
+    ns1:evidence-with "WB:WBVar00000396" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003198/0fe082d6-f865-4af3-b77e-9fc503aa0c61> a WB:WBGene00003198,
+<http://model.geneontology.org/WB_WBGene00003198/4c921c11-fdfa-4964-9f7e-98526e20b4cb> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003198/a8d40db4-0230-46de-90cf-6bd7e2b04d65> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003198/ab69a426-0b82-452d-879e-2790298f32e3> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003198/0fe082d6-f865-4af3-b77e-9fc503aa0c61> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003198/ee981626-e9ab-47fa-9ca1-06ba7cd010fd> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003198/b525e916-2b71-4f6f-8a30-922b1484cf39> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003198/4c921c11-fdfa-4964-9f7e-98526e20b4cb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003198/ee981626-e9ab-47fa-9ca1-06ba7cd010fd> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003198/b525e916-2b71-4f6f-8a30-922b1484cf39> a WB:WBGene00003198,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003198/3943895f-45ef-4eca-b740-115b0023240d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003198/7a179098-d624-462b-a4af-ea0a4eda2144> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003198  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000396  2021-05-13 WB  id=WBOA:3764|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003198/a8d40db4-0230-46de-90cf-6bd7e2b04d65> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003198/ee981626-e9ab-47fa-9ca1-06ba7cd010fd> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003198/ab69a426-0b82-452d-879e-2790298f32e3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003198/4c921c11-fdfa-4964-9f7e-98526e20b4cb> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003198/fefc86b7-270b-4845-bab7-f8ba5f720d79> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003198/c5ea06ff-0083-465a-9ed5-643dc9a9f9e2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003198  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000396  2021-05-13 WB  id=WBOA:3764|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003198/a8d40db4-0230-46de-90cf-6bd7e2b04d65> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003198/0fe082d6-f865-4af3-b77e-9fc503aa0c61> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003198/ab69a426-0b82-452d-879e-2790298f32e3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003198/b525e916-2b71-4f6f-8a30-922b1484cf39> .
 

--- a/models/WB_WBGene00003199.ttl
+++ b/models/WB_WBGene00003199.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,123 +29,129 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003199> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "mel-14 (WB:WBGene00003199)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003199> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003199/336c8431-de51-464c-8728-a1604b7b13b5> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003199/01a4e33e-e767-461a-a878-87e19fff023d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000390" ;
+    ns1:evidence-with "WB:WBVar00088005" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/64cc94ee-9cec-4981-93e5-8c28e138ba78> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003199/0776e5af-8861-4b44-8a3d-7b3adb7d2284> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000389" ;
+    ns1:evidence-with "WB:WBVar00000390" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/6ed74c0c-69eb-4399-8eeb-96055b01f2df> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003199/0789e4b2-c735-4507-b0af-741be3950ad2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000390" ;
+    ns1:evidence-with "WB:WBVar00000390" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/75920c52-137d-49fb-9a55-5bd7af92e04a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003199/07c6c50a-30da-4f0c-92b6-682583d96cca> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000389" ;
+    ns1:evidence-with "WB:WBVar00000389" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/9b3a0e81-9897-481e-9a56-441eb1ff1bb0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003199/744729ab-930e-4dcc-b530-426939d90905> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088005" ;
+    ns1:evidence-with "WB:WBVar00088005" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/b664d208-c9dc-4b70-8026-6829db145113> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003199/e1008275-9d80-4a71-84a3-7cabf7cdeaec> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088005" ;
+    ns1:evidence-with "WB:WBVar00000389" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003199/0e677c55-407e-4faf-aa1f-a36e56f27546> a WB:WBGene00003199,
+<http://model.geneontology.org/WB_WBGene00003199/018c3c9a-0922-42ae-86e9-378ad11e9eef> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/52821846-24d2-4539-b395-3dddafae62b9> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003199/6b2404ef-e5e2-48cc-856d-97dfec29a2b7> a WB:WBGene00003199,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003199/d005158b-3f90-4b58-83f7-20d9184d05fd> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003199/ca655d25-19d1-46e3-8f5e-d8f0829a50a7> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003199/0e677c55-407e-4faf-aa1f-a36e56f27546> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003199/52821846-24d2-4539-b395-3dddafae62b9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003199/6b2404ef-e5e2-48cc-856d-97dfec29a2b7> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003199/018c3c9a-0922-42ae-86e9-378ad11e9eef> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003199/64cc94ee-9cec-4981-93e5-8c28e138ba78>,
-        <http://model.geneontology.org/WB_WBGene00003199/6ed74c0c-69eb-4399-8eeb-96055b01f2df>,
-        <http://model.geneontology.org/WB_WBGene00003199/9b3a0e81-9897-481e-9a56-441eb1ff1bb0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003199/0776e5af-8861-4b44-8a3d-7b3adb7d2284>,
+        <http://model.geneontology.org/WB_WBGene00003199/744729ab-930e-4dcc-b530-426939d90905>,
+        <http://model.geneontology.org/WB_WBGene00003199/e1008275-9d80-4a71-84a3-7cabf7cdeaec> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003199  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000389  2021-03-12 WB  id=WBOA:89565|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003199  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000390  2021-03-12 WB  id=WBOA:89564|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003199  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088005  2021-03-12 WB  id=WBOA:3765|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003199/d005158b-3f90-4b58-83f7-20d9184d05fd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003199/52821846-24d2-4539-b395-3dddafae62b9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003199/ca655d25-19d1-46e3-8f5e-d8f0829a50a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003199/018c3c9a-0922-42ae-86e9-378ad11e9eef> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003199/336c8431-de51-464c-8728-a1604b7b13b5>,
-        <http://model.geneontology.org/WB_WBGene00003199/75920c52-137d-49fb-9a55-5bd7af92e04a>,
-        <http://model.geneontology.org/WB_WBGene00003199/b664d208-c9dc-4b70-8026-6829db145113> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003199/01a4e33e-e767-461a-a878-87e19fff023d>,
+        <http://model.geneontology.org/WB_WBGene00003199/0789e4b2-c735-4507-b0af-741be3950ad2>,
+        <http://model.geneontology.org/WB_WBGene00003199/07c6c50a-30da-4f0c-92b6-682583d96cca> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003199  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000389  2021-03-12 WB  id=WBOA:89565|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003199  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000390  2021-03-12 WB  id=WBOA:89564|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00003199  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088005  2021-03-12 WB  id=WBOA:3765|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003199/d005158b-3f90-4b58-83f7-20d9184d05fd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003199/0e677c55-407e-4faf-aa1f-a36e56f27546> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003199/ca655d25-19d1-46e3-8f5e-d8f0829a50a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003199/6b2404ef-e5e2-48cc-856d-97dfec29a2b7> .
 

--- a/models/WB_WBGene00003201.ttl
+++ b/models/WB_WBGene00003201.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003201> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-16 (WB:WBGene00003201)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003201> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003201/2c6d823a-f12a-4b17-b7ca-8e364e98786a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003201/1d110bf5-956f-4898-a8f3-7af0ad5b1bc0> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000392" ;
+    ns1:evidence-with "WB:WBVar00000392" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003201/7a7daff3-5f6f-46bd-99e3-eebb5d7c24a0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003201/960453a1-06a7-4d89-ba8a-d1d2194f33db> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000392" ;
+    ns1:evidence-with "WB:WBVar00000392" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003201/5356750c-5a87-44a2-b9e4-8ac97cf46684> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003201/2bbb7f61-a07a-4fee-bf55-8367537db5c2> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003201/b4074206-5cb3-475e-a794-b9a37cc70fa7> a WB:WBGene00003201,
+<http://model.geneontology.org/WB_WBGene00003201/31afdb6a-d1eb-4613-adfd-6a4627880df5> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003201/b569873c-81d9-491c-8cf8-6e27d4fdcdff> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003201/2bbb7f61-a07a-4fee-bf55-8367537db5c2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003201/d9e59cc3-599e-4697-95b6-b1265c2f47af> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003201/b569873c-81d9-491c-8cf8-6e27d4fdcdff> a WB:WBGene00003201,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003201/b4074206-5cb3-475e-a794-b9a37cc70fa7> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003201/5356750c-5a87-44a2-b9e4-8ac97cf46684> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003201/7a7daff3-5f6f-46bd-99e3-eebb5d7c24a0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003201/1d110bf5-956f-4898-a8f3-7af0ad5b1bc0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003201  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000392  2021-05-13 WB  id=WBOA:3767|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003201/d9e59cc3-599e-4697-95b6-b1265c2f47af> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003201/b4074206-5cb3-475e-a794-b9a37cc70fa7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003201/2c6d823a-f12a-4b17-b7ca-8e364e98786a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003201  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000392  2021-05-13 WB  id=WBOA:3767|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003201/d9e59cc3-599e-4697-95b6-b1265c2f47af> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003201/5356750c-5a87-44a2-b9e4-8ac97cf46684> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003201/31afdb6a-d1eb-4613-adfd-6a4627880df5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003201/2bbb7f61-a07a-4fee-bf55-8367537db5c2> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003201/960453a1-06a7-4d89-ba8a-d1d2194f33db> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003201  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000392  2021-05-13 WB  id=WBOA:3767|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003201/31afdb6a-d1eb-4613-adfd-6a4627880df5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003201/b569873c-81d9-491c-8cf8-6e27d4fdcdff> .
 

--- a/models/WB_WBGene00003202.ttl
+++ b/models/WB_WBGene00003202.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003202> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-17 (WB:WBGene00003202)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003202> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003202/18c6b45f-3527-4a78-aca1-df0a024a4c95> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003202/3c3e03d0-e353-47f4-a7e7-fca15864579e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000393" ;
+    ns1:evidence-with "WB:WBVar00000393" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003202/2608c086-fd27-4683-94e2-d083393494e6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003202/61b83a45-be64-491b-9d68-484345cabc92> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000393" ;
+    ns1:evidence-with "WB:WBVar00000393" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003202/20ee849e-96a4-4aa8-b736-d6d4f231d96f> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003202/8b061db1-8394-4be3-87a8-59ce808f0445> a WB:WBGene00003202,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003202/b7bec127-5ab7-423f-8a94-8ae6d17b0b30> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003202/9fc590c0-0847-4bff-a009-775cff6a9659> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003202/e81d62a3-2235-4105-affc-0aa4740702f8> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003202/20ee849e-96a4-4aa8-b736-d6d4f231d96f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003202/e81d62a3-2235-4105-affc-0aa4740702f8> a WB:WBGene00003202,
+<http://model.geneontology.org/WB_WBGene00003202/be74882f-3088-43d3-8d88-9eb3047eaece> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003202/8b061db1-8394-4be3-87a8-59ce808f0445> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003202/9fc590c0-0847-4bff-a009-775cff6a9659> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003202/2608c086-fd27-4683-94e2-d083393494e6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003202/3c3e03d0-e353-47f4-a7e7-fca15864579e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003202  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000393  2021-05-13 WB  id=WBOA:3768|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003202/b7bec127-5ab7-423f-8a94-8ae6d17b0b30> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003202/e81d62a3-2235-4105-affc-0aa4740702f8> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003202/18c6b45f-3527-4a78-aca1-df0a024a4c95> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003202  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000393  2021-05-13 WB  id=WBOA:3768|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003202/b7bec127-5ab7-423f-8a94-8ae6d17b0b30> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003202/20ee849e-96a4-4aa8-b736-d6d4f231d96f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003202/be74882f-3088-43d3-8d88-9eb3047eaece> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003202/9fc590c0-0847-4bff-a009-775cff6a9659> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003202/61b83a45-be64-491b-9d68-484345cabc92> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003202  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000393  2021-05-13 WB  id=WBOA:3768|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003202/be74882f-3088-43d3-8d88-9eb3047eaece> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003202/8b061db1-8394-4be3-87a8-59ce808f0445> .
 

--- a/models/WB_WBGene00003203.ttl
+++ b/models/WB_WBGene00003203.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003203> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-18 (WB:WBGene00003203)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003203> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003203/8002d190-fa7b-4f1e-8624-c4b215f10310> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003203/84944ae9-5214-4d1a-aee6-fffa7fc8ee59> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000394" ;
+    ns1:evidence-with "WB:WBVar00000394" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003203/b6922b63-043a-4c68-9505-eb93f29c965c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003203/eb47dd18-1612-49f6-abff-da1a12ca85e8> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000394" ;
+    ns1:evidence-with "WB:WBVar00000394" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003203/786be8b2-b85d-4dc8-8a11-82fbcf67f645> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003203/66a1c309-400f-455a-96f3-3804990c6b77> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003203/abf59ae0-5bd8-443b-9809-ac30c0b15534> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003203/937eb7c0-aa12-4e27-8f7f-88007919041b> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003203/9df7aba1-3e8c-48f9-940e-5c40f697ab2f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003203/73fe1174-50f6-48a0-ae78-7bfc5987c330> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003203/937eb7c0-aa12-4e27-8f7f-88007919041b> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003203/73fe1174-50f6-48a0-ae78-7bfc5987c330> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003203/abf59ae0-5bd8-443b-9809-ac30c0b15534> a WB:WBGene00003203,
+<http://model.geneontology.org/WB_WBGene00003203/9df7aba1-3e8c-48f9-940e-5c40f697ab2f> a WB:WBGene00003203,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003203/b6922b63-043a-4c68-9505-eb93f29c965c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003203/84944ae9-5214-4d1a-aee6-fffa7fc8ee59> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003203  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000394  2021-05-13 WB  id=WBOA:3769|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003203/786be8b2-b85d-4dc8-8a11-82fbcf67f645> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003203/abf59ae0-5bd8-443b-9809-ac30c0b15534> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003203/8002d190-fa7b-4f1e-8624-c4b215f10310> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003203  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000394  2021-05-13 WB  id=WBOA:3769|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003203/786be8b2-b85d-4dc8-8a11-82fbcf67f645> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003203/937eb7c0-aa12-4e27-8f7f-88007919041b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003203/66a1c309-400f-455a-96f3-3804990c6b77> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003203/73fe1174-50f6-48a0-ae78-7bfc5987c330> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003203/eb47dd18-1612-49f6-abff-da1a12ca85e8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003203  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000394  2021-05-13 WB  id=WBOA:3769|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003203/66a1c309-400f-455a-96f3-3804990c6b77> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003203/9df7aba1-3e8c-48f9-940e-5c40f697ab2f> .
 

--- a/models/WB_WBGene00003204.ttl
+++ b/models/WB_WBGene00003204.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003204> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-20 (WB:WBGene00003204)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003204> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003204/4a9031b0-dea1-4884-a4f4-5834a2357889> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003204/229ec0c0-da42-49e7-98d8-ea63cf3cb4e1> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000404" ;
+    ns1:evidence-with "WB:WBVar00000404" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003204/72b2f342-74b7-45e1-b1d9-e94b60be5b44> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003204/d33e2b5c-a8a6-4078-94fc-422e53041345> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000404" ;
+    ns1:evidence-with "WB:WBVar00000404" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003204/4fcb6bbe-3fb9-44ca-ba23-9087574b932f> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003204/65270443-f4d6-4879-9f59-c020e9920234> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003204/79935d13-65e9-4d4c-8bab-5ab7bc8cad56> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003204/8dde08f2-1f07-4344-b173-ae5c00153812> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003204/5dc98097-56de-4a1b-b8cc-e91ebcd07ddd> a WB:WBGene00003204,
+<http://model.geneontology.org/WB_WBGene00003204/79935d13-65e9-4d4c-8bab-5ab7bc8cad56> a WB:WBGene00003204,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003204/679ed2af-2ca0-4993-acd9-d2d29c63b7c2> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003204/8dde08f2-1f07-4344-b173-ae5c00153812> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003204/5dc98097-56de-4a1b-b8cc-e91ebcd07ddd> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003204/4fcb6bbe-3fb9-44ca-ba23-9087574b932f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003204/4a9031b0-dea1-4884-a4f4-5834a2357889> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003204/d33e2b5c-a8a6-4078-94fc-422e53041345> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003204  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000404  2021-05-13 WB  id=WBOA:3770|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003204/679ed2af-2ca0-4993-acd9-d2d29c63b7c2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003204/5dc98097-56de-4a1b-b8cc-e91ebcd07ddd> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003204/72b2f342-74b7-45e1-b1d9-e94b60be5b44> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003204  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000404  2021-05-13 WB  id=WBOA:3770|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003204/679ed2af-2ca0-4993-acd9-d2d29c63b7c2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003204/4fcb6bbe-3fb9-44ca-ba23-9087574b932f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003204/65270443-f4d6-4879-9f59-c020e9920234> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003204/8dde08f2-1f07-4344-b173-ae5c00153812> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003204/229ec0c0-da42-49e7-98d8-ea63cf3cb4e1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003204  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000404  2021-05-13 WB  id=WBOA:3770|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003204/65270443-f4d6-4879-9f59-c020e9920234> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003204/79935d13-65e9-4d4c-8bab-5ab7bc8cad56> .
 

--- a/models/WB_WBGene00003205.ttl
+++ b/models/WB_WBGene00003205.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003205> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "mel-22 (WB:WBGene00003205)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003205> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003205/7ec862e2-504f-4220-baab-b0b2d8ae09f5> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003205/9459e4b7-d1fe-49ad-aa1c-1b385aefbb8c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088011" ;
+    ns1:evidence-with "WB:WBVar00088011" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003205/8d2747de-8b9a-48c7-9533-23a9d8c2bfd6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003205/d141ca21-0269-4099-8aa5-1eb8a0fb6286> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00088011" ;
+    ns1:evidence-with "WB:WBVar00088011" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003205/04217e74-382a-4ba8-84a2-0f813ae6018f> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003205/2d18025c-58b1-4bc3-9c18-65f50c8bdd12> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003205/d27e4d12-4629-4af0-b11d-88da25e749b4> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003205/d5b8ab40-acef-42ea-9a39-6f1a80dab041> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003205/6f835553-d1d6-4e2a-a196-f031c22725df> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003205/d27e4d12-4629-4af0-b11d-88da25e749b4> a WB:WBGene00003205,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003205/7fd418fe-4a92-4f77-b7ca-549cc8d5d6ca> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003205/04217e74-382a-4ba8-84a2-0f813ae6018f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003205/7fd418fe-4a92-4f77-b7ca-549cc8d5d6ca> a WB:WBGene00003205,
+<http://model.geneontology.org/WB_WBGene00003205/d5b8ab40-acef-42ea-9a39-6f1a80dab041> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003205/7ec862e2-504f-4220-baab-b0b2d8ae09f5> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003205/9459e4b7-d1fe-49ad-aa1c-1b385aefbb8c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003205  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088011  2021-05-13 WB  id=WBOA:3771|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003205/6f835553-d1d6-4e2a-a196-f031c22725df> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003205/7fd418fe-4a92-4f77-b7ca-549cc8d5d6ca> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003205/8d2747de-8b9a-48c7-9533-23a9d8c2bfd6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003205  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088011  2021-05-13 WB  id=WBOA:3771|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003205/6f835553-d1d6-4e2a-a196-f031c22725df> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003205/04217e74-382a-4ba8-84a2-0f813ae6018f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003205/2d18025c-58b1-4bc3-9c18-65f50c8bdd12> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003205/d5b8ab40-acef-42ea-9a39-6f1a80dab041> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003205/d141ca21-0269-4099-8aa5-1eb8a0fb6286> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003205  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00088011  2021-05-13 WB  id=WBOA:3771|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003205/2d18025c-58b1-4bc3-9c18-65f50c8bdd12> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003205/d27e4d12-4629-4af0-b11d-88da25e749b4> .
 

--- a/models/WB_WBGene00003261.ttl
+++ b/models/WB_WBGene00003261.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,106 +29,110 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003261> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "mir-2 (WB:WBGene00003261)" ;
     dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003261> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003261/1ba39173-77b2-4093-a633-dbab44683598> a ECO:0000250,
+<http://model.geneontology.org/WB_WBGene00003261/2eb74e5b-746e-4d56-82fc-603e2265e133> a ECO:0000250,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002285" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-08-05" ;
-    dc:source "GO_REF:0000024" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003261/400a7060-b081-4b84-8a80-6d9469b09139> a GO:1903231,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003261/0e51cf19-7989-4de4-a3ee-75c357e155b3> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-08-05" ;
-    dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003261/4b22b04d-4e3b-4974-9740-e6f6f3dc9cab> a ECO:0000250,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002285" ;
+    ns1:evidence-with "WB:WBGene00002285" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "GO_REF:0000024" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/a26f7463-f331-426f-ab73-ad9845c4b730> a ECO:0000250,
+<http://model.geneontology.org/WB_WBGene00003261/4b828370-f09e-4aa6-91f8-7f784901b41c> a ECO:0000250,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002285" ;
+    ns1:evidence-with "WB:WBGene00002285" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
     dc:source "GO_REF:0000024" ;
+    dct:created "2015-08-05" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/dd274bb7-d6b5-45d5-9c39-093803d6696c> a ECO:0000250,
+<http://model.geneontology.org/WB_WBGene00003261/7244bda7-c61b-4e9e-8812-db883259c6f5> a GO:1903231,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002285" ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003261/891296c7-d4d6-41c3-8b82-aa3062188f93> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
-    dc:source "GO_REF:0000024" ;
+    dct:created "2015-08-05" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/dde773be-63b6-47a5-9c28-40a2acfafda5> a WB:WBGene00003261,
+<http://model.geneontology.org/WB_WBGene00003261/95a19d99-7159-49ae-aab6-66928de789f8> a WB:WBGene00003261,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003261/1c4d9d49-19c5-4cb8-bdf4-6a37cfe8008c> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003261/203b6b93-5748-4033-add9-654c97ed7014> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/0e51cf19-7989-4de4-a3ee-75c357e155b3> a WB:WBGene00003261,
+<http://model.geneontology.org/WB_WBGene00003261/a995baac-0401-4bb8-8604-2600cbb8e1d7> a ECO:0000250,
         owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00002285" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
+    dc:source "GO_REF:0000024" ;
     dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/1c4d9d49-19c5-4cb8-bdf4-6a37cfe8008c> a GO:0016442,
+<http://model.geneontology.org/WB_WBGene00003261/fa29c255-fb6f-4558-81f8-94b322e12a95> a ECO:0000250,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00002285" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-08-05" ;
+    dc:source "GO_REF:0000024" ;
+    dct:created "2015-08-05" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003261/203b6b93-5748-4033-add9-654c97ed7014> a GO:0016442,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/53749eac-4901-43c9-bf5f-9fd9a8883402> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003261/5988ba3b-55b0-44bd-ad70-f5abdc6fa507> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003261/97a4e403-8e0f-4b2e-b41b-dafd4e9cc467> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-08-05" ;
-    dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003261/5988ba3b-55b0-44bd-ad70-f5abdc6fa507> a GO:0035194,
+<http://model.geneontology.org/WB_WBGene00003261/2c3ccef0-cba5-4242-8502-18e69c66c28f> a WB:WBGene00003261,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
     dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003261/97a4e403-8e0f-4b2e-b41b-dafd4e9cc467> a WB:WBGene00003261,
+<http://model.geneontology.org/WB_WBGene00003261/891296c7-d4d6-41c3-8b82-aa3062188f93> a WB:WBGene00003261,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
     dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003261/9aa7b79e-8e0d-411f-a692-781453ddca1d> a GO:0035194,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-08-05" ;
+    dct:created "2015-08-05" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003261/c4714faf-240e-4d11-903b-4fc0b91f8cfe> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003261/9aa7b79e-8e0d-411f-a692-781453ddca1d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003261/2c3ccef0-cba5-4242-8502-18e69c66c28f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-08-05" ;
+    dct:created "2015-08-05" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -136,50 +140,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003261/dd274bb7-d6b5-45d5-9c39-093803d6696c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003261/a995baac-0401-4bb8-8604-2600cbb8e1d7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
     dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003261  RO:0002331 GO:0035194 GO_REF:0000024 ECO:0000250 WB:WBGene00002285  2015-08-05 WB  id=WBOA:89549|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-08-05T13:31|modification-date=2015-08-05T13:31" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/53749eac-4901-43c9-bf5f-9fd9a8883402> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/5988ba3b-55b0-44bd-ad70-f5abdc6fa507> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003261/a26f7463-f331-426f-ab73-ad9845c4b730> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-08-05" ;
-    dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003261  RO:0002331 GO:0035194 GO_REF:0000024 ECO:0000250 WB:WBGene00002285  2015-08-05 WB  id=WBOA:89549|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-08-05T13:31|modification-date=2015-08-05T13:31" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/53749eac-4901-43c9-bf5f-9fd9a8883402> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/97a4e403-8e0f-4b2e-b41b-dafd4e9cc467> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/c4714faf-240e-4d11-903b-4fc0b91f8cfe> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/2c3ccef0-cba5-4242-8502-18e69c66c28f> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003261/1ba39173-77b2-4093-a633-dbab44683598> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003261/4b828370-f09e-4aa6-91f8-7f784901b41c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-08-05" ;
     dct:created "2015-08-05" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003261  RO:0002331 GO:0035194 GO_REF:0000024 ECO:0000250 WB:WBGene00002285  2015-08-05 WB  id=WBOA:89549|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-08-05T13:31|modification-date=2015-08-05T13:31" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/c4714faf-240e-4d11-903b-4fc0b91f8cfe> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/9aa7b79e-8e0d-411f-a692-781453ddca1d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003261/fa29c255-fb6f-4558-81f8-94b322e12a95> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-08-05" ;
+    dct:created "2015-08-05" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003261  RO:0002327 GO:1903231 GO_REF:0000024 ECO:0000250 WB:WBGene00002285  2015-08-05 WB  id=WBOA:89550|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-08-05T13:31|modification-date=2015-08-05T13:31" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/400a7060-b081-4b84-8a80-6d9469b09139> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/0e51cf19-7989-4de4-a3ee-75c357e155b3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/7244bda7-c61b-4e9e-8812-db883259c6f5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/891296c7-d4d6-41c3-8b82-aa3062188f93> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003261/4b22b04d-4e3b-4974-9740-e6f6f3dc9cab> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003261/2eb74e5b-746e-4d56-82fc-603e2265e133> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003261  BFO:0000050 GO:0016442 GO_REF:0000024 ECO:0000250 WB:WBGene00002285  2020-05-13 WB  id=WBOA:89548|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/dde773be-63b6-47a5-9c28-40a2acfafda5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/1c4d9d49-19c5-4cb8-bdf4-6a37cfe8008c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003261/95a19d99-7159-49ae-aab6-66928de789f8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003261/203b6b93-5748-4033-add9-654c97ed7014> .
 

--- a/models/WB_WBGene00003262.ttl
+++ b/models/WB_WBGene00003262.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,389 +29,413 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003262> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:title "mir-34 (WB:WBGene00003262)" ;
     dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003262> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003262/0d3b2414-2f04-4de9-8da1-c22dbd6e2ec0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/0b1b008b-9b72-4991-9a88-122843843a5d> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090815" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dc:source "PMID:22081425" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/1943100a-f8bc-494c-8b94-1e34f3e590eb> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090815" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dc:source "PMID:22081425" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/256ff972-73cb-44b7-acda-de19c623d761> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00020706" ;
+    ns1:evidence-with "WB:WBGene00013595" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dc:source "PMID:22081425" ;
+    dct:created "2011-11-15" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/281852ee-4f16-4285-a02c-3b53d79db627> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/0bcc45b3-3460-4409-90e0-eaaab9229c16> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/1c21eb27-9ba7-498d-a467-6f632604ee3a> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dc:source "PMID:19421141" ;
+    dct:created "2009-11-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/3004c4ee-2347-496a-bf03-5521be40122e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/21761c97-d1b6-45a5-a7de-f32855179ea4> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dc:source "PMID:19421141" ;
+    dct:created "2009-11-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/3bb1621c-ef8b-465d-bee4-b79b5c069bbc> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003262/31e88a1b-e0b4-42c5-8e7d-d61717c9d805> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00013595" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dc:source "PMID:19421141" ;
+    dct:created "2009-11-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/37cebc2d-b391-4202-99f6-9426637b0708> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00145843" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dc:source "PMID:19421141" ;
+    dct:created "2009-11-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/3afa6e44-0f28-4ef4-b6bc-82c7ca6b472e> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090815" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/4de330e9-e7dd-4efd-8dd5-ec73f2d739e3> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090815" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/5a35d90c-df7b-4096-8c5f-54f5a745b54b> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000247" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dc:source "PMID:22081425" ;
+    dct:created "2011-11-15" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/4919cec2-93af-4839-8e2c-e0a12afbd63e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/71c84e4c-3985-4dd5-beaf-fd61d8328845> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dc:source "PMID:19421141" ;
+    dct:created "2009-11-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/4fe3b7c6-314e-46de-bd22-0096e5f5f527> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/7af338a0-03c0-4c9d-8d13-4724eac83449> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dc:source "PMID:22081425" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/54ff3634-1297-41fa-a0cc-e7734e2269de> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00020706" ;
+    ns1:evidence-with "WB:WBGene00013595" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dc:source "PMID:22081425" ;
+    dct:created "2011-11-15" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/56ab15cf-ec5e-4530-b886-698189ede392> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/8078848b-9e01-4544-b973-1f2f7b4d6bb0> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/5f1a9786-cad9-49fd-8d39-04964e0bc340> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003262/8f24fa41-916d-427f-879a-369d578712d1> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000247" ;
+    ns1:evidence-with "WB:WBVar00090815" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/98fcd6c4-fcfc-48bb-baa2-9bf1d2e796ae> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00020706" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dc:source "PMID:22081425" ;
+    dct:created "2011-11-15" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/63967294-e1e4-4984-8699-83d82acc898f> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003262/9c420f3f-4107-4564-a840-42acb6a64db4> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00013595" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2011-11-15" ;
-    dc:source "PMID:22081425" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/70113c53-f495-4470-adf8-481c75ebbc3a> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090815" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/7ee324c1-1b90-497c-9414-6154f1b404e6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/9fb4aea4-adf9-48d8-9cad-c7dcfac2e0ae> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/81046117-3517-4c50-8ded-4bdf9a53c2b3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/a81d2a75-6810-49fa-a00f-933037fcfa66> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090815" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dc:source "PMID:22081425" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/83a16ab1-87e0-4dd6-a87e-14f5f894ed8b> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090815" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dc:source "PMID:22081425" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/9f647932-00fc-48a3-a5ff-5b01b7df9194> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dc:source "PMID:19421141" ;
+    dct:created "2009-11-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/a31ed74a-3f83-49d9-96a1-f3b7056b7231> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/a967bc68-2276-48d4-bd87-84827d051028> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dc:source "PMID:19421141" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/a4930049-ae91-458d-a5c3-9278349a1c3c> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/a7978f66-a097-494e-856e-dd61e3ba7a62> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003262/ad65f6b5-446f-4844-b1ca-2de7f46f3d43> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000247" ;
+    ns1:evidence-with "WB:WBVar00145843" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/af6aaa81-2395-4900-9731-94b8f8c35442> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000247" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dc:source "PMID:22081425" ;
+    dct:created "2011-11-15" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/a7fee153-a47e-450c-b167-51469945359b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/e69c7d22-6293-49e5-bf72-0793e13232c9> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBGene00020706" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2011-11-15" ;
+    dc:source "PMID:22081425" ;
+    dct:created "2011-11-15" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/ef297faf-de0e-4102-a5b1-3348f337c122> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00090815" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/af01fc11-7f25-4539-98e2-327c1bd2fe3d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/f5785254-2f51-427c-8d3a-205b7bcfb9a6> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dc:source "PMID:19421141" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/bdce4d3a-92dc-40ef-bab5-93bf6d97a4fa> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00145843" ;
+    ns1:evidence-with "WB:WBVar00090815" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/c17d7fe3-9c10-447b-91a3-11fbc34942cc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003262/fb3ce394-fcc7-4b68-8dfc-83be46105798> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00090815" ;
+    ns1:evidence-with "WB:WBVar00090815" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dc:source "PMID:22081425" ;
+    dct:created "2021-04-14" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/01e1c349-eccc-4884-be3b-cae4c7f45f60> a GO:0006979,
+<http://model.geneontology.org/WB_WBGene00003262/0cfc2619-ab5d-4cdc-a920-838dfa31fd78> a WB:WBGene00003262,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/1c2af4cd-0bba-457f-a682-c13624e5ee9b> a WB:WBGene00003262,
+<http://model.geneontology.org/WB_WBGene00003262/2e67cee7-67e1-4eca-9464-6e4675f6a702> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/3e089083-1dbc-43e2-b317-55ecc531c8e7> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/d12e46a3-db19-4251-bed2-9173a13af6e9> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/3dd6f4d4-33e9-49c3-9582-027e688dacda> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/aafe4f19-5259-4fc8-812f-99983c6c750b> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/7d06de87-72cf-4d55-a5f5-0aaf5556116f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/3e089083-1dbc-43e2-b317-55ecc531c8e7> a GO:0009314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/373bd1d7-dd17-4686-9804-3c18cb7beafc> a WB:WBGene00003262,
+<http://model.geneontology.org/WB_WBGene00003262/4be2a381-0c68-485d-8949-29c180c00665> a GO:0008340,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/3c04d15f-85b1-40f7-94a0-5a4460d5050f> a GO:0009314,
+<http://model.geneontology.org/WB_WBGene00003262/506cc299-8262-44e2-a103-b1788b33b623> a GO:0006915,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/3fa1342c-7ebf-47c2-9815-0d68f1b7b513> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/f2c0f415-6cff-46b1-b390-888a2a50bc2d> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/a3fe9f34-7dcc-4d1a-8414-8f944802d637> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/568ae55a-e521-46fd-821b-74e2aa3d7302> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/6f1d8727-7f27-4d75-9f85-cb1d526e0e02> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/373bd1d7-dd17-4686-9804-3c18cb7beafc> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/6f1d8727-7f27-4d75-9f85-cb1d526e0e02> a GO:0008340,
+<http://model.geneontology.org/WB_WBGene00003262/577d9893-c5c0-493e-8faa-272adce5dd0d> a WB:WBGene00003262,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/6fce05e0-bf12-4c6f-b667-98ef9aab02d0> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00003262/58b356cd-a23c-4cb3-bd49-2c8297621e44> a GO:0003674,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/7245b75f-42d9-45f6-a3f8-34b0a2c4d48e> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/01e1c349-eccc-4884-be3b-cae4c7f45f60> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/d62ace29-e756-4076-9131-8be252363a49> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/7760e6b3-89c4-4e81-8f7e-2a1d8e54225e> a WB:WBGene00003262,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/79e4dca4-3311-4b34-ba4f-e05cc55bbabd> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/3c04d15f-85b1-40f7-94a0-5a4460d5050f> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/1c2af4cd-0bba-457f-a682-c13624e5ee9b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/80b4fce4-45af-4d00-b7ed-fc7b51825636> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/851606ec-7560-416e-8c1c-df859d9c10c6> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/a666c085-3ef7-4a56-9cb8-9eb2b1b4a8a6> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/f778bb84-e762-4c98-803d-847e44577c69> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/877a7a93-77b4-4914-94f7-80d9cd8712a0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dct:created "2011-11-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/851606ec-7560-416e-8c1c-df859d9c10c6> a GO:0010507,
+<http://model.geneontology.org/WB_WBGene00003262/6a6392e9-54ba-4855-9ede-1826d63aaf05> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/c49daed7-07f8-4f72-9f45-54d24ec0d1c2> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/0cfc2619-ab5d-4cdc-a920-838dfa31fd78> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2011-11-15" ;
-    dct:created "2011-11-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/86586f87-15ba-4f78-88fd-88e53cc7c437> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003262/6b356800-24b4-4211-8469-07dfad7e2576> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/d5124088-b855-49e5-81cc-712f58b50af1> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/e9871cf2-b8c5-47c1-a148-afceef24e199> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/4be2a381-0c68-485d-8949-29c180c00665> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/577d9893-c5c0-493e-8faa-272adce5dd0d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/7d06de87-72cf-4d55-a5f5-0aaf5556116f> a WB:WBGene00003262,
+        owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/a3fe9f34-7dcc-4d1a-8414-8f944802d637> a WB:WBGene00003262,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003262/a666c085-3ef7-4a56-9cb8-9eb2b1b4a8a6> a WB:WBGene00003262,
+<http://model.geneontology.org/WB_WBGene00003262/877a7a93-77b4-4914-94f7-80d9cd8712a0> a WB:WBGene00003262,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dct:created "2011-11-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/d5124088-b855-49e5-81cc-712f58b50af1> a GO:0006974,
+<http://model.geneontology.org/WB_WBGene00003262/8bbbdd56-26ba-4e07-9cc1-e71227e73649> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/dc656463-c7ca-4ec6-b3f3-d9c7401d42c1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/f06d0aaf-1cc3-4745-9ff9-4676b831544a> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/aafe4f19-5259-4fc8-812f-99983c6c750b> a GO:0006974,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/d62ace29-e756-4076-9131-8be252363a49> a WB:WBGene00003262,
+<http://model.geneontology.org/WB_WBGene00003262/bcc62bc0-01da-4bdc-85e6-7cd363f46f81> a WB:WBGene00003262,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/c49daed7-07f8-4f72-9f45-54d24ec0d1c2> a GO:0009408,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/dfb21f47-a3cb-4f97-a2dc-3d330efdd2b1> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003262/d12e46a3-db19-4251-bed2-9173a13af6e9> a WB:WBGene00003262,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/6fce05e0-bf12-4c6f-b667-98ef9aab02d0> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/7760e6b3-89c4-4e81-8f7e-2a1d8e54225e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/dc656463-c7ca-4ec6-b3f3-d9c7401d42c1> a GO:0006979,
+        owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/e9871cf2-b8c5-47c1-a148-afceef24e199> a WB:WBGene00003262,
+<http://model.geneontology.org/WB_WBGene00003262/edac9085-b917-4e31-946c-08775561b7ac> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003262/506cc299-8262-44e2-a103-b1788b33b623> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003262/bcc62bc0-01da-4bdc-85e6-7cd363f46f81> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2009-11-23" ;
     dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003262/f2c0f415-6cff-46b1-b390-888a2a50bc2d> a GO:0006915,
+<http://model.geneontology.org/WB_WBGene00003262/f06d0aaf-1cc3-4745-9ff9-4676b831544a> a WB:WBGene00003262,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003262/f778bb84-e762-4c98-803d-847e44577c69> a GO:0010507,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2011-11-15" ;
+    dct:created "2011-11-15" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -419,190 +443,190 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/256ff972-73cb-44b7-acda-de19c623d761>,
-        <http://model.geneontology.org/WB_WBGene00003262/63967294-e1e4-4984-8699-83d82acc898f>,
-        <http://model.geneontology.org/WB_WBGene00003262/a7978f66-a097-494e-856e-dd61e3ba7a62> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/0bcc45b3-3460-4409-90e0-eaaab9229c16>,
+        <http://model.geneontology.org/WB_WBGene00003262/ef297faf-de0e-4102-a5b1-3348f337c122> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006979 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12295|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
+        "WB:WBGene00003262  RO:0002331 GO:0006979 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89585|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/8bbbdd56-26ba-4e07-9cc1-e71227e73649> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/f06d0aaf-1cc3-4745-9ff9-4676b831544a> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/31e88a1b-e0b4-42c5-8e7d-d61717c9d805> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009314 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/2e67cee7-67e1-4eca-9464-6e4675f6a702> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/d12e46a3-db19-4251-bed2-9173a13af6e9> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/a81d2a75-6810-49fa-a00f-933037fcfa66> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009314 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/2e67cee7-67e1-4eca-9464-6e4675f6a702> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/3e089083-1dbc-43e2-b317-55ecc531c8e7> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/37cebc2d-b391-4202-99f6-9426637b0708> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006974 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/3dd6f4d4-33e9-49c3-9582-027e688dacda> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/7d06de87-72cf-4d55-a5f5-0aaf5556116f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/71c84e4c-3985-4dd5-beaf-fd61d8328845> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006915 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/edac9085-b917-4e31-946c-08775561b7ac> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/bcc62bc0-01da-4bdc-85e6-7cd363f46f81> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/3afa6e44-0f28-4ef4-b6bc-82c7ca6b472e>,
+        <http://model.geneontology.org/WB_WBGene00003262/ad65f6b5-446f-4844-b1ca-2de7f46f3d43> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009408 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12294|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
+        "WB:WBGene00003262  RO:0002331 GO:0009408 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89584|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/6a6392e9-54ba-4855-9ede-1826d63aaf05> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/c49daed7-07f8-4f72-9f45-54d24ec0d1c2> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/7af338a0-03c0-4c9d-8d13-4724eac83449>,
+        <http://model.geneontology.org/WB_WBGene00003262/98fcd6c4-fcfc-48bb-baa2-9bf1d2e796ae>,
+        <http://model.geneontology.org/WB_WBGene00003262/af6aaa81-2395-4900-9731-94b8f8c35442> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-11-15" ;
     dct:created "2011-11-15" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00000247  2011-11-15 WB  id=WBOA:12297|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15",
+        "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00013595  2011-11-15 WB  id=WBOA:12296|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15",
+        "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00020706  2011-11-15 WB  id=WBOA:12298|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/58b356cd-a23c-4cb3-bd49-2c8297621e44> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/f778bb84-e762-4c98-803d-847e44577c69> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/8078848b-9e01-4544-b973-1f2f7b4d6bb0>,
+        <http://model.geneontology.org/WB_WBGene00003262/8f24fa41-916d-427f-879a-369d578712d1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-04-14" ;
+    dct:created "2021-04-14" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0008340 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12293|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
+        "WB:WBGene00003262  RO:0002331 GO:0008340 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89583|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/6b356800-24b4-4211-8469-07dfad7e2576> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/577d9893-c5c0-493e-8faa-272adce5dd0d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/0b1b008b-9b72-4991-9a88-122843843a5d>,
+        <http://model.geneontology.org/WB_WBGene00003262/5a35d90c-df7b-4096-8c5f-54f5a745b54b>,
+        <http://model.geneontology.org/WB_WBGene00003262/e69c7d22-6293-49e5-bf72-0793e13232c9> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2011-11-15" ;
+    dct:created "2011-11-15" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00000247  2011-11-15 WB  id=WBOA:12297|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15",
         "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00013595  2011-11-15 WB  id=WBOA:12296|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15",
         "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00020706  2011-11-15 WB  id=WBOA:12298|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/80b4fce4-45af-4d00-b7ed-fc7b51825636> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/a666c085-3ef7-4a56-9cb8-9eb2b1b4a8a6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/58b356cd-a23c-4cb3-bd49-2c8297621e44> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/877a7a93-77b4-4914-94f7-80d9cd8712a0> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/4919cec2-93af-4839-8e2c-e0a12afbd63e> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006974 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/86586f87-15ba-4f78-88fd-88e53cc7c437> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/e9871cf2-b8c5-47c1-a148-afceef24e199> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/a7fee153-a47e-450c-b167-51469945359b>,
-        <http://model.geneontology.org/WB_WBGene00003262/c17d7fe3-9c10-447b-91a3-11fbc34942cc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/4de330e9-e7dd-4efd-8dd5-ec73f2d739e3>,
+        <http://model.geneontology.org/WB_WBGene00003262/a967bc68-2276-48d4-bd87-84827d051028> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0008340 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12293|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
-        "WB:WBGene00003262  RO:0002331 GO:0008340 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89583|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/568ae55a-e521-46fd-821b-74e2aa3d7302> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/373bd1d7-dd17-4686-9804-3c18cb7beafc> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/3bb1621c-ef8b-465d-bee4-b79b5c069bbc>,
-        <http://model.geneontology.org/WB_WBGene00003262/54ff3634-1297-41fa-a0cc-e7734e2269de>,
-        <http://model.geneontology.org/WB_WBGene00003262/5f1a9786-cad9-49fd-8d39-04964e0bc340> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2011-11-15" ;
-    dct:created "2011-11-15" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00000247  2011-11-15 WB  id=WBOA:12297|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15",
-        "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00013595  2011-11-15 WB  id=WBOA:12296|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15",
-        "WB:WBGene00003262  RO:0002331 GO:0010507 WB:WBPaper00040404|PMID:22081425 ECO:0000316 WB:WBGene00020706  2011-11-15 WB  id=WBOA:12298|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-11-15|modification-date=2011-11-15" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/80b4fce4-45af-4d00-b7ed-fc7b51825636> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/851606ec-7560-416e-8c1c-df859d9c10c6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/1943100a-f8bc-494c-8b94-1e34f3e590eb>,
-        <http://model.geneontology.org/WB_WBGene00003262/bdce4d3a-92dc-40ef-bab5-93bf6d97a4fa> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009408 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12294|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
-        "WB:WBGene00003262  RO:0002331 GO:0009408 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89584|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/dfb21f47-a3cb-4f97-a2dc-3d330efdd2b1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/6fce05e0-bf12-4c6f-b667-98ef9aab02d0> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/3004c4ee-2347-496a-bf03-5521be40122e> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009314 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/79e4dca4-3311-4b34-ba4f-e05cc55bbabd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/3c04d15f-85b1-40f7-94a0-5a4460d5050f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/0d3b2414-2f04-4de9-8da1-c22dbd6e2ec0>,
-        <http://model.geneontology.org/WB_WBGene00003262/56ab15cf-ec5e-4530-b886-698189ede392> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006979 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12295|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
-        "WB:WBGene00003262  RO:0002331 GO:0006979 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89585|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/7245b75f-42d9-45f6-a3f8-34b0a2c4d48e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/01e1c349-eccc-4884-be3b-cae4c7f45f60> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/af01fc11-7f25-4539-98e2-327c1bd2fe3d> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006915 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/3fa1342c-7ebf-47c2-9815-0d68f1b7b513> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/a3fe9f34-7dcc-4d1a-8414-8f944802d637> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/281852ee-4f16-4285-a02c-3b53d79db627> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006974 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/86586f87-15ba-4f78-88fd-88e53cc7c437> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/d5124088-b855-49e5-81cc-712f58b50af1> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/81046117-3517-4c50-8ded-4bdf9a53c2b3>,
-        <http://model.geneontology.org/WB_WBGene00003262/a4930049-ae91-458d-a5c3-9278349a1c3c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-04-14" ;
-    dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0008340 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12293|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
         "WB:WBGene00003262  RO:0002331 GO:0008340 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89583|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/568ae55a-e521-46fd-821b-74e2aa3d7302> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/6f1d8727-7f27-4d75-9f85-cb1d526e0e02> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/6b356800-24b4-4211-8469-07dfad7e2576> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/4be2a381-0c68-485d-8949-29c180c00665> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/9f647932-00fc-48a3-a5ff-5b01b7df9194> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006915 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/3fa1342c-7ebf-47c2-9815-0d68f1b7b513> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/f2c0f415-6cff-46b1-b390-888a2a50bc2d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/a31ed74a-3f83-49d9-96a1-f3b7056b7231> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2009-11-23" ;
-    dct:created "2009-11-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009314 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/79e4dca4-3311-4b34-ba4f-e05cc55bbabd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/1c2af4cd-0bba-457f-a682-c13624e5ee9b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/70113c53-f495-4470-adf8-481c75ebbc3a>,
-        <http://model.geneontology.org/WB_WBGene00003262/7ee324c1-1b90-497c-9414-6154f1b404e6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/9fb4aea4-adf9-48d8-9cad-c7dcfac2e0ae>,
+        <http://model.geneontology.org/WB_WBGene00003262/f5785254-2f51-427c-8d3a-205b7bcfb9a6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0009408 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12294|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
         "WB:WBGene00003262  RO:0002331 GO:0009408 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89584|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/dfb21f47-a3cb-4f97-a2dc-3d330efdd2b1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/7760e6b3-89c4-4e81-8f7e-2a1d8e54225e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/6a6392e9-54ba-4855-9ede-1826d63aaf05> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/0cfc2619-ab5d-4cdc-a920-838dfa31fd78> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003262/4fe3b7c6-314e-46de-bd22-0096e5f5f527>,
-        <http://model.geneontology.org/WB_WBGene00003262/83a16ab1-87e0-4dd6-a87e-14f5f894ed8b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/21761c97-d1b6-45a5-a7de-f32855179ea4> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006974 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/3dd6f4d4-33e9-49c3-9582-027e688dacda> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/aafe4f19-5259-4fc8-812f-99983c6c750b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/1c21eb27-9ba7-498d-a467-6f632604ee3a> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2009-11-23" ;
+    dct:created "2009-11-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006915 WB:WBPaper00033129|PMID:19421141 ECO:0000315 WB:WBVar00145843  2009-11-23 WB  id=WBOA:8905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2009-11-23|modification-date=2009-11-23" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/edac9085-b917-4e31-946c-08775561b7ac> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/506cc299-8262-44e2-a103-b1788b33b623> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003262/9c420f3f-4107-4564-a840-42acb6a64db4>,
+        <http://model.geneontology.org/WB_WBGene00003262/fb3ce394-fcc7-4b68-8dfc-83be46105798> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-04-14" ;
     dct:created "2021-04-14" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003262  RO:0002331 GO:0006979 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00090815  2021-04-14 WB  id=WBOA:12295|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14",
         "WB:WBGene00003262  RO:0002331 GO:0006979 WB:WBPaper00040404|PMID:22081425 ECO:0000315 WB:WBVar00145843  2021-04-14 WB  id=WBOA:89585|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-04-14|modification-date=2021-04-14" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/7245b75f-42d9-45f6-a3f8-34b0a2c4d48e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/d62ace29-e756-4076-9131-8be252363a49> .
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003262/8bbbdd56-26ba-4e07-9cc1-e71227e73649> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003262/dc656463-c7ca-4ec6-b3f3-d9c7401d42c1> .
 

--- a/models/WB_WBGene00003263.ttl
+++ b/models/WB_WBGene00003263.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,117 +29,120 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003263> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dc:title "mir-35 (WB:WBGene00003263)" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003263> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003263/8145f9d0-1627-4249-a851-df5c5aaeba2d> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003263/78a9407b-f442-4dee-afa1-f7ba716078dc> a ECO:0000304,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-12" ;
+    dc:source "PMID:11679671" ;
+    dct:created "2004-11-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003263/86eb8549-2639-4bd6-974f-6b55f7eef410> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dc:source "PMID:11679671" ;
+    dct:created "2004-11-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003263/a18cf4f7-695b-4699-bb4f-dddfcbd832cf> a GO:0003729,
+<http://model.geneontology.org/WB_WBGene00003263/a69f861f-f7ca-4e3d-a365-b59a7a36d82d> a ECO:0000304,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003263/f2273427-d1f4-4d5d-927b-8d61f2d0adc8> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dc:source "PMID:11679671" ;
+    dct:created "2004-11-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003263/f8a59a72-b340-4a23-8603-960e85148ede> a GO:0003729,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003263/ba03bdfd-9258-4179-ba87-a36117b2717a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003263/a4af3e90-6836-4862-ade4-97417103f322> a ECO:0000304,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-12" ;
-    dc:source "PMID:11679671" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003263/a919968f-87b4-4b8e-96af-ac71368230a7> a ECO:0000304,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dc:source "PMID:11679671" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003263/3ff39a14-393c-453c-98fa-8ac2d51a9680> a GO:0050779,
+<http://model.geneontology.org/WB_WBGene00003263/769186d5-1cff-470c-96ac-7ceab1054322> a WB:WBGene00003263,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003263/5a7944a5-598f-4705-a551-975b45af178e> a WB:WBGene00003263,
+<http://model.geneontology.org/WB_WBGene00003263/94c4654c-35b2-4ae6-b23b-5523843b7343> a GO:0050779,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003263/78c79164-4f39-47e7-a9b2-9373be169385> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003263/9d7ace0f-6983-4033-98da-f48d45d8a45d> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003263/3ff39a14-393c-453c-98fa-8ac2d51a9680> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003263/5a7944a5-598f-4705-a551-975b45af178e> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003263/94c4654c-35b2-4ae6-b23b-5523843b7343> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003263/769186d5-1cff-470c-96ac-7ceab1054322> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003263/f2273427-d1f4-4d5d-927b-8d61f2d0adc8> a WB:WBGene00003263,
+<http://model.geneontology.org/WB_WBGene00003263/ba03bdfd-9258-4179-ba87-a36117b2717a> a WB:WBGene00003263,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003263/8145f9d0-1627-4249-a851-df5c5aaeba2d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003263/a69f861f-f7ca-4e3d-a365-b59a7a36d82d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003263  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3897|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T10:20|modification-date=2004-11-03T10:20" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003263/78c79164-4f39-47e7-a9b2-9373be169385> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003263/3ff39a14-393c-453c-98fa-8ac2d51a9680> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003263/9d7ace0f-6983-4033-98da-f48d45d8a45d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003263/94c4654c-35b2-4ae6-b23b-5523843b7343> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003263/a4af3e90-6836-4862-ade4-97417103f322> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003263/78a9407b-f442-4dee-afa1-f7ba716078dc> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003263  RO:0002327 GO:0003729 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-12 WB  id=WBOA:3899|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-12T11:13|modification-date=2004-11-12T11:13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003263/a18cf4f7-695b-4699-bb4f-dddfcbd832cf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003263/f2273427-d1f4-4d5d-927b-8d61f2d0adc8> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003263/f8a59a72-b340-4a23-8603-960e85148ede> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003263/ba03bdfd-9258-4179-ba87-a36117b2717a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003263/a919968f-87b4-4b8e-96af-ac71368230a7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003263/86eb8549-2639-4bd6-974f-6b55f7eef410> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003263  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3897|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T10:20|modification-date=2004-11-03T10:20" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003263/78c79164-4f39-47e7-a9b2-9373be169385> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003263/5a7944a5-598f-4705-a551-975b45af178e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003263/9d7ace0f-6983-4033-98da-f48d45d8a45d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003263/769186d5-1cff-470c-96ac-7ceab1054322> .
 

--- a/models/WB_WBGene00003264.ttl
+++ b/models/WB_WBGene00003264.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,117 +29,120 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003264> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dc:title "mir-36 (WB:WBGene00003264)" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003264> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003264/00fe5565-9737-4090-903d-6082190bf338> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003264/267d6b97-c6f2-401c-b987-0cedccc8c522> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-12" ;
+    dc:date "2004-11-03" ;
     dc:source "PMID:11679671" ;
+    dct:created "2004-11-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003264/068b44c1-3f25-433d-933a-02a4abbd9ec2> a GO:0003729,
+<http://model.geneontology.org/WB_WBGene00003264/26f978c7-ee0f-4025-aea5-9a7cd09762a7> a GO:0003729,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003264/ed0d6256-1fcf-4903-af32-b358c46bdcd8> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003264/88cd94fe-c216-4bc9-9dbb-2895da6989e7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003264/62962592-3405-49bc-8ae6-7d8c69e3927b> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003264/93209e66-22a8-4aaf-a8bc-30ab23e84b6e> a ECO:0000304,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-12" ;
+    dc:source "PMID:11679671" ;
+    dct:created "2004-11-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003264/f96e0ce2-ff84-4934-a901-584e8c269872> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dc:source "PMID:11679671" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003264/687ffdfd-88d8-4762-a068-d9529aadf679> a ECO:0000304,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dc:source "PMID:11679671" ;
+    dct:created "2004-11-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003264/02bab153-5773-41ec-9e4a-2640145724c0> a GO:0050779,
+<http://model.geneontology.org/WB_WBGene00003264/2ee21bf6-e8ea-4d93-ae5c-449f31daa00a> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003264/5e5a561f-3343-44bc-bd00-c68725a2124e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003264/826cecda-4bd5-447f-9654-31c004a40835> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dct:created "2004-11-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003264/5e5a561f-3343-44bc-bd00-c68725a2124e> a GO:0050779,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003264/49e257b5-677b-4c2e-b4f3-a2934a64af25> a WB:WBGene00003264,
+<http://model.geneontology.org/WB_WBGene00003264/826cecda-4bd5-447f-9654-31c004a40835> a WB:WBGene00003264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003264/bacf8522-e325-4298-b28d-9cd281f4ed0c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003264/02bab153-5773-41ec-9e4a-2640145724c0> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003264/49e257b5-677b-4c2e-b4f3-a2934a64af25> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003264/ed0d6256-1fcf-4903-af32-b358c46bdcd8> a WB:WBGene00003264,
+<http://model.geneontology.org/WB_WBGene00003264/88cd94fe-c216-4bc9-9dbb-2895da6989e7> a WB:WBGene00003264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003264/687ffdfd-88d8-4762-a068-d9529aadf679> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003264/f96e0ce2-ff84-4934-a901-584e8c269872> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003264  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3901|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T10:31|modification-date=2004-11-03T10:31" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003264/bacf8522-e325-4298-b28d-9cd281f4ed0c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003264/49e257b5-677b-4c2e-b4f3-a2934a64af25> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003264/00fe5565-9737-4090-903d-6082190bf338> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-12" ;
-    dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003264  RO:0002327 GO:0003729 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-12 WB  id=WBOA:3903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-12T11:18|modification-date=2004-11-12T11:18" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003264/068b44c1-3f25-433d-933a-02a4abbd9ec2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003264/ed0d6256-1fcf-4903-af32-b358c46bdcd8> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003264/62962592-3405-49bc-8ae6-7d8c69e3927b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003264  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3901|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T10:31|modification-date=2004-11-03T10:31" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003264/bacf8522-e325-4298-b28d-9cd281f4ed0c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003264/02bab153-5773-41ec-9e4a-2640145724c0> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003264/2ee21bf6-e8ea-4d93-ae5c-449f31daa00a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003264/5e5a561f-3343-44bc-bd00-c68725a2124e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003264/93209e66-22a8-4aaf-a8bc-30ab23e84b6e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-12" ;
+    dct:created "2004-11-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003264  RO:0002327 GO:0003729 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-12 WB  id=WBOA:3903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-12T11:18|modification-date=2004-11-12T11:18" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003264/26f978c7-ee0f-4025-aea5-9a7cd09762a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003264/88cd94fe-c216-4bc9-9dbb-2895da6989e7> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003264/267d6b97-c6f2-401c-b987-0cedccc8c522> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dct:created "2004-11-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003264  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3901|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T10:31|modification-date=2004-11-03T10:31" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003264/2ee21bf6-e8ea-4d93-ae5c-449f31daa00a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003264/826cecda-4bd5-447f-9654-31c004a40835> .
 

--- a/models/WB_WBGene00003265.ttl
+++ b/models/WB_WBGene00003265.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,117 +29,120 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003265> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dc:title "mir-37 (WB:WBGene00003265)" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003265> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003265/19a045c5-5024-4e31-b2f2-69a16322fc92> a ECO:0000304,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dc:source "PMID:11679671" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003265/4296a4db-b48c-4413-af79-fc90cbc54373> a ECO:0000304,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dc:source "PMID:11679671" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003265/a68161dc-95fd-40c4-91af-92c3df13857f> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003265/1923b9f9-bfcd-4c27-be89-107601f672ad> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dc:source "PMID:11679671" ;
+    dct:created "2004-11-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003265/c2a6b468-5895-467c-a1eb-b9af790092e2> a GO:0003729,
+<http://model.geneontology.org/WB_WBGene00003265/2301b1d1-617e-4d46-b961-c779a8199c1b> a ECO:0000304,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003265/57d2c3b4-8449-450d-b0a3-76553f27bf55> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dc:source "PMID:11679671" ;
+    dct:created "2004-11-03" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003265/605df8d4-096a-4f1f-929c-7d3fc62c7709> a GO:0003729,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003265/3a1f930d-7b93-404e-bfb3-c2ef46c80297> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003265/c1e3136e-8fb0-441f-948e-11253a79ca60> a ECO:0000304,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dc:source "PMID:11679671" ;
+    dct:created "2004-11-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003265/08fbf3ad-ab7c-44ea-9453-87819fadcf34> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003265/e528a1c1-0a2d-43cd-8f12-d911ea24576d> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003265/c0ba1f89-3bf3-4fd7-a8a5-a1a46b04d528> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003265/57d2c3b4-8449-450d-b0a3-76553f27bf55> a WB:WBGene00003265,
+<http://model.geneontology.org/WB_WBGene00003265/3a1f930d-7b93-404e-bfb3-c2ef46c80297> a WB:WBGene00003265,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-12" ;
     dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003265/c0ba1f89-3bf3-4fd7-a8a5-a1a46b04d528> a WB:WBGene00003265,
+<http://model.geneontology.org/WB_WBGene00003265/8068dabb-c10a-4fda-bc30-1f793396ddab> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003265/d38336bb-127e-49c7-accf-2dfaa1724700> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003265/87895ac5-b190-4403-abcb-d616436a4d25> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dct:created "2004-11-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003265/87895ac5-b190-4403-abcb-d616436a4d25> a WB:WBGene00003265,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003265/e528a1c1-0a2d-43cd-8f12-d911ea24576d> a GO:0050779,
+<http://model.geneontology.org/WB_WBGene00003265/d38336bb-127e-49c7-accf-2dfaa1724700> a GO:0050779,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003265/a68161dc-95fd-40c4-91af-92c3df13857f> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-12" ;
-    dct:created "2004-11-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003265  RO:0002327 GO:0003729 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-12 WB  id=WBOA:3907|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-12T11:21|modification-date=2004-11-12T11:21" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003265/c2a6b468-5895-467c-a1eb-b9af790092e2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003265/57d2c3b4-8449-450d-b0a3-76553f27bf55> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003265/19a045c5-5024-4e31-b2f2-69a16322fc92> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003265/2301b1d1-617e-4d46-b961-c779a8199c1b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003265  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T11:17|modification-date=2004-11-03T11:17" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003265/08fbf3ad-ab7c-44ea-9453-87819fadcf34> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003265/c0ba1f89-3bf3-4fd7-a8a5-a1a46b04d528> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003265/4296a4db-b48c-4413-af79-fc90cbc54373> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2004-11-03" ;
-    dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003265  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T11:17|modification-date=2004-11-03T11:17" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003265/08fbf3ad-ab7c-44ea-9453-87819fadcf34> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003265/e528a1c1-0a2d-43cd-8f12-d911ea24576d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003265/8068dabb-c10a-4fda-bc30-1f793396ddab> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003265/d38336bb-127e-49c7-accf-2dfaa1724700> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003265/c1e3136e-8fb0-441f-948e-11253a79ca60> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-03" ;
+    dct:created "2004-11-03" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003265  RO:0002331 GO:0050779 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-03 WB  id=WBOA:3905|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T11:17|modification-date=2004-11-03T11:17" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003265/8068dabb-c10a-4fda-bc30-1f793396ddab> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003265/87895ac5-b190-4403-abcb-d616436a4d25> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003265/1923b9f9-bfcd-4c27-be89-107601f672ad> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2004-11-12" ;
+    dct:created "2004-11-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003265  RO:0002327 GO:0003729 WB:WBPaper00004927|PMID:11679671 ECO:0000304   2004-11-12 WB  id=WBOA:3907|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-12T11:21|modification-date=2004-11-12T11:21" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003265/605df8d4-096a-4f1f-929c-7d3fc62c7709> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003265/3a1f930d-7b93-404e-bfb3-c2ef46c80297> .
 

--- a/models/WB_WBGene00003284.ttl
+++ b/models/WB_WBGene00003284.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003284> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dc:title "mir-56 (WB:WBGene00003284)" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003284> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003284/226fba1a-7364-44ac-b9c9-d206e2c15b42> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003284/1a9b8f38-8bc4-476e-932f-dce34d142ccf> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dc:source "PMID:12672692" ;
+    dct:created "2004-11-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003284/d5d8ea3a-c59f-4c44-b13b-14e232d76f39> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003284/55526e25-e890-461f-b2ae-2359ff1ea3d7> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dc:source "PMID:12672692" ;
+    dct:created "2004-11-03" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003284/389978eb-08ae-45d3-9169-aa18c4536fae> a GO:0050779,
+<http://model.geneontology.org/WB_WBGene00003284/27cc2982-a708-45a5-ba59-9ba91d50360c> a GO:0050779,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003284/4449c8c6-86ef-4b19-888a-bba4aaa28cf6> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003284/b1eca9dc-bf83-4d87-bdc4-d4259f9e5b5b> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003284/389978eb-08ae-45d3-9169-aa18c4536fae> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003284/6b92adaf-4abc-428e-9d36-e0bd1b71e362> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003284/27cc2982-a708-45a5-ba59-9ba91d50360c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003284/bbfb995a-a68a-4775-bbb7-451065afaca3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003284/6b92adaf-4abc-428e-9d36-e0bd1b71e362> a WB:WBGene00003284,
+<http://model.geneontology.org/WB_WBGene00003284/bbfb995a-a68a-4775-bbb7-451065afaca3> a WB:WBGene00003284,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003284/d5d8ea3a-c59f-4c44-b13b-14e232d76f39> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003284/1a9b8f38-8bc4-476e-932f-dce34d142ccf> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003284  RO:0002331 GO:0050779 WB:WBPaper00005825|PMID:12672692 ECO:0000304   2004-11-03 WB  id=WBOA:3908|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T13:18|modification-date=2004-11-03T13:18" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003284/4449c8c6-86ef-4b19-888a-bba4aaa28cf6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003284/6b92adaf-4abc-428e-9d36-e0bd1b71e362> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003284/b1eca9dc-bf83-4d87-bdc4-d4259f9e5b5b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003284/bbfb995a-a68a-4775-bbb7-451065afaca3> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003284/226fba1a-7364-44ac-b9c9-d206e2c15b42> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003284/55526e25-e890-461f-b2ae-2359ff1ea3d7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2004-11-03" ;
     dct:created "2004-11-03" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003284  RO:0002331 GO:0050779 WB:WBPaper00005825|PMID:12672692 ECO:0000304   2004-11-03 WB  id=WBOA:3908|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2004-11-03T13:18|modification-date=2004-11-03T13:18" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003284/4449c8c6-86ef-4b19-888a-bba4aaa28cf6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003284/389978eb-08ae-45d3-9169-aa18c4536fae> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003284/b1eca9dc-bf83-4d87-bdc4-d4259f9e5b5b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003284/27cc2982-a708-45a5-ba59-9ba91d50360c> .
 

--- a/models/WB_WBGene00003289.ttl
+++ b/models/WB_WBGene00003289.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003289> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dc:title "mir-61 (WB:WBGene00003289)" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003289> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003289/3fa597db-a3fe-4847-882e-ded175d34733> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003289/7950588e-1260-423b-8d85-70f8d2b68044> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dc:source "PMID:16239437" ;
+    dct:created "2009-02-20" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "This annotation is based on ectopic expression assay in coelomocytes expressing mir-61 and reporter genes." .
 
-<http://model.geneontology.org/WB_WBGene00003289/981bc145-d284-4725-9e9c-74fc62a929d6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003289/b9178526-6632-4714-9605-c8911f7c070e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dc:source "PMID:16239437" ;
+    dct:created "2009-02-20" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "This annotation is based on ectopic expression assay in coelomocytes expressing mir-61 and reporter genes." .
 
-<http://model.geneontology.org/WB_WBGene00003289/c66c88ea-09f5-4acc-8bee-056115536ac8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003289/bb0d17e2-d321-4b4a-a9ed-2bb925d2585b> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dc:source "PMID:16239437" ;
+    dct:created "2009-02-20" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "This annotation is based on ectopic expression of mir-61 in P6.p." .
 
-<http://model.geneontology.org/WB_WBGene00003289/fa548b7e-b2d4-4939-b1f1-f4c8c798bc70> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003289/f1dba230-0edb-46fa-bdac-a74e82cc6953> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dc:source "PMID:16239437" ;
+    dct:created "2009-02-20" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "This annotation is based on ectopic expression of mir-61 in P6.p." .
 
-<http://model.geneontology.org/WB_WBGene00003289/3292be53-4274-4878-942b-8a144fc64353> a GO:0040028,
+<http://model.geneontology.org/WB_WBGene00003289/200629a6-12e1-4dee-a7af-1a9195efee6e> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003289/953c2e57-6fbe-41ec-b69e-28716c5f188e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003289/24b5dead-61bc-4906-8791-cac6a4d1c2d0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003289/41f3283f-853d-4fed-b20f-2ca496a9666c> a WB:WBGene00003289,
+<http://model.geneontology.org/WB_WBGene00003289/24b5dead-61bc-4906-8791-cac6a4d1c2d0> a WB:WBGene00003289,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003289/8497d61a-c23c-41a4-86aa-d259b64e2b80> a GO:0035195,
+<http://model.geneontology.org/WB_WBGene00003289/4f196c17-8f85-48fc-a710-be817d8c7e9a> a GO:0040028,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003289/ad43f8ba-c89a-4f85-8c63-a5beeac99b29> a WB:WBGene00003289,
+<http://model.geneontology.org/WB_WBGene00003289/90f542e1-3c88-48a1-9037-7b3c530ebef4> a WB:WBGene00003289,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003289/e82b8412-c195-48ef-9486-7d4dd1d4aa9e> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003289/953c2e57-6fbe-41ec-b69e-28716c5f188e> a GO:0035195,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003289/3292be53-4274-4878-942b-8a144fc64353> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003289/ad43f8ba-c89a-4f85-8c63-a5beeac99b29> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003289/ea594bb9-0e0f-4e89-a64b-667e4ce67210> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003289/b3e4e7c4-0fbc-4615-a218-622c2593ea50> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003289/8497d61a-c23c-41a4-86aa-d259b64e2b80> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003289/41f3283f-853d-4fed-b20f-2ca496a9666c> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003289/4f196c17-8f85-48fc-a710-be817d8c7e9a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003289/90f542e1-3c88-48a1-9037-7b3c530ebef4> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003289/fa548b7e-b2d4-4939-b1f1-f4c8c798bc70> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003289/b9178526-6632-4714-9605-c8911f7c070e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2009-02-20" ;
     dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0040028 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8032|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression of mir-61 in P6.p.|creation-date=2009-02-20|modification-date=2009-02-20" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/e82b8412-c195-48ef-9486-7d4dd1d4aa9e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/ad43f8ba-c89a-4f85-8c63-a5beeac99b29> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003289/c66c88ea-09f5-4acc-8bee-056115536ac8> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-02-20" ;
-    dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0040028 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8032|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression of mir-61 in P6.p.|creation-date=2009-02-20|modification-date=2009-02-20" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/e82b8412-c195-48ef-9486-7d4dd1d4aa9e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/3292be53-4274-4878-942b-8a144fc64353> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003289/3fa597db-a3fe-4847-882e-ded175d34733> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-02-20" ;
-    dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0035195 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8033|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression assay in coelomocytes expressing mir-61 and reporter genes.|creation-date=2009-02-20|modification-date=2009-02-20" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/ea594bb9-0e0f-4e89-a64b-667e4ce67210> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/8497d61a-c23c-41a4-86aa-d259b64e2b80> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003289/981bc145-d284-4725-9e9c-74fc62a929d6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2009-02-20" ;
-    dct:created "2009-02-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0035195 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8033|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression assay in coelomocytes expressing mir-61 and reporter genes.|creation-date=2009-02-20|modification-date=2009-02-20" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/ea594bb9-0e0f-4e89-a64b-667e4ce67210> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/41f3283f-853d-4fed-b20f-2ca496a9666c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/200629a6-12e1-4dee-a7af-1a9195efee6e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/24b5dead-61bc-4906-8791-cac6a4d1c2d0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003289/f1dba230-0edb-46fa-bdac-a74e82cc6953> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-02-20" ;
+    dct:created "2009-02-20" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0040028 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8032|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression of mir-61 in P6.p.|creation-date=2009-02-20|modification-date=2009-02-20" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/b3e4e7c4-0fbc-4615-a218-622c2593ea50> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/90f542e1-3c88-48a1-9037-7b3c530ebef4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003289/7950588e-1260-423b-8d85-70f8d2b68044> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-02-20" ;
+    dct:created "2009-02-20" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0035195 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8033|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression assay in coelomocytes expressing mir-61 and reporter genes.|creation-date=2009-02-20|modification-date=2009-02-20" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/200629a6-12e1-4dee-a7af-1a9195efee6e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/953c2e57-6fbe-41ec-b69e-28716c5f188e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003289/bb0d17e2-d321-4b4a-a9ed-2bb925d2585b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2009-02-20" ;
+    dct:created "2009-02-20" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003289  RO:0002331 GO:0040028 WB:WBPaper00026909|PMID:16239437 ECO:0000315   2009-02-20 WB  id=WBOA:8032|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=This annotation is based on ectopic expression of mir-61 in P6.p.|creation-date=2009-02-20|modification-date=2009-02-20" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003289/b3e4e7c4-0fbc-4615-a218-622c2593ea50> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003289/4f196c17-8f85-48fc-a710-be817d8c7e9a> .
 

--- a/models/WB_WBGene00003299.ttl
+++ b/models/WB_WBGene00003299.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,435 +29,459 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003299> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:title "mir-71 (WB:WBGene00003299)" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003299> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003299/25cae22f-d26d-4bbc-9680-4284b9263f63> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/0b795fb3-8e8a-4694-aa80-ded727dee5d4> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
-    dc:source "PMID:22482727" ;
+    dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/2acba4a1-ef1d-4274-beb6-f947e14878cf> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/0e58c5d7-3fe7-490e-a300-df38886fb455> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-04-23" ;
     dc:source "PMID:25746291" ;
+    dct:created "2015-04-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/2c0c4d02-bfc2-4824-aeb3-c9a291f16065> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/12d7881a-d89c-4b68-8d12-6aac0c783616> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/5e371264-354c-41d9-b90b-ff8e92f155d4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/1cff8958-2f7a-48dc-8c84-5b151817faa3> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/5fb2b864-999d-43f0-bd9d-59d1971743f3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/2ced65aa-50e3-4319-9d71-907ef2a5c60e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
+    dc:date "2020-05-18" ;
     dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/60100ccc-2a2a-4375-894d-090f93daf435> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/2d994c23-015d-4db5-8cf6-a74c4988eea9> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/613f21bb-31ec-4974-a884-09d55c8da4c2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/3a6920fa-3fd2-4f4f-854c-4bb7c24c85ed> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/3abcbac8-105b-4ead-9145-335041a4219e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-04-23" ;
     dc:source "PMID:25746291" ;
+    dct:created "2015-04-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/6182c2fa-16f8-437a-894c-5bb3b655160a> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dc:source "PMID:22482727" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/64288b96-2b92-440d-9f04-08de0606b2b6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/427a01c6-3ad8-4779-8201-a6d2ff333caa> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/683e0884-ed0a-4ca8-82ce-6afc5a74de05> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/4f46540a-b328-4d96-94e9-97c561da908d> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-04-23" ;
     dc:source "PMID:25746291" ;
+    dct:created "2015-04-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/8dbc9935-0968-4970-a3fb-ada9cd8b5ae0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/51b9a4d3-67c6-42a8-9687-25d3facc7e29> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dc:source "PMID:22876200" ;
+    dc:date "2015-04-23" ;
+    dc:source "PMID:25746291" ;
+    dct:created "2015-04-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/98d5a83c-ab8d-456f-87eb-4c590e020665> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dc:source "PMID:22876200" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/a193a954-c640-4082-bc7a-8c6e850c1d28> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/65687106-88da-4b0b-a047-ed152a9ad52d> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dc:source "PMID:22482727" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/a23952ae-d1bc-413d-ba71-fd76eb52aa51> a WB:WBGene00003299,
+<http://model.geneontology.org/WB_WBGene00003299/6c0965cc-c6ee-4df3-99bf-744d6311d23f> a ECO:0000305,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/6606b15c-66a5-4a74-beac-12f6b1d5ca3a> ;
+    ns1:evidence-with "GO:0035195" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dc:source "PMID:22876200" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/6c7d6ab0-c46b-4d4b-bf39-1245d4e02b7a> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/7d7267ca-8aeb-40d8-8962-607a2e27a287> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dc:source "PMID:22482727" ;
+    dct:created "2014-09-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/7f345682-181a-4cbb-9556-6b01b161c798> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/f6adc8d2-e64b-4d26-a912-e038e40342f8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/a90ae577-e7cc-4a23-886b-d30dc28e370a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/9eaaf8cb-f94b-4480-a1cd-1cfcceccce4f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dc:source "PMID:22876200" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/ab213b04-fd27-455b-8b49-2ef8a82dc2b3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/a1dc47bb-0b6e-4c72-9036-a1f437a465a3> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dc:source "PMID:22482727" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/bb0e9e75-a457-4bdf-a05e-96bbb172c73d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/c6a8f53b-e3e7-4a8c-8909-f30ec2b95201> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/c0cb024b-8e3f-462d-8fc6-27236ff6393a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/d990c4d4-a369-4478-b9ab-c57e4329dc46> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dc:source "PMID:22482727" ;
+    dct:created "2014-09-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/e3245e81-57ef-4eda-a5e4-dd749864ba75> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/c54cdd45-0012-47d8-825c-2f490b6e8bef> a ECO:0000305,
+<http://model.geneontology.org/WB_WBGene00003299/e33ef041-c96f-43c3-a279-e5e5458897ef> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "GO:0035195" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dc:source "PMID:22876200" ;
+    dc:date "2014-09-23" ;
+    dc:source "PMID:22482727" ;
+    dct:created "2014-09-23" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/cbd284d5-de29-4374-a315-85d72448f256> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/e902ee01-40ee-4d60-9291-be52b541afea> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/dc7f989c-4f81-4ea8-9c93-ffceb5f32d34> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dc:source "PMID:25746291" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/e91b4078-83fd-4cee-ae0c-673b4843fa9a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/ee800619-9c37-4d49-a1d6-f3c9b986b835> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/ec9effad-f821-49e1-b82f-8997056fc68e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/fc6a5359-9d61-49ac-ac9a-e48831bde5d9> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dc:source "PMID:22482727" ;
+    dct:created "2014-09-23" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/08bf726b-2f36-436e-8167-e3eefebc07a0> a WB:WBGene00006575,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/42812911-395a-41da-a1d9-53ecf94f9209> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/4c4d837f-e898-48a5-b042-178f60026e3d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/c6873658-732a-4026-9207-bd08279418a5> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/5147ac22-60c1-48d4-bb95-90d3b367c608> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/56e1da5c-7847-48a1-9f07-35964faaef92> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/63331943-93b5-4517-a046-17f45c49b87d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/fd313d9b-f68b-4445-96cc-2f42e27df4e0> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/f9a97904-31ab-4df8-99c5-201aefc218ca> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/65dcf611-be7c-45a9-8932-f0980bae9cfa> a WB:WBGene00003299,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
-    dc:source "PMID:22482727" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/edf2d104-88a1-4362-840a-d3b4bb163ca9> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003299/66009ba2-b40f-4c31-9f78-f8bf7668e5fa> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/de9fc4d3-5b7c-42b9-8b29-078a3699f669> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/65dcf611-be7c-45a9-8932-f0980bae9cfa> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dc:source "PMID:22482727" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/f0f64a1d-753c-4810-a25e-84fb6035de53> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dc:source "PMID:22876200" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/0db47407-0e61-4d10-aacb-7727bc545212> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/b77ec224-df1d-466e-9c5e-028e43215d0d> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/361f73b9-2fd4-4b0f-9585-0e3852aa2b2b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/1480b503-61eb-4b3c-8166-bc5b7a44ae6a> a WB:WBGene00003299,
+<http://model.geneontology.org/WB_WBGene00003299/67a874a0-a0dd-46a0-8003-58a14fb1f0fc> a WB:WBGene00006575,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/1685f40b-3269-4cf0-98e0-299f9ec490f3> a WB:WBGene00003299,
+<http://model.geneontology.org/WB_WBGene00003299/6b791a9a-f7ab-48ad-8273-7aeabbddb4f2> a GO:0035545,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/20151f03-0f7e-44cf-9505-66db17727202> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003299/7095fe78-c8b9-4206-a359-f73afde15969> a GO:0003730,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/60f332f6-4775-4a7a-9501-33402dda9f6d> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/24846ba0-2e6e-41ff-be99-2ee6edb60878> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/24846ba0-2e6e-41ff-be99-2ee6edb60878> a WB:WBGene00003299,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/361f73b9-2fd4-4b0f-9585-0e3852aa2b2b> a WB:WBGene00003299,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/5fae50d6-a7fc-49c0-a971-e0f7ce7374a1> a GO:0003730,
-        owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/b1581541-48bc-42c4-8bff-7bda6b2fa1f5> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/fbec9613-974f-4c15-92d7-a310dd25be58> ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/67a874a0-a0dd-46a0-8003-58a14fb1f0fc> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/56e1da5c-7847-48a1-9f07-35964faaef92> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/60f332f6-4775-4a7a-9501-33402dda9f6d> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00003299/77b0a457-2dbf-4fd1-8c1c-474846165d58> a GO:0009408,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-04-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/6606b15c-66a5-4a74-beac-12f6b1d5ca3a> a GO:0016442,
+<http://model.geneontology.org/WB_WBGene00003299/7c85f85c-9d11-461f-bf90-0ef810681868> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/6b791a9a-f7ab-48ad-8273-7aeabbddb4f2> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/5147ac22-60c1-48d4-bb95-90d3b367c608> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/7ea4779c-841a-4541-83a9-d969240b9ba8> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/cdd7425f-7fcf-4cab-9eb6-197e0bc3d61d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/9d417426-c9bc-46db-b4a0-f56cf9409eca> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/95f31094-725c-454b-8041-a926eb48f252> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/9d417426-c9bc-46db-b4a0-f56cf9409eca> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/9dcba038-5ccf-4c41-93a4-faf70577d7e1> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/77b0a457-2dbf-4fd1-8c1c-474846165d58> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/95f31094-725c-454b-8041-a926eb48f252> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/a3f8710a-876e-4c59-a9d0-0bdb823786b4> a GO:0006979,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/c6873658-732a-4026-9207-bd08279418a5> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/cdd7425f-7fcf-4cab-9eb6-197e0bc3d61d> a GO:0008340,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/ce6f7938-292c-41df-a589-0b2d7d3dd664> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/a3f8710a-876e-4c59-a9d0-0bdb823786b4> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/d1be2300-2756-41d0-b81b-cd877f1337fe> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/d1be2300-2756-41d0-b81b-cd877f1337fe> a WB:WBGene00003299,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/e3964ff9-3db1-47aa-841d-bfffc26718b0> a WB:WBGene00000912,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/e72b23cf-e105-45f5-85a2-042ba1f4d44c> a WB:WBGene00000912,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/f6adc8d2-e64b-4d26-a912-e038e40342f8> a GO:0016442,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/660d6f35-f2d2-4674-8519-45c8cda535d2> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/ab3f4694-c90d-409e-843f-8bbc2d61e9b5> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/1685f40b-3269-4cf0-98e0-299f9ec490f3> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/6788374e-3450-422d-a553-8c824650ffd0> a WB:WBGene00000912,
+<http://model.geneontology.org/WB_WBGene00003299/f9a97904-31ab-4df8-99c5-201aefc218ca> a WB:WBGene00003299,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/7fdab987-b218-43df-ad51-af3543a4082d> a WB:WBGene00003299,
+<http://model.geneontology.org/WB_WBGene00003299/4c4d837f-e898-48a5-b042-178f60026e3d> a GO:0035195,
         owl:NamedIndividual ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/08bf726b-2f36-436e-8167-e3eefebc07a0> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003299/de9fc4d3-5b7c-42b9-8b29-078a3699f669> a GO:1900182,
+        owl:NamedIndividual ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/e72b23cf-e105-45f5-85a2-042ba1f4d44c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003299/8857f378-a5a6-4c64-b9cf-92114d468ad2> a WB:WBGene00006575,
+<http://model.geneontology.org/WB_WBGene00003299/fd313d9b-f68b-4445-96cc-2f42e27df4e0> a GO:0051091,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/9d9b4080-fd17-404e-b369-93d08577735f> a WB:WBGene00003299,
-        owl:NamedIndividual ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/e3964ff9-3db1-47aa-841d-bfffc26718b0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-18" ;
     dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/a5a65988-be5d-404b-a55f-86a603cd6d52> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/b259dc98-f04c-4c75-ae04-c80b23b50f39> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/9d9b4080-fd17-404e-b369-93d08577735f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/ab3f4694-c90d-409e-843f-8bbc2d61e9b5> a GO:0006979,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/ae35773a-b4ff-45c4-a6bf-36a57a9a820a> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/c33d122b-8441-4e45-a626-7571bef55843> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/1480b503-61eb-4b3c-8166-bc5b7a44ae6a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/b1581541-48bc-42c4-8bff-7bda6b2fa1f5> a WB:WBGene00006575,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/b6478d47-c134-4b96-9317-b66591167f87> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/34f0d9a5-1af8-4b7e-80ba-cf45d3a77ba5> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/7fdab987-b218-43df-ad51-af3543a4082d> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/b66a5b5d-1623-480b-bcf8-8d0d6e7eeb38> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003299/3e53a964-7087-4907-96a9-42bdcc0ee7d5> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003299/f837a592-5932-4f18-afd7-dffd459629d2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/b77ec224-df1d-466e-9c5e-028e43215d0d> a GO:0008340,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/c33d122b-8441-4e45-a626-7571bef55843> a GO:0035545,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/f837a592-5932-4f18-afd7-dffd459629d2> a WB:WBGene00003299,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/f8be79a5-53ed-4f8c-983e-30ac5d0c5a46> a WB:WBGene00000912,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/fbec9613-974f-4c15-92d7-a310dd25be58> a WB:WBGene00003299,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/34f0d9a5-1af8-4b7e-80ba-cf45d3a77ba5> a GO:0051091,
-        owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/f8be79a5-53ed-4f8c-983e-30ac5d0c5a46> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/3e53a964-7087-4907-96a9-42bdcc0ee7d5> a GO:0035195,
-        owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/8857f378-a5a6-4c64-b9cf-92114d468ad2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003299/b259dc98-f04c-4c75-ae04-c80b23b50f39> a GO:1900182,
-        owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00003299/6788374e-3450-422d-a553-8c824650ffd0> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002233 a owl:ObjectProperty .
@@ -467,250 +491,250 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/25cae22f-d26d-4bbc-9680-4284b9263f63> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/6c7d6ab0-c46b-4d4b-bf39-1245d4e02b7a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0006979 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14251|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/660d6f35-f2d2-4674-8519-45c8cda535d2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/1685f40b-3269-4cf0-98e0-299f9ec490f3> .
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035195 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14254|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/42812911-395a-41da-a1d9-53ecf94f9209> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/4c4d837f-e898-48a5-b042-178f60026e3d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/c54cdd45-0012-47d8-825c-2f490b6e8bef> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/6c0965cc-c6ee-4df3-99bf-744d6311d23f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003299  BFO:0000050 GO:0016442 WB:WBPaper00041411|PMID:22876200 ECO:0000305 GO:0035195  2020-05-13 WB  id=WBOA:14256|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/a23952ae-d1bc-413d-ba71-fd76eb52aa51> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/6606b15c-66a5-4a74-beac-12f6b1d5ca3a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7f345682-181a-4cbb-9556-6b01b161c798> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/f6adc8d2-e64b-4d26-a912-e038e40342f8> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/683e0884-ed0a-4ca8-82ce-6afc5a74de05>,
-        <http://model.geneontology.org/WB_WBGene00003299/a193a954-c640-4082-bc7a-8c6e850c1d28> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14249|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
-        "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51797|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/0db47407-0e61-4d10-aacb-7727bc545212> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/361f73b9-2fd4-4b0f-9585-0e3852aa2b2b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/c0cb024b-8e3f-462d-8fc6-27236ff6393a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0051091 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14253|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/b6478d47-c134-4b96-9317-b66591167f87> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/34f0d9a5-1af8-4b7e-80ba-cf45d3a77ba5> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/8dbc9935-0968-4970-a3fb-ada9cd8b5ae0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/2d994c23-015d-4db5-8cf6-a74c4988eea9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035195 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14254|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/3e53a964-7087-4907-96a9-42bdcc0ee7d5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/8857f378-a5a6-4c64-b9cf-92114d468ad2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/64288b96-2b92-440d-9f04-08de0606b2b6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035545 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB  id=WBOA:14257|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/ae35773a-b4ff-45c4-a6bf-36a57a9a820a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/c33d122b-8441-4e45-a626-7571bef55843> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/ec9effad-f821-49e1-b82f-8997056fc68e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:1900182 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14252|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/a5a65988-be5d-404b-a55f-86a603cd6d52> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/b259dc98-f04c-4c75-ae04-c80b23b50f39> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/e91b4078-83fd-4cee-ae0c-673b4843fa9a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0051091 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14253|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/b6478d47-c134-4b96-9317-b66591167f87> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/7fdab987-b218-43df-ad51-af3543a4082d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/2acba4a1-ef1d-4274-beb6-f947e14878cf>,
-        <http://model.geneontology.org/WB_WBGene00003299/edf2d104-88a1-4362-840a-d3b4bb163ca9> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14249|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
-        "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51797|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/0db47407-0e61-4d10-aacb-7727bc545212> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/b77ec224-df1d-466e-9c5e-028e43215d0d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/6182c2fa-16f8-437a-894c-5bb3b655160a>,
-        <http://model.geneontology.org/WB_WBGene00003299/dc7f989c-4f81-4ea8-9c93-ffceb5f32d34> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2015-04-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0009408 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14250|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
-        "WB:WBGene00003299  RO:0002331 GO:0009408 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51798|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/20151f03-0f7e-44cf-9505-66db17727202> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/60f332f6-4775-4a7a-9501-33402dda9f6d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/bb0e9e75-a457-4bdf-a05e-96bbb172c73d> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0051091 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14253|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/34f0d9a5-1af8-4b7e-80ba-cf45d3a77ba5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/f8be79a5-53ed-4f8c-983e-30ac5d0c5a46> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/a90ae577-e7cc-4a23-886b-d30dc28e370a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003299  RO:0002327 GO:0003730 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14255|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
     owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/5fae50d6-a7fc-49c0-a971-e0f7ce7374a1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/b1581541-48bc-42c4-8bff-7bda6b2fa1f5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7095fe78-c8b9-4206-a359-f73afde15969> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/67a874a0-a0dd-46a0-8003-58a14fb1f0fc> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/5e371264-354c-41d9-b90b-ff8e92f155d4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/c6a8f53b-e3e7-4a8c-8909-f30ec2b95201> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0051091 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14253|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/fd313d9b-f68b-4445-96cc-2f42e27df4e0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/e3964ff9-3db1-47aa-841d-bfffc26718b0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/e3245e81-57ef-4eda-a5e4-dd749864ba75> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0051091 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14253|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/63331943-93b5-4517-a046-17f45c49b87d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/fd313d9b-f68b-4445-96cc-2f42e27df4e0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/12d7881a-d89c-4b68-8d12-6aac0c783616> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:1900182 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14252|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/de9fc4d3-5b7c-42b9-8b29-078a3699f669> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/e72b23cf-e105-45f5-85a2-042ba1f4d44c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/51b9a4d3-67c6-42a8-9687-25d3facc7e29>,
+        <http://model.geneontology.org/WB_WBGene00003299/a1dc47bb-0b6e-4c72-9036-a1f437a465a3> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14249|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
+        "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51797|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7ea4779c-841a-4541-83a9-d969240b9ba8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/9d417426-c9bc-46db-b4a0-f56cf9409eca> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/2ced65aa-50e3-4319-9d71-907ef2a5c60e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0051091 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14253|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/63331943-93b5-4517-a046-17f45c49b87d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/f9a97904-31ab-4df8-99c5-201aefc218ca> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/427a01c6-3ad8-4779-8201-a6d2ff333caa> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035545 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB  id=WBOA:14257|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7c85f85c-9d11-461f-bf90-0ef810681868> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/6b791a9a-f7ab-48ad-8273-7aeabbddb4f2> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/9eaaf8cb-f94b-4480-a1cd-1cfcceccce4f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002327 GO:0003730 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14255|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7095fe78-c8b9-4206-a359-f73afde15969> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/56e1da5c-7847-48a1-9f07-35964faaef92> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/fc6a5359-9d61-49ac-ac9a-e48831bde5d9> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0006979 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14251|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/ce6f7938-292c-41df-a589-0b2d7d3dd664> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/d1be2300-2756-41d0-b81b-cd877f1337fe> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/0e58c5d7-3fe7-490e-a300-df38886fb455>,
+        <http://model.geneontology.org/WB_WBGene00003299/d990c4d4-a369-4478-b9ab-c57e4329dc46> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0009408 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14250|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
+        "WB:WBGene00003299  RO:0002331 GO:0009408 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51798|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/9dcba038-5ccf-4c41-93a4-faf70577d7e1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/95f31094-725c-454b-8041-a926eb48f252> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/0b795fb3-8e8a-4694-aa80-ded727dee5d4> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035195 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14254|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/42812911-395a-41da-a1d9-53ecf94f9209> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/c6873658-732a-4026-9207-bd08279418a5> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/1cff8958-2f7a-48dc-8c84-5b151817faa3> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035545 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB  id=WBOA:14257|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/ae35773a-b4ff-45c4-a6bf-36a57a9a820a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/1480b503-61eb-4b3c-8166-bc5b7a44ae6a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7c85f85c-9d11-461f-bf90-0ef810681868> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/5147ac22-60c1-48d4-bb95-90d3b367c608> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/ab213b04-fd27-455b-8b49-2ef8a82dc2b3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/e902ee01-40ee-4d60-9291-be52b541afea> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:1900182 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14252|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/66009ba2-b40f-4c31-9f78-f8bf7668e5fa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/de9fc4d3-5b7c-42b9-8b29-078a3699f669> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/ee800619-9c37-4d49-a1d6-f3c9b986b835> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-18" ;
+    dct:created "2020-05-18" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:1900182 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14252|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/66009ba2-b40f-4c31-9f78-f8bf7668e5fa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/65dcf611-be7c-45a9-8932-f0980bae9cfa> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/3a6920fa-3fd2-4f4f-854c-4bb7c24c85ed> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2014-09-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035195 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14254|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/4c4d837f-e898-48a5-b042-178f60026e3d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/08bf726b-2f36-436e-8167-e3eefebc07a0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/4f46540a-b328-4d96-94e9-97c561da908d>,
+        <http://model.geneontology.org/WB_WBGene00003299/65687106-88da-4b0b-a047-ed152a9ad52d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2015-04-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14249|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
+        "WB:WBGene00003299  RO:0002331 GO:0008340 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51797|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/7ea4779c-841a-4541-83a9-d969240b9ba8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/cdd7425f-7fcf-4cab-9eb6-197e0bc3d61d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/e33ef041-c96f-43c3-a279-e5e5458897ef> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2014-09-23" ;
+    dct:created "2014-09-23" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0006979 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14251|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/660d6f35-f2d2-4674-8519-45c8cda535d2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/ab3f4694-c90d-409e-843f-8bbc2d61e9b5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/ce6f7938-292c-41df-a589-0b2d7d3dd664> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/a3f8710a-876e-4c59-a9d0-0bdb823786b4> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/60100ccc-2a2a-4375-894d-090f93daf435> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002327 GO:0003730 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14255|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/5fae50d6-a7fc-49c0-a971-e0f7ce7374a1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/fbec9613-974f-4c15-92d7-a310dd25be58> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/98d5a83c-ab8d-456f-87eb-4c590e020665> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035195 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14254|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/b66a5b5d-1623-480b-bcf8-8d0d6e7eeb38> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/3e53a964-7087-4907-96a9-42bdcc0ee7d5> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/cbd284d5-de29-4374-a315-85d72448f256> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:1900182 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14252|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/a5a65988-be5d-404b-a55f-86a603cd6d52> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/9d9b4080-fd17-404e-b369-93d08577735f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/f0f64a1d-753c-4810-a25e-84fb6035de53> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2014-09-23" ;
-    dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0035195 WB:WBPaper00041411|PMID:22876200 ECO:0000315   2014-09-23 WB RO:0002233(WB:WBGene00006575) id=WBOA:14254|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/b66a5b5d-1623-480b-bcf8-8d0d6e7eeb38> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/f837a592-5932-4f18-afd7-dffd459629d2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/5fb2b864-999d-43f0-bd9d-59d1971743f3>,
-        <http://model.geneontology.org/WB_WBGene00003299/613f21bb-31ec-4974-a884-09d55c8da4c2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003299/3abcbac8-105b-4ead-9145-335041a4219e>,
+        <http://model.geneontology.org/WB_WBGene00003299/7d7267ca-8aeb-40d8-8962-607a2e27a287> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2015-04-23" ;
     dct:created "2014-09-23" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003299  RO:0002331 GO:0009408 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2014-09-23 WB  id=WBOA:14250|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2014-09-23T9:41|modification-date=2014-09-23T9:41",
         "WB:WBGene00003299  RO:0002331 GO:0009408 WB:WBPaper00046567|PMID:25746291 ECO:0000315   2015-04-23 WB  id=WBOA:51798|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2015-04-23T10:25|modification-date=2015-04-23T10:25" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/20151f03-0f7e-44cf-9505-66db17727202> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/24846ba0-2e6e-41ff-be99-2ee6edb60878> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003299/2c0c4d02-bfc2-4824-aeb3-c9a291f16065> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-18" ;
-    dct:created "2020-05-18" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003299  RO:0002331 GO:1900182 WB:WBPaper00040961|PMID:22482727 ECO:0000315   2020-05-18 WB RO:0002233(WB:WBGene00000912) id=WBOA:14252|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-18|modification-date=2020-05-18" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/b259dc98-f04c-4c75-ae04-c80b23b50f39> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/6788374e-3450-422d-a553-8c824650ffd0> .
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003299/9dcba038-5ccf-4c41-93a4-faf70577d7e1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003299/77b0a457-2dbf-4fd1-8c1c-474846165d58> .
 

--- a/models/WB_WBGene00003308.ttl
+++ b/models/WB_WBGene00003308.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003308> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dc:title "mir-80 (WB:WBGene00003308)" ;
     dct:created "2013-11-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003308> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003308/2151b94a-6d17-456b-8cbc-9654d36c9f78> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003308/a74388a6-d07b-4daa-95f5-a8e84f8890e9> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dc:source "PMID:24009527" ;
+    dct:created "2013-11-21" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003308/40259e0f-f83a-4e0e-a3a8-f0b5e901ef7f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003308/f1e146ae-8ba5-4207-ab18-3a7b456b05f3> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dc:source "PMID:24009527" ;
+    dct:created "2013-11-21" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003308/8de2a0e5-ce76-418b-ac5c-06b8132f528e> a GO:0010468,
+<http://model.geneontology.org/WB_WBGene00003308/4edd7319-ea34-4a2d-9bce-8bfd59efa4c7> a GO:0010468,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dct:created "2013-11-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003308/a75880fe-cee7-4e0a-ad1b-c5dc9234be67> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003308/62deca7e-b05a-40b2-8a62-914200a9abcb> a WB:WBGene00003308,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003308/8de2a0e5-ce76-418b-ac5c-06b8132f528e> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003308/c2269396-0918-4978-a0f9-a9df792db470> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dct:created "2013-11-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003308/c2269396-0918-4978-a0f9-a9df792db470> a WB:WBGene00003308,
+<http://model.geneontology.org/WB_WBGene00003308/e9d0f3d2-bf97-45ab-a8ec-ee779d36a466> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003308/4edd7319-ea34-4a2d-9bce-8bfd59efa4c7> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003308/62deca7e-b05a-40b2-8a62-914200a9abcb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dct:created "2013-11-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003308/40259e0f-f83a-4e0e-a3a8-f0b5e901ef7f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003308/f1e146ae-8ba5-4207-ab18-3a7b456b05f3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dct:created "2013-11-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003308  RO:0002331 GO:0010468 WB:WBPaper00044166|PMID:24009527 ECO:0000315   2013-11-21 WB  id=WBOA:14232|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2013-11-21T13:32|modification-date=2013-11-21T13:32" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003308/a75880fe-cee7-4e0a-ad1b-c5dc9234be67> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003308/c2269396-0918-4978-a0f9-a9df792db470> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003308/e9d0f3d2-bf97-45ab-a8ec-ee779d36a466> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003308/62deca7e-b05a-40b2-8a62-914200a9abcb> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003308/2151b94a-6d17-456b-8cbc-9654d36c9f78> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003308/a74388a6-d07b-4daa-95f5-a8e84f8890e9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2013-11-21" ;
     dct:created "2013-11-21" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003308  RO:0002331 GO:0010468 WB:WBPaper00044166|PMID:24009527 ECO:0000315   2013-11-21 WB  id=WBOA:14232|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2013-11-21T13:32|modification-date=2013-11-21T13:32" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003308/a75880fe-cee7-4e0a-ad1b-c5dc9234be67> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003308/8de2a0e5-ce76-418b-ac5c-06b8132f528e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003308/e9d0f3d2-bf97-45ab-a8ec-ee779d36a466> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003308/4edd7319-ea34-4a2d-9bce-8bfd59efa4c7> .
 

--- a/models/WB_WBGene00003312.ttl
+++ b/models/WB_WBGene00003312.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,207 +29,216 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003312> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dc:title "mir-84 (WB:WBGene00003312)" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003312> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003312/1b3987b2-1ec6-4ab0-855b-57e9857510b7> a GO:0030371,
+<http://model.geneontology.org/WB_WBGene00003312/1e8ac964-a5b7-4421-9b5d-8d6083ce0760> a ECO:0000316,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/f470f74d-a7cc-40ec-b02d-6a9cf9a1f917> ;
+    ns1:evidence-with "WB:WBGene00003039,WB:WBGene00003335" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/1f167da8-791a-4630-be3f-7f2f63b234e4> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003039" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/21aadc16-23ca-4f31-91b9-cce4ad0c47a3> a GO:0030371,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/fa4a5eb8-f7ae-4657-98ba-ddda54fa0369> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/4a39f938-d9c6-4ee8-bec0-78323b8f96b2> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003312/4747d4db-182b-4d7d-900f-02e422b6480e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039,WB:WBGene00003335" ;
+    ns1:evidence-with "WB:WBGene00003039" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/62941e8a-e8ca-472f-a541-a93c8e3664d4> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003312/4c795c68-1dbd-41c3-bfb3-4fb448be43e7> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002285" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:17065234" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/691c8d5d-1892-496c-a3d7-b82182eccbeb> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/7e328de7-b583-41ba-87e6-fd3bf8c03b1b> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002335" ;
+    ns1:evidence-with "WB:WBGene00002335" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:15766527" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/85409ac8-9b7b-4608-baa4-19af809c35a6> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003312/591d3e00-1e3e-4f5e-a951-70c307ecba29> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002285" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dc:source "PMID:17065234" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/95945605-70a9-410f-9ff1-fa6203a97fb5> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00002335" ;
+    ns1:evidence-with "WB:WBGene00002335" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:15766527" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/b60d6361-66da-49a5-9f0c-3ea108a7df42> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003312/60fb9f7d-1b15-4c4b-9bad-25729dd4fd60> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    ns1:evidence-with "WB:WBGene00002285" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
+    dc:source "PMID:17065234" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/e9e6a8af-d471-4271-94a6-dbe35708d311> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003312/71fa3f3e-96e7-4b1a-87ce-02d8f0aac931> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039,WB:WBGene00003335" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    ns1:evidence-with "WB:WBGene00002285" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
-    dc:source "PMID:16139228" ;
+    dc:source "PMID:17065234" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/f4fbc22b-b3f1-4182-a3cc-3d95bf460db7> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003312/d089b8fd-3625-4548-8549-81c61c252c25> a ECO:0000304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:11679672" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/1a82f623-2269-472d-8172-2b550538f0dd> a GO:0018996,
+<http://model.geneontology.org/WB_WBGene00003312/f3c8a0dd-c656-4499-98f8-294bc7172085> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003039,WB:WBGene00003335" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/30a455b3-e62d-48d2-afbc-a8b38211cc10> a GO:0045962,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/5290b46d-4899-41ba-ac7f-4f6978940ef9> a GO:0046580,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/4064feb1-2952-4728-870b-76e69d2250fb> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003312/54515587-44a8-4750-859e-1696eedc104c> a WB:WBGene00003312,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/77c302fc-cb0d-4af5-b854-2f50dce2cdaf> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/c2596a6d-176a-4e88-9b96-99a32f6e9c0c> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/7baee44c-1ec3-4d8c-ac46-1218a9339b0c> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/e0bba9b4-fb29-4304-85be-0e006a21080c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/bd431090-9ef3-4bc2-b7dd-72044bf65802> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/4e20ab74-ac67-41ee-bc07-b68c2a17f10f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003312/88b9a78f-276f-4ded-a71a-9da6db7f72a2> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/7150315c-9b5a-4d77-8223-5e2bff3c0769> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/69cbc9ce-4b7f-4d19-8a29-117e3bbb2c7b> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/30a455b3-e62d-48d2-afbc-a8b38211cc10> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/8cc6c64a-6b72-402d-b956-6cc8b7aa26a4> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/69cbc9ce-4b7f-4d19-8a29-117e3bbb2c7b> a WB:WBGene00003312,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/7150315c-9b5a-4d77-8223-5e2bff3c0769> a GO:0045962,
+<http://model.geneontology.org/WB_WBGene00003312/8cc6c64a-6b72-402d-b956-6cc8b7aa26a4> a WB:WBGene00003312,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/77c302fc-cb0d-4af5-b854-2f50dce2cdaf> a GO:0046580,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/a106a5f8-71e4-45c8-8b8d-7f857ad3285b> a GO:0035278,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/a258fa4f-f614-4fc6-b86e-c5c9e0dd4567> a WB:WBGene00003312,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/adb0e2f1-92f6-4ba1-8ad0-647664b28398> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/a106a5f8-71e4-45c8-8b8d-7f857ad3285b> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/a258fa4f-f614-4fc6-b86e-c5c9e0dd4567> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/afb7f6f8-a1eb-41bc-8420-48a4e2fd1888> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/1a82f623-2269-472d-8172-2b550538f0dd> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/d9f9b0dc-da15-4435-83cb-f495b0cba5c4> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/c2596a6d-176a-4e88-9b96-99a32f6e9c0c> a WB:WBGene00003312,
+<http://model.geneontology.org/WB_WBGene00003312/a0e5e958-0f69-4e0c-b391-4e46a20a63f7> a WB:WBGene00003312,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003312/d9f9b0dc-da15-4435-83cb-f495b0cba5c4> a WB:WBGene00003312,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003312/f470f74d-a7cc-40ec-b02d-6a9cf9a1f917> a WB:WBGene00003312,
+<http://model.geneontology.org/WB_WBGene00003312/b3d37618-3891-4568-a826-c7ef81eaa371> a GO:0035278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/bd431090-9ef3-4bc2-b7dd-72044bf65802> a WB:WBGene00003312,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/cf143160-9613-42eb-94f4-63aefd78b169> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/5290b46d-4899-41ba-ac7f-4f6978940ef9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/a0e5e958-0f69-4e0c-b391-4e46a20a63f7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/d32744aa-bf41-44c3-b5ae-984eda6c5af9> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003312/b3d37618-3891-4568-a826-c7ef81eaa371> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003312/54515587-44a8-4750-859e-1696eedc104c> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/e0bba9b4-fb29-4304-85be-0e006a21080c> a GO:0018996,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003312/fa4a5eb8-f7ae-4657-98ba-ddda54fa0369> a WB:WBGene00003312,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -237,110 +246,110 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/e9e6a8af-d471-4271-94a6-dbe35708d311> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/4c795c68-1dbd-41c3-bfb3-4fb448be43e7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2010-03-17 WB  id=WBOA:3912|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/cf143160-9613-42eb-94f4-63aefd78b169> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/a0e5e958-0f69-4e0c-b391-4e46a20a63f7> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/1f167da8-791a-4630-be3f-7f2f63b234e4> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039  2010-03-17 WB  id=WBOA:9446|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/88b9a78f-276f-4ded-a71a-9da6db7f72a2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/8cc6c64a-6b72-402d-b956-6cc8b7aa26a4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/591d3e00-1e3e-4f5e-a951-70c307ecba29> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2010-03-17 WB  id=WBOA:3912|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/cf143160-9613-42eb-94f4-63aefd78b169> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/5290b46d-4899-41ba-ac7f-4f6978940ef9> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/71fa3f3e-96e7-4b1a-87ce-02d8f0aac931> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00002285  2010-03-17 WB  id=WBOA:3911|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/7baee44c-1ec3-4d8c-ac46-1218a9339b0c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/e0bba9b4-fb29-4304-85be-0e006a21080c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/1e8ac964-a5b7-4421-9b5d-8d6083ce0760> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003335  2010-03-17 WB  id=WBOA:9449|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/adb0e2f1-92f6-4ba1-8ad0-647664b28398> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/a106a5f8-71e4-45c8-8b8d-7f857ad3285b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/d32744aa-bf41-44c3-b5ae-984eda6c5af9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/b3d37618-3891-4568-a826-c7ef81eaa371> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/f4fbc22b-b3f1-4182-a3cc-3d95bf460db7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/d089b8fd-3625-4548-8549-81c61c252c25> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003312  RO:0002327 GO:0030371 WB:WBPaper00004928|PMID:11679672 ECO:0000304   2010-03-17 WB  id=WBOA:3913|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/1b3987b2-1ec6-4ab0-855b-57e9857510b7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/f470f74d-a7cc-40ec-b02d-6a9cf9a1f917> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/21aadc16-23ca-4f31-91b9-cce4ad0c47a3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/fa4a5eb8-f7ae-4657-98ba-ddda54fa0369> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/95945605-70a9-410f-9ff1-fa6203a97fb5> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/60fb9f7d-1b15-4c4b-9bad-25729dd4fd60> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2010-03-17 WB  id=WBOA:3912|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/4064feb1-2952-4728-870b-76e69d2250fb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/c2596a6d-176a-4e88-9b96-99a32f6e9c0c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/85409ac8-9b7b-4608-baa4-19af809c35a6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00002285  2010-03-17 WB  id=WBOA:3911|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/afb7f6f8-a1eb-41bc-8420-48a4e2fd1888> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/1a82f623-2269-472d-8172-2b550538f0dd> .
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/7baee44c-1ec3-4d8c-ac46-1218a9339b0c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/bd431090-9ef3-4bc2-b7dd-72044bf65802> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/7e328de7-b583-41ba-87e6-fd3bf8c03b1b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0046580 WB:WBPaper00025025|PMID:15766527 ECO:0000316 WB:WBGene00002335  2010-03-17 WB  id=WBOA:3912|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/4064feb1-2952-4728-870b-76e69d2250fb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/77c302fc-cb0d-4af5-b854-2f50dce2cdaf> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/4a39f938-d9c6-4ee8-bec0-78323b8f96b2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/f3c8a0dd-c656-4499-98f8-294bc7172085> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003335  2010-03-17 WB  id=WBOA:9449|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/adb0e2f1-92f6-4ba1-8ad0-647664b28398> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/a258fa4f-f614-4fc6-b86e-c5c9e0dd4567> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/d32744aa-bf41-44c3-b5ae-984eda6c5af9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/54515587-44a8-4750-859e-1696eedc104c> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/62941e8a-e8ca-472f-a541-a93c8e3664d4> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0018996 WB:WBPaper00028747|PMID:17065234 ECO:0000316 WB:WBGene00002285  2010-03-17 WB  id=WBOA:3911|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/afb7f6f8-a1eb-41bc-8420-48a4e2fd1888> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/d9f9b0dc-da15-4435-83cb-f495b0cba5c4> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/691c8d5d-1892-496c-a3d7-b82182eccbeb> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003312/4747d4db-182b-4d7d-900f-02e422b6480e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039  2010-03-17 WB  id=WBOA:9446|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/4e20ab74-ac67-41ee-bc07-b68c2a17f10f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/69cbc9ce-4b7f-4d19-8a29-117e3bbb2c7b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003312/b60d6361-66da-49a5-9f0c-3ea108a7df42> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003312  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039  2010-03-17 WB  id=WBOA:9446|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/4e20ab74-ac67-41ee-bc07-b68c2a17f10f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/7150315c-9b5a-4d77-8223-5e2bff3c0769> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003312/88b9a78f-276f-4ded-a71a-9da6db7f72a2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003312/30a455b3-e62d-48d2-afbc-a8b38211cc10> .
 

--- a/models/WB_WBGene00003335.ttl
+++ b/models/WB_WBGene00003335.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003335> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:title "mir-241 (WB:WBGene00003335)" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003335> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003335/360de2b5-65be-47f0-9fd7-699fd9ed4a6d> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003335/b0ef5c9e-e536-4740-88bd-4d89fa00c923> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
+    ns1:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/651fc6ec-5746-43d1-80e3-82b7f46069ad> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003335/b25737a6-7b7b-481c-a823-02b503faf572> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
+    ns1:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/89f6ddd4-4a6b-4b60-b486-d18cd87094e2> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003335/e08145fa-96ff-4be8-8d51-03268640b7f3> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
+    ns1:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/b0d944ad-a1a9-4d0c-89d1-a73beda4f930> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00003335/ec53fc32-103d-40cc-8ce6-574cc264297b> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
+    ns1:evidence-with "WB:WBGene00003039,WB:WBGene00003312" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dc:source "PMID:16139228" ;
+    dct:created "2010-03-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/07c9c200-0b6a-4fed-818c-386c34cce8c2> a WB:WBGene00003335,
+<http://model.geneontology.org/WB_WBGene00003335/2624d195-2d0e-4c32-b9fa-8bd65211e315> a WB:WBGene00003335,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/2a1280c3-889d-43f2-9142-101dd74edce5> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003335/50babdc3-803b-4542-a9eb-96185ad5ecab> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003335/7b68ccb0-f899-404e-96c5-a7b876d48112> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003335/3317f6bf-b386-4a23-ab5b-fe2f652370ec> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003335/d6c5a681-3ea1-4005-b08a-dbfa4a555814> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003335/07c9c200-0b6a-4fed-818c-386c34cce8c2> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003335/50babdc3-803b-4542-a9eb-96185ad5ecab> a GO:0035278,
+<http://model.geneontology.org/WB_WBGene00003335/588beef5-0e96-40f0-b808-412249605357> a WB:WBGene00003335,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/7b68ccb0-f899-404e-96c5-a7b876d48112> a WB:WBGene00003335,
+<http://model.geneontology.org/WB_WBGene00003335/af0f257d-4008-4bbe-9fc2-892919a05b40> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003335/c52f0fd9-a86e-49e5-9527-bdae77101886> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003335/588beef5-0e96-40f0-b808-412249605357> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003335/bfdc3637-3a86-4304-bccd-7d58fc7d18f2> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003335/c698fef4-273c-4bb2-9b3a-980130f7695e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003335/2624d195-2d0e-4c32-b9fa-8bd65211e315> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003335/c52f0fd9-a86e-49e5-9527-bdae77101886> a GO:0045962,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003335/d6c5a681-3ea1-4005-b08a-dbfa4a555814> a GO:0045962,
+<http://model.geneontology.org/WB_WBGene00003335/c698fef4-273c-4bb2-9b3a-980130f7695e> a GO:0035278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003335/360de2b5-65be-47f0-9fd7-699fd9ed4a6d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003335/e08145fa-96ff-4be8-8d51-03268640b7f3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-17" ;
     dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9447|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/3317f6bf-b386-4a23-ab5b-fe2f652370ec> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/07c9c200-0b6a-4fed-818c-386c34cce8c2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003335/89f6ddd4-4a6b-4b60-b486-d18cd87094e2> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9448|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/2a1280c3-889d-43f2-9142-101dd74edce5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/50babdc3-803b-4542-a9eb-96185ad5ecab> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003335/b0d944ad-a1a9-4d0c-89d1-a73beda4f930> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9447|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/3317f6bf-b386-4a23-ab5b-fe2f652370ec> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/d6c5a681-3ea1-4005-b08a-dbfa4a555814> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003335/651fc6ec-5746-43d1-80e3-82b7f46069ad> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-17" ;
-    dct:created "2010-03-17" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9448|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/2a1280c3-889d-43f2-9142-101dd74edce5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/7b68ccb0-f899-404e-96c5-a7b876d48112> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/bfdc3637-3a86-4304-bccd-7d58fc7d18f2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/2624d195-2d0e-4c32-b9fa-8bd65211e315> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003335/ec53fc32-103d-40cc-8ce6-574cc264297b> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9447|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/af0f257d-4008-4bbe-9fc2-892919a05b40> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/588beef5-0e96-40f0-b808-412249605357> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003335/b25737a6-7b7b-481c-a823-02b503faf572> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0045962 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9447|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/af0f257d-4008-4bbe-9fc2-892919a05b40> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/c52f0fd9-a86e-49e5-9527-bdae77101886> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003335/b0ef5c9e-e536-4740-88bd-4d89fa00c923> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-17" ;
+    dct:created "2010-03-17" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003335  RO:0002331 GO:0035278 WB:WBPaper00026780|PMID:16139228 ECO:0000316 WB:WBGene00003039,WB:WBGene00003312  2010-03-17 WB  id=WBOA:9448|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-17|modification-date=2010-03-17" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003335/bfdc3637-3a86-4304-bccd-7d58fc7d18f2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003335/c698fef4-273c-4bb2-9b3a-980130f7695e> .
 

--- a/models/WB_WBGene00003366.ttl
+++ b/models/WB_WBGene00003366.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,183 +29,191 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003366> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-20" ;
     dc:title "mir-273 (WB:WBGene00003366)" ;
     dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003366> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003366/0b8cc955-256e-4000-a6f4-9d0b180696e9> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00003366/02470a9a-a2e5-488a-b140-0aa716658598> a GO:0000900,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dc:source "PMID:15306811" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/12115e66-cc6f-4207-9f44-7f524f5bce5f> a GO:0003730,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/6db59002-7989-44ef-9e03-fd6e8745da00> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-20" ;
-    dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/579df0f9-6369-4d1a-9800-6b33b3da9daf> a ECO:0000314,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-13" ;
-    dc:source "PMID:15306811" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/65882f5f-ca42-49bf-a2e2-c4d17b1ba869> a ECO:0000314,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dc:source "PMID:15306811" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/6d8b82ef-d7e3-4c9a-a1d1-36428ebc802a> a ECO:0000314,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dc:source "PMID:15306811" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/744067e0-bcc1-4bd3-9703-3e8a1a298232> a GO:0000900,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/58cec430-587b-42d8-bd89-41b271aa96a3> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/4d63af1e-a154-4a13-848c-5b3b46a60a54> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/750f050b-5a73-4c52-a111-d017580a36b5> a ECO:0000304,
+<http://model.geneontology.org/WB_WBGene00003366/3490a988-0697-4f1a-97d8-01ff69565cbf> a GO:0003730,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/18ef9225-4041-4ffc-8960-f64110f7ea44> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-20" ;
-    dc:source "PMID:15306811" ;
+    dct:created "2020-04-20" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/a1616216-f324-4bea-956e-24a19a34358d> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00003366/4c75402e-975f-450b-bc44-dbe5fae84ccc> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dc:source "PMID:14685240" ;
+    dct:created "2005-01-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/c10d8581-4d41-40a3-ae03-12c11f9184b7> a ECO:0000314,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-13" ;
-    dc:source "PMID:14685240" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/efa173bb-c5ca-49ff-839d-0178ff0bcc6f> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00003366/545fb0a8-a6f9-4141-8386-bda042d3e4f4> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-12" ;
     dc:source "PMID:15306811" ;
+    dct:created "2005-01-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/122975b1-db7b-4d5c-a7ad-4b3fe91e7121> a GO:0045167,
+<http://model.geneontology.org/WB_WBGene00003366/826a6962-18cb-49a6-929c-1c9f3e88dd4a> a ECO:0000314,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-13" ;
+    dc:source "PMID:14685240" ;
+    dct:created "2005-01-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/89d06d20-0b64-44b2-a5ee-990bfce3cc83> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-12" ;
+    dc:source "PMID:15306811" ;
     dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/35d0dd46-beea-4edf-9e62-da13e475bcfe> a WB:WBGene00003366,
+<http://model.geneontology.org/WB_WBGene00003366/a0701aed-bdc6-4d11-a180-2df82ff2baa7> a ECO:0000314,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dc:source "PMID:15306811" ;
+    dct:created "2005-01-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/a7336545-b624-4b32-bd07-69f8af1bbcb3> a ECO:0000314,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-13" ;
+    dc:source "PMID:15306811" ;
+    dct:created "2005-01-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/c220fd23-7c75-4970-b6e0-ba7005315487> a ECO:0000314,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dc:source "PMID:15306811" ;
+    dct:created "2005-01-12" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/d13fe46c-ae76-4119-8a2c-b0ac70c57477> a ECO:0000304,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-20" ;
+    dc:source "PMID:15306811" ;
+    dct:created "2020-04-20" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/0ee351b6-f700-453f-840b-af55dbcca64a> a GO:0007400,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/37011e93-e38c-4653-bb99-07d54ccc3178> a WB:WBGene00003366,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/58cec430-587b-42d8-bd89-41b271aa96a3> a WB:WBGene00003366,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-13" ;
-    dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/6db59002-7989-44ef-9e03-fd6e8745da00> a WB:WBGene00003366,
+<http://model.geneontology.org/WB_WBGene00003366/18ef9225-4041-4ffc-8960-f64110f7ea44> a WB:WBGene00003366,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-04-20" ;
     dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/812361a9-636d-4e93-8336-c6423442f9aa> a GO:0035195,
+<http://model.geneontology.org/WB_WBGene00003366/1a10e1ca-4fef-46a9-890b-f721b0146552> a WB:WBGene00003366,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-12" ;
     dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/9589ea05-180c-4928-962a-707e3accadfe> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003366/24a83b04-775f-4cf7-b175-ea6c5ef9d51b> a WB:WBGene00003366,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003366/eea46dd7-a8da-4480-a46d-152244ef396c> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/35d0dd46-beea-4edf-9e62-da13e475bcfe> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/3f2d4741-0c04-4b74-b566-fe0abeef775d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003366/0ee351b6-f700-453f-840b-af55dbcca64a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/7feeb3d1-1e1c-45c8-b9ef-2285d101badf> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/c9925994-7fbd-46df-a38e-0d2f57edd53d> a WB:WBGene00003366,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/e8f90141-8821-4f1a-b552-c4976201fe83> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003366/812361a9-636d-4e93-8336-c6423442f9aa> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/37011e93-e38c-4653-bb99-07d54ccc3178> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003366/eea46dd7-a8da-4480-a46d-152244ef396c> a GO:0007400,
+<http://model.geneontology.org/WB_WBGene00003366/4d63af1e-a154-4a13-848c-5b3b46a60a54> a WB:WBGene00003366,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003366/f0039f4b-e1c9-4540-a005-78e4ca861c37> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003366/7feeb3d1-1e1c-45c8-b9ef-2285d101badf> a WB:WBGene00003366,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003366/122975b1-db7b-4d5c-a7ad-4b3fe91e7121> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/c9925994-7fbd-46df-a38e-0d2f57edd53d> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-13" ;
+    dct:created "2005-01-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/9dee019e-915b-4231-b17c-91b3ab5774af> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003366/a37b10e1-8a18-4ca0-b7c8-fe83595e5d62> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/24a83b04-775f-4cf7-b175-ea6c5ef9d51b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-12" ;
     dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/a37b10e1-8a18-4ca0-b7c8-fe83595e5d62> a GO:0045167,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/aaf73c9e-7765-4257-aaa9-8446f957d5fa> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003366/d315a561-bfb1-42df-9a14-dde744db18a8> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003366/1a10e1ca-4fef-46a9-890b-f721b0146552> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003366/d315a561-bfb1-42df-9a14-dde744db18a8> a GO:0035195,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -213,98 +221,98 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/efa173bb-c5ca-49ff-839d-0178ff0bcc6f> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0045167 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3915|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/f0039f4b-e1c9-4540-a005-78e4ca861c37> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/122975b1-db7b-4d5c-a7ad-4b3fe91e7121> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/65882f5f-ca42-49bf-a2e2-c4d17b1ba869> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0035195 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3914|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/e8f90141-8821-4f1a-b552-c4976201fe83> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/37011e93-e38c-4653-bb99-07d54ccc3178> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/a1616216-f324-4bea-956e-24a19a34358d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/826a6962-18cb-49a6-929c-1c9f3e88dd4a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0007400 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2005-01-13 WB  id=WBOA:3916|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-13T11:14|modification-date=2005-01-13T11:14" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/9589ea05-180c-4928-962a-707e3accadfe> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/eea46dd7-a8da-4480-a46d-152244ef396c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/3f2d4741-0c04-4b74-b566-fe0abeef775d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/0ee351b6-f700-453f-840b-af55dbcca64a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/c10d8581-4d41-40a3-ae03-12c11f9184b7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/a7336545-b624-4b32-bd07-69f8af1bbcb3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-13" ;
     dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0007400 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2005-01-13 WB  id=WBOA:3916|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-13T11:14|modification-date=2005-01-13T11:14" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/9589ea05-180c-4928-962a-707e3accadfe> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/35d0dd46-beea-4edf-9e62-da13e475bcfe> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/0b8cc955-256e-4000-a6f4-9d0b180696e9> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-12" ;
-    dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0035195 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3914|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/e8f90141-8821-4f1a-b552-c4976201fe83> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/812361a9-636d-4e93-8336-c6423442f9aa> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/750f050b-5a73-4c52-a111-d017580a36b5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-04-20" ;
-    dct:created "2020-04-20" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003366  RO:0002327 GO:0003730 WB:WBPaper00024291|PMID:15306811 ECO:0000304   2020-04-20 WB  id=WBOA:3917|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-20|modification-date=2020-04-20" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/12115e66-cc6f-4207-9f44-7f524f5bce5f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/6db59002-7989-44ef-9e03-fd6e8745da00> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/579df0f9-6369-4d1a-9800-6b33b3da9daf> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2005-01-13" ;
-    dct:created "2005-01-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003366  RO:0002327 GO:0000900 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-13 WB  id=WBOA:3918|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-13T11:14|modification-date=2005-01-13T11:14" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/744067e0-bcc1-4bd3-9703-3e8a1a298232> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/58cec430-587b-42d8-bd89-41b271aa96a3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/02470a9a-a2e5-488a-b140-0aa716658598> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/4d63af1e-a154-4a13-848c-5b3b46a60a54> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003366/6d8b82ef-d7e3-4c9a-a1d1-36428ebc802a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/d13fe46c-ae76-4119-8a2c-b0ac70c57477> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-04-20" ;
+    dct:created "2020-04-20" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003366  RO:0002327 GO:0003730 WB:WBPaper00024291|PMID:15306811 ECO:0000304   2020-04-20 WB  id=WBOA:3917|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-04-20|modification-date=2020-04-20" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/3490a988-0697-4f1a-97d8-01ff69565cbf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/18ef9225-4041-4ffc-8960-f64110f7ea44> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/c220fd23-7c75-4970-b6e0-ba7005315487> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2005-01-12" ;
     dct:created "2005-01-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0035195 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3914|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/aaf73c9e-7765-4257-aaa9-8446f957d5fa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/d315a561-bfb1-42df-9a14-dde744db18a8> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/545fb0a8-a6f9-4141-8386-bda042d3e4f4> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0045167 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3915|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/f0039f4b-e1c9-4540-a005-78e4ca861c37> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/c9925994-7fbd-46df-a38e-0d2f57edd53d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/9dee019e-915b-4231-b17c-91b3ab5774af> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/24a83b04-775f-4cf7-b175-ea6c5ef9d51b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/4c75402e-975f-450b-bc44-dbe5fae84ccc> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-13" ;
+    dct:created "2005-01-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0007400 WB:WBPaper00006260|PMID:14685240 ECO:0000314   2005-01-13 WB  id=WBOA:3916|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-13T11:14|modification-date=2005-01-13T11:14" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/3f2d4741-0c04-4b74-b566-fe0abeef775d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/7feeb3d1-1e1c-45c8-b9ef-2285d101badf> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/89d06d20-0b64-44b2-a5ee-990bfce3cc83> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0045167 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3915|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/9dee019e-915b-4231-b17c-91b3ab5774af> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/a37b10e1-8a18-4ca0-b7c8-fe83595e5d62> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003366/a0701aed-bdc6-4d11-a180-2df82ff2baa7> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2005-01-12" ;
+    dct:created "2005-01-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003366  RO:0002331 GO:0035195 WB:WBPaper00024291|PMID:15306811 ECO:0000314   2005-01-12 WB  id=WBOA:3914|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2005-01-12T15:27|modification-date=2005-01-12T15:27" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003366/aaf73c9e-7765-4257-aaa9-8446f957d5fa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003366/1a10e1ca-4fef-46a9-890b-f721b0146552> .
 

--- a/models/WB_WBGene00003474.ttl
+++ b/models/WB_WBGene00003474.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,94 +29,98 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003474> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dc:title "mtl-2 (WB:WBGene00003474)" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003474> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003474/0eb06135-d9ae-4a1c-8aa8-2bb29b76fc63> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003474/80b5fa66-4692-4537-b3b6-fc3beb26c8eb> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dc:source "PMID:8428932" ;
+    dct:created "2007-05-07" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/5d662151-4e23-4ca9-9648-579aba4b4bd4> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003474/95b22246-2776-4dac-84f2-121d7cb0ada5> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dc:source "PMID:8428932" ;
+    dct:created "2007-05-07" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/7d5cc7f8-422a-4720-aabd-e056f7bc1ca5> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003474/bcd65a67-277b-410a-8da6-a6c8f2d90465> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dc:source "PMID:8428932" ;
+    dct:created "2007-05-07" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/7dbdc5c9-9f5c-44b5-a188-644b6cadbe35> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003474/fabf8b7d-1f9d-4b1c-9a52-3e2c5b1693c2> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dc:source "PMID:8428932" ;
+    dct:created "2007-05-07" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/12a0f799-2646-48bb-b952-4ca14d275aca> a WB:WBGene00003474,
+<http://model.geneontology.org/WB_WBGene00003474/10a74685-b072-4f99-acb5-71c3124634a9> a GO:0046686,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/175e4565-362b-4087-ad5c-a39e640c1ed9> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003474/57eb71d3-cf91-4a86-bcc2-8a96f2325230> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003474/68f95593-9033-4228-ba02-da1e6ccfa1b0> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003474/cae2c2a8-bbed-4e00-811c-732b9c9cb7f6> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003474/10a74685-b072-4f99-acb5-71c3124634a9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003474/dfda05e1-26ce-4a0e-ba6b-86a4716c052a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/68f95593-9033-4228-ba02-da1e6ccfa1b0> a GO:0046686,
+<http://model.geneontology.org/WB_WBGene00003474/8eab2c1f-2902-4da4-8a4a-b052bce53b95> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003474/d0b3a1e5-a4d8-43f0-863e-a21ae16a7296> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003474/b6003a93-2c5d-4fd5-8d7d-063e5a6b2d8b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/8baa0577-c808-4ea9-a768-c36003e885d1> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003474/99647956-655b-4e0b-8642-0fabec7d5d93> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003474/12a0f799-2646-48bb-b952-4ca14d275aca> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-05-07" ;
-    dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003474/99647956-655b-4e0b-8642-0fabec7d5d93> a GO:0009408,
+<http://model.geneontology.org/WB_WBGene00003474/b6003a93-2c5d-4fd5-8d7d-063e5a6b2d8b> a WB:WBGene00003474,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003474/cae2c2a8-bbed-4e00-811c-732b9c9cb7f6> a WB:WBGene00003474,
+<http://model.geneontology.org/WB_WBGene00003474/d0b3a1e5-a4d8-43f0-863e-a21ae16a7296> a GO:0009408,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003474/dfda05e1-26ce-4a0e-ba6b-86a4716c052a> a WB:WBGene00003474,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-05-07" ;
+    dct:created "2007-05-07" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -124,50 +128,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003474/5d662151-4e23-4ca9-9648-579aba4b4bd4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003474/fabf8b7d-1f9d-4b1c-9a52-3e2c5b1693c2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2007-05-07" ;
     dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0009408 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4062|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/8baa0577-c808-4ea9-a768-c36003e885d1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/12a0f799-2646-48bb-b952-4ca14d275aca> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003474/0eb06135-d9ae-4a1c-8aa8-2bb29b76fc63> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-05-07" ;
-    dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0046686 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4061|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/175e4565-362b-4087-ad5c-a39e640c1ed9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/68f95593-9033-4228-ba02-da1e6ccfa1b0> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003474/7d5cc7f8-422a-4720-aabd-e056f7bc1ca5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-05-07" ;
-    dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0046686 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4061|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/175e4565-362b-4087-ad5c-a39e640c1ed9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/cae2c2a8-bbed-4e00-811c-732b9c9cb7f6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003474/7dbdc5c9-9f5c-44b5-a188-644b6cadbe35> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2007-05-07" ;
-    dct:created "2007-05-07" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0009408 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4062|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/8baa0577-c808-4ea9-a768-c36003e885d1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/99647956-655b-4e0b-8642-0fabec7d5d93> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/8eab2c1f-2902-4da4-8a4a-b052bce53b95> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/d0b3a1e5-a4d8-43f0-863e-a21ae16a7296> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003474/bcd65a67-277b-410a-8da6-a6c8f2d90465> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-05-07" ;
+    dct:created "2007-05-07" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0046686 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4061|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/57eb71d3-cf91-4a86-bcc2-8a96f2325230> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/dfda05e1-26ce-4a0e-ba6b-86a4716c052a> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003474/95b22246-2776-4dac-84f2-121d7cb0ada5> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-05-07" ;
+    dct:created "2007-05-07" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0009408 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4062|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/8eab2c1f-2902-4da4-8a4a-b052bce53b95> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/b6003a93-2c5d-4fd5-8d7d-063e5a6b2d8b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003474/80b5fa66-4692-4537-b3b6-fc3beb26c8eb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2007-05-07" ;
+    dct:created "2007-05-07" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003474  RO:0002331 GO:0046686 WB:WBPaper00001688|PMID:8428932 ECO:0000270   2007-05-07 WB  id=WBOA:4061|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2007-05-07|modification-date=2007-05-07" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003474/57eb71d3-cf91-4a86-bcc2-8a96f2325230> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003474/10a74685-b072-4f99-acb5-71c3124634a9> .
 

--- a/models/WB_WBGene00003555.ttl
+++ b/models/WB_WBGene00003555.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,52 +29,53 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003555> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-25" ;
     dc:title "nas-39 (WB:WBGene00003555)" ;
     dct:created "2010-10-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003555> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003555/38ffa411-a7ca-439f-89ea-39dfee0cc66b> a GO:0008237,
+<http://model.geneontology.org/WB_WBGene00003555/baedf7be-60f8-4a17-9264-b5308742be80> a ECO:0000250,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003555/b53d486e-1576-4c65-b7d7-ad0238bf5594> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-10-25" ;
-    dct:created "2010-10-25" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003555/9dfaf88e-2a4e-4ee2-86f5-591902c38af9> a ECO:0000250,
-        owl:NamedIndividual ;
-    ns3:evidence-with "FB:FBgn0003719" ;
+    ns1:evidence-with "FB:FBgn0003719" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-25" ;
     dc:source "PMID:20109220" ;
+    dct:created "2010-10-25" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003555/eaeb894d-c1e4-475d-9f7f-54ce47d31178> a GO:0008237,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003555/a062da82-8923-4742-a895-90f33e97e6bd> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-10-25" ;
+    dct:created "2010-10-25" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003555/b53d486e-1576-4c65-b7d7-ad0238bf5594> a WB:WBGene00003555,
+<http://model.geneontology.org/WB_WBGene00003555/a062da82-8923-4742-a895-90f33e97e6bd> a WB:WBGene00003555,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-25" ;
     dct:created "2010-10-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003555/9dfaf88e-2a4e-4ee2-86f5-591902c38af9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003555/baedf7be-60f8-4a17-9264-b5308742be80> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-25" ;
     dct:created "2010-10-25" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003555  RO:0002327 GO:0008237 WB:WBPaper00035910|PMID:20109220 ECO:0000250 FB:FBgn0003719  2010-10-25 WB  id=WBOA:10518|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-10-25T11:54|modification-date=2010-10-25T11:54" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003555/38ffa411-a7ca-439f-89ea-39dfee0cc66b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003555/b53d486e-1576-4c65-b7d7-ad0238bf5594> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003555/eaeb894d-c1e4-475d-9f7f-54ce47d31178> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003555/a062da82-8923-4742-a895-90f33e97e6bd> .
 

--- a/models/WB_WBGene00003771.ttl
+++ b/models/WB_WBGene00003771.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,94 +29,98 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003771> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:title "nlp-33 (WB:WBGene00003771)" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003771> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003771/0d3789e4-376f-42ba-8080-4bfae6ea5374> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003771/14549678-34a0-4176-b159-41636f4fd718> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
+    dct:created "2010-03-19" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/867c34a1-6e3d-4a6e-ba3e-d7d9f26e8893> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003771/4fdd5493-d219-4fa5-a2cf-d2d7545e8636> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
+    dct:created "2010-03-19" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/f005e7ea-25f4-4fbc-a880-d5d4d6456cae> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003771/927cc658-951a-436f-ab88-c2ba4ce4268f> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
+    dct:created "2010-03-19" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/f6eabd68-9b70-4892-9b80-a05aed9088aa> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00003771/a869c2d3-e210-4d08-b2a4-86b071385c7a> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dc:source "PMID:15048112" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003771/163a2921-db2e-4e84-9c73-a0177bf6157f> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003771/4dc9f34a-6d3b-4576-8e0e-fc3785985d5e> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003771/c86f0ad3-23ec-4601-8b61-d6a27317a730> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/35b03037-ca38-4614-8b30-54b78e0d6ef9> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003771/c801f669-c6a1-4a44-8ab6-53881efc4190> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003771/7e6092aa-9e1a-4128-8465-4a35c72ccd72> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-19" ;
-    dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00003771/4dc9f34a-6d3b-4576-8e0e-fc3785985d5e> a GO:0050832,
+<http://model.geneontology.org/WB_WBGene00003771/47037e3c-8734-486b-ae65-24067a255f66> a GO:0045087,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/7e6092aa-9e1a-4128-8465-4a35c72ccd72> a WB:WBGene00003771,
+<http://model.geneontology.org/WB_WBGene00003771/4edcab08-219e-46ea-80b4-0b44c3264179> a GO:0050832,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/c801f669-c6a1-4a44-8ab6-53881efc4190> a GO:0045087,
+<http://model.geneontology.org/WB_WBGene00003771/6f7ac2f1-91c2-470f-bcaa-27a7923343d3> a WB:WBGene00003771,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003771/c86f0ad3-23ec-4601-8b61-d6a27317a730> a WB:WBGene00003771,
+<http://model.geneontology.org/WB_WBGene00003771/dc6f32bd-fed8-4e40-adbd-279e86fb6e99> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003771/4edcab08-219e-46ea-80b4-0b44c3264179> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003771/6f7ac2f1-91c2-470f-bcaa-27a7923343d3> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-19" ;
+    dct:created "2010-03-19" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003771/de32ae9f-e7da-428b-9592-99125f184df2> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00003771/47037e3c-8734-486b-ae65-24067a255f66> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003771/e5fe0ea5-a476-4ab9-b965-6be52fb2bab4> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-19" ;
+    dct:created "2010-03-19" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00003771/e5fe0ea5-a476-4ab9-b965-6be52fb2bab4> a WB:WBGene00003771,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
@@ -124,50 +128,50 @@ obo:BFO_0000050 a owl:ObjectProperty .
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003771/0d3789e4-376f-42ba-8080-4bfae6ea5374> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003771/14549678-34a0-4176-b159-41636f4fd718> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003771  RO:0002331 GO:0045087 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9489|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/35b03037-ca38-4614-8b30-54b78e0d6ef9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/c801f669-c6a1-4a44-8ab6-53881efc4190> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003771/f005e7ea-25f4-4fbc-a880-d5d4d6456cae> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-19" ;
-    dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003771  RO:0002331 GO:0050832 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9484|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/163a2921-db2e-4e84-9c73-a0177bf6157f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/c86f0ad3-23ec-4601-8b61-d6a27317a730> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003771/f6eabd68-9b70-4892-9b80-a05aed9088aa> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-03-19" ;
-    dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003771  RO:0002331 GO:0050832 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9484|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/163a2921-db2e-4e84-9c73-a0177bf6157f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/4dc9f34a-6d3b-4576-8e0e-fc3785985d5e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/dc6f32bd-fed8-4e40-adbd-279e86fb6e99> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/4edcab08-219e-46ea-80b4-0b44c3264179> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003771/867c34a1-6e3d-4a6e-ba3e-d7d9f26e8893> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003771/4fdd5493-d219-4fa5-a2cf-d2d7545e8636> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-03-19" ;
     dct:created "2010-03-19" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003771  RO:0002331 GO:0045087 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9489|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/35b03037-ca38-4614-8b30-54b78e0d6ef9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/7e6092aa-9e1a-4128-8465-4a35c72ccd72> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/de32ae9f-e7da-428b-9592-99125f184df2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/e5fe0ea5-a476-4ab9-b965-6be52fb2bab4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003771/927cc658-951a-436f-ab88-c2ba4ce4268f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-19" ;
+    dct:created "2010-03-19" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003771  RO:0002331 GO:0045087 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9489|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/de32ae9f-e7da-428b-9592-99125f184df2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/47037e3c-8734-486b-ae65-24067a255f66> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003771/a869c2d3-e210-4d08-b2a4-86b071385c7a> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-03-19" ;
+    dct:created "2010-03-19" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003771  RO:0002331 GO:0050832 WB:WBPaper00006488|PMID:15048112 ECO:0000270   2010-03-19 WB  id=WBOA:9484|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-03-19|modification-date=2010-03-19" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003771/dc6f32bd-fed8-4e40-adbd-279e86fb6e99> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003771/6f7ac2f1-91c2-470f-bcaa-27a7923343d3> .
 

--- a/models/WB_WBGene00003866.ttl
+++ b/models/WB_WBGene00003866.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00003866> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "ooc-1 (WB:WBGene00003866)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00003866> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00003866/44cb3656-be16-4a5c-a148-1f6f1f465dc3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003866/d4aeb707-f44f-45a1-b7c0-28480b5aea63> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000403" ;
+    ns1:evidence-with "WB:WBVar00000403" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003866/b3be38a5-2bd4-4419-8192-2b189d6b4afc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00003866/dda1e349-657d-47ae-82e2-40cd24fee2f3> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000403" ;
+    ns1:evidence-with "WB:WBVar00000403" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3224814" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00003866/8c19972f-c88e-47e2-b9d2-cceaaf268545> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00003866/12cd236b-a450-4574-8d5c-344f8dc2a730> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003866/5a868618-ef0b-4d65-b454-dbbf994264ab> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003866/54679b36-0c57-4ac7-be82-c1124a777be9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003866/a290a579-dac3-4997-a515-c19c8eb6508c> a WB:WBGene00003866,
+<http://model.geneontology.org/WB_WBGene00003866/54679b36-0c57-4ac7-be82-c1124a777be9> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00003866/b92632ec-43ec-4fee-afe0-53f586885699> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00003866/5a868618-ef0b-4d65-b454-dbbf994264ab> a WB:WBGene00003866,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00003866/a290a579-dac3-4997-a515-c19c8eb6508c> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00003866/8c19972f-c88e-47e2-b9d2-cceaaf268545> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003866/44cb3656-be16-4a5c-a148-1f6f1f465dc3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003866/dda1e349-657d-47ae-82e2-40cd24fee2f3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00003866  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000403  2021-05-13 WB  id=WBOA:4336|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003866/b92632ec-43ec-4fee-afe0-53f586885699> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003866/8c19972f-c88e-47e2-b9d2-cceaaf268545> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00003866/b3be38a5-2bd4-4419-8192-2b189d6b4afc> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00003866  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000403  2021-05-13 WB  id=WBOA:4336|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003866/b92632ec-43ec-4fee-afe0-53f586885699> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003866/a290a579-dac3-4997-a515-c19c8eb6508c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003866/12cd236b-a450-4574-8d5c-344f8dc2a730> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003866/5a868618-ef0b-4d65-b454-dbbf994264ab> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00003866/d4aeb707-f44f-45a1-b7c0-28480b5aea63> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00003866  RO:0002264 GO:0009792 WB:WBPaper00001109|PMID:3224814 ECO:0000315 WB:WBVar00000403  2021-05-13 WB  id=WBOA:4336|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00003866/12cd236b-a450-4574-8d5c-344f8dc2a730> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00003866/54679b36-0c57-4ac7-be82-c1124a777be9> .
 

--- a/models/WB_WBGene00004012.ttl
+++ b/models/WB_WBGene00004012.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004012> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "pha-3 (WB:WBGene00004012)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004012> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004012/132bd50b-2fc9-49e7-9ffd-e8df0ff80948> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004012/5e8aa9cd-e1b3-4bdb-9016-406517628fd9> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000045" ;
+    ns1:evidence-with "WB:WBVar00000045" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8462849" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004012/7a322413-27d0-4e18-b4fc-f70068bb2882> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004012/8c1529a7-4db4-46e8-91cc-44ef87aef1a8> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000045" ;
+    ns1:evidence-with "WB:WBVar00000045" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8462849" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004012/2bb22976-cb9a-4dd5-a350-a2d1c95d0375> a WB:WBGene00004012,
+<http://model.geneontology.org/WB_WBGene00004012/483c23bf-1c8c-4991-9277-ad2323ff05d8> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004012/6e6f924e-d630-4283-bdcf-c815262858cf> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004012/c0abe4c4-1d2e-410b-9eb4-d7e0b2e63cda> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004012/52e10089-23dd-4534-b2b9-19108e52f287> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004012/6e6f924e-d630-4283-bdcf-c815262858cf> a WB:WBGene00004012,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004012/2bb22976-cb9a-4dd5-a350-a2d1c95d0375> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004012/5c948f45-d2ab-4b4e-8149-9d23e30026a7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004012/5c948f45-d2ab-4b4e-8149-9d23e30026a7> a GO:0060465,
+<http://model.geneontology.org/WB_WBGene00004012/c0abe4c4-1d2e-410b-9eb4-d7e0b2e63cda> a GO:0060465,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004012/7a322413-27d0-4e18-b4fc-f70068bb2882> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004012/5e8aa9cd-e1b3-4bdb-9016-406517628fd9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004012  RO:0002264 GO:0060465 WB:WBPaper00001709|PMID:8462849 ECO:0000315 WB:WBVar00000045  2021-05-13 WB  id=WBOA:9007|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004012/52e10089-23dd-4534-b2b9-19108e52f287> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004012/5c948f45-d2ab-4b4e-8149-9d23e30026a7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004012/132bd50b-2fc9-49e7-9ffd-e8df0ff80948> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004012  RO:0002264 GO:0060465 WB:WBPaper00001709|PMID:8462849 ECO:0000315 WB:WBVar00000045  2021-05-13 WB  id=WBOA:9007|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004012/52e10089-23dd-4534-b2b9-19108e52f287> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004012/2bb22976-cb9a-4dd5-a350-a2d1c95d0375> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004012/483c23bf-1c8c-4991-9277-ad2323ff05d8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004012/6e6f924e-d630-4283-bdcf-c815262858cf> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004012/8c1529a7-4db4-46e8-91cc-44ef87aef1a8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004012  RO:0002264 GO:0060465 WB:WBPaper00001709|PMID:8462849 ECO:0000315 WB:WBVar00000045  2021-05-13 WB  id=WBOA:9007|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004012/483c23bf-1c8c-4991-9277-ad2323ff05d8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004012/c0abe4c4-1d2e-410b-9eb4-d7e0b2e63cda> .
 

--- a/models/WB_WBGene00004291.ttl
+++ b/models/WB_WBGene00004291.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,304 +29,324 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004291> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "rad-4 (WB:WBGene00004291)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004291> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004291/048da654-3955-49d4-883a-eba2fbbbbb8b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/0a696d4b-760c-4dd8-9760-68c4f6c01197> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/2c7b676b-c153-4f89-acc9-9cdad3fa9ac1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/1386f32b-39a4-4c66-9258-8e6c259b2e25> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBGene00001860" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/4f7bb755-d290-4e43-aaef-7f60f373df8e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/2a861899-5d9e-4773-8001-647d3252821a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/5411dcc1-4c68-4fac-b27d-2c77ee83d04d> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/2c6841c2-8f3c-4f18-8beb-6087179d2ab2> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001868" ;
+    ns1:evidence-with "WB:WBGene00001865" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/6de6dc62-2a15-4b67-b1d6-143dd9ed6781> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/32164ca9-cf6d-4fa8-8747-373065ba7a62> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBGene00001862" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/8730a325-cac9-4974-bfe5-dbb341d5d453> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/390fd61e-1c3b-4629-b74c-807d00918fc4> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001862" ;
+    ns1:evidence-with "WB:WBGene00001862" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/879c58c7-be8a-44ab-bb03-d9090ddedd42> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/3d08a8a8-e06e-42ec-bfa9-5bc82eaf8b05> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001860" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/883c67b9-5869-4e90-a09b-175ea02b1900> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/3d484872-a241-4d07-8b20-f5167aa83dfe> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001862" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/8b0ec8ad-de1f-4180-a8b4-5092696d7f4f> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/3e8cf494-0b46-4fd3-9258-b751e8ab9259> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001865" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/8ffa4c13-a41a-4408-8e7f-0eccd9a40868> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/4399e451-e98d-4062-bf16-2c28d4a48c46> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001860" ;
+    ns1:evidence-with "WB:WBGene00001860" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/a8a1066c-443f-4704-8d33-d84f72a97b25> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/5a843500-a818-4d85-a70c-5676aafa2bed> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/aad5bbbb-5f9e-48d0-8b67-abe636fa4f5e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/651afac0-265f-455d-b310-40a1369f6cd5> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBGene00001865" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/ad148b47-58fc-4829-bf12-c692abd85312> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/68c7ed21-c48d-4d01-8d8f-da04c8dc02a2> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006818" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/ad82ae5f-6e68-4e52-9c92-2e99d7af19bd> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/6ac6dc8c-b0ca-42c6-ad8d-f853eaa6aefb> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/b9f81d7d-00b0-4c73-9e6c-e601fc10d1af> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/aa3137d9-07da-4b87-a824-01ef1c8c4f2c> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006818" ;
+    ns1:evidence-with "WB:WBGene00001868" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/d30a1a9b-7c8c-4ea5-ba7b-2638499d05e5> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/bc3e0c09-ab00-40e6-8485-4a209e7e9c30> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001865" ;
+    ns1:evidence-with "WB:WBGene00001868" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/d80f0b2d-6508-48f1-84e3-094663f84bee> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/ccd72fb6-3ddf-4642-9fbc-36f3aa99ac1c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/db6563bb-6156-40a3-abc2-b326ff0ceef2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/d13c5421-93b7-4494-b8c0-276605456731> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBGene00006818" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/efb79bda-3de9-4876-96dc-0b0a78987ba4> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004291/ee2fbc0a-59de-4af0-8845-4519e1ec1051> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001868" ;
+    ns1:evidence-with "WB:WBVar00089074" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/ff0af8c8-595f-4540-b2f5-be3ee1a386b2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004291/f49eaed4-8c4f-4a0a-9874-06251bc26b2d> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089074" ;
+    ns1:evidence-with "WB:WBGene00006818" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/35ac22df-211a-441f-b334-9d3a7137538a> a GO:0009411,
+<http://model.geneontology.org/WB_WBGene00004291/330047ed-0db2-4c2a-8f87-60566db9a686> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/e314aaae-1f5d-4af0-a746-fce471ce0f67> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/39416fe1-2428-467e-8940-e3bc9967b2d8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004291/3693f92e-814a-4740-b2eb-30f0c769597b> a GO:0006974,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/7de1f9a2-014b-4162-925e-dcdcd4591200> a WB:WBGene00004291,
+<http://model.geneontology.org/WB_WBGene00004291/39416fe1-2428-467e-8940-e3bc9967b2d8> a GO:0009411,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/7fc6e130-212e-4c04-8cea-fc5d5109ad08> a WB:WBGene00004291,
+<http://model.geneontology.org/WB_WBGene00004291/40998102-3f76-4d7f-bc85-174dc9ba8603> a GO:0000003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/8bef0ef1-f8a1-405d-a801-2984197e82b9> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004291/573d76b1-4fdd-4da8-9a4a-656679621f4b> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/7fc6e130-212e-4c04-8cea-fc5d5109ad08> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/b210a270-6afb-4aec-891d-dd3347bfad4b> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/e70fa7b6-e706-4acc-a358-e288b9bec1c1> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/3693f92e-814a-4740-b2eb-30f0c769597b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/9af9b61e-783f-453c-8af7-2d4d31df6dba> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/ba150883-5b1d-4ae0-ad98-50fc326426cc> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/f6641fe0-d785-420d-b438-7307bd88a786> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004291/9e4b999a-5841-4840-bd8e-fad196d03918> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004291/61dbb874-45e2-4b7c-9653-ca91a82b7d9d> a GO:0045132,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/a02877cc-969d-479d-9c6d-140fc00e460b> a GO:0006974,
+<http://model.geneontology.org/WB_WBGene00004291/772a8bd1-3d7e-49d5-be27-276727d15a08> a WB:WBGene00004291,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/ab6ce8df-0a1d-4605-9baf-12f87aeb884f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004291/80adb464-2de0-4343-bbb0-c0d1eb1b7c8a> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/7de1f9a2-014b-4162-925e-dcdcd4591200> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/35ac22df-211a-441f-b334-9d3a7137538a> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/80cbcf70-e1a3-4282-b18a-b2e91faa27ef> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/40998102-3f76-4d7f-bc85-174dc9ba8603> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/b210a270-6afb-4aec-891d-dd3347bfad4b> a GO:0045132,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004291/b2251459-de95-49bb-a1b0-4a04584029cb> a WB:WBGene00004291,
+<http://model.geneontology.org/WB_WBGene00004291/80cbcf70-e1a3-4282-b18a-b2e91faa27ef> a WB:WBGene00004291,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/ba150883-5b1d-4ae0-ad98-50fc326426cc> a WB:WBGene00004291,
+<http://model.geneontology.org/WB_WBGene00004291/a788d49a-0ab0-415e-9982-f328ec1757c8> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/772a8bd1-3d7e-49d5-be27-276727d15a08> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/61dbb874-45e2-4b7c-9653-ca91a82b7d9d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004291/cc329728-658b-48dd-9754-8ed6e12c335a> a WB:WBGene00004291,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/c4b7c7d0-5c5f-4823-9c63-1eb704fe0c09> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/b2251459-de95-49bb-a1b0-4a04584029cb> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/9e4b999a-5841-4840-bd8e-fad196d03918> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004291/d2f52705-1051-40e9-9cb7-858e291d9cfa> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/ddfc2018-bdf2-48bb-aeb9-2198a1563646> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/a02877cc-969d-479d-9c6d-140fc00e460b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004291/ddfc2018-bdf2-48bb-aeb9-2198a1563646> a WB:WBGene00004291,
+<http://model.geneontology.org/WB_WBGene00004291/e00d3308-0268-4d41-9b7e-69ee0efec6e9> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004291/f6641fe0-d785-420d-b438-7307bd88a786> a GO:0000003,
+<http://model.geneontology.org/WB_WBGene00004291/e314aaae-1f5d-4af0-a746-fce471ce0f67> a WB:WBGene00004291,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004291/e70fa7b6-e706-4acc-a358-e288b9bec1c1> a WB:WBGene00004291,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004291/f4760f04-d28d-4ae6-8901-66d7bf39b260> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004291/cc329728-658b-48dd-9754-8ed6e12c335a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004291/e00d3308-0268-4d41-9b7e-69ee0efec6e9> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -334,40 +354,28 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/ff0af8c8-595f-4540-b2f5-be3ee1a386b2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/ee2fbc0a-59de-4af0-8845-4519e1ec1051> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4882|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0009792 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4887|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/ab6ce8df-0a1d-4605-9baf-12f87aeb884f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/7de1f9a2-014b-4162-925e-dcdcd4591200> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/f4760f04-d28d-4ae6-8901-66d7bf39b260> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/cc329728-658b-48dd-9754-8ed6e12c335a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/6de6dc62-2a15-4b67-b1d6-143dd9ed6781> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/1386f32b-39a4-4c66-9258-8e6c259b2e25>,
+        <http://model.geneontology.org/WB_WBGene00004291/2c6841c2-8f3c-4f18-8beb-6087179d2ab2>,
+        <http://model.geneontology.org/WB_WBGene00004291/390fd61e-1c3b-4629-b74c-807d00918fc4>,
+        <http://model.geneontology.org/WB_WBGene00004291/68c7ed21-c48d-4d01-8d8f-da04c8dc02a2>,
+        <http://model.geneontology.org/WB_WBGene00004291/bc3e0c09-ab00-40e6-8485-4a209e7e9c30>,
+        <http://model.geneontology.org/WB_WBGene00004291/d13c5421-93b7-4494-b8c0-276605456731> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4884|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/9af9b61e-783f-453c-8af7-2d4d31df6dba> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/f6641fe0-d785-420d-b438-7307bd88a786> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/5411dcc1-4c68-4fac-b27d-2c77ee83d04d>,
-        <http://model.geneontology.org/WB_WBGene00004291/8730a325-cac9-4974-bfe5-dbb341d5d453>,
-        <http://model.geneontology.org/WB_WBGene00004291/879c58c7-be8a-44ab-bb03-d9090ddedd42>,
-        <http://model.geneontology.org/WB_WBGene00004291/ad82ae5f-6e68-4e52-9c92-2e99d7af19bd>,
-        <http://model.geneontology.org/WB_WBGene00004291/b9f81d7d-00b0-4c73-9e6c-e601fc10d1af>,
-        <http://model.geneontology.org/WB_WBGene00004291/d30a1a9b-7c8c-4ea5-ba7b-2638499d05e5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4885|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000316 WB:WBGene00001860  2021-05-13 WB  id=WBOA:4886|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
@@ -376,92 +384,80 @@ obo:RO_0002418 a owl:ObjectProperty .
         "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000316 WB:WBGene00001868  2021-05-13 WB  id=WBOA:4890|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000316 WB:WBGene00006818  2021-05-13 WB  id=WBOA:4891|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/8bef0ef1-f8a1-405d-a801-2984197e82b9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/b210a270-6afb-4aec-891d-dd3347bfad4b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/a788d49a-0ab0-415e-9982-f328ec1757c8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/61dbb874-45e2-4b7c-9653-ca91a82b7d9d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/2c7b676b-c153-4f89-acc9-9cdad3fa9ac1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/3e8cf494-0b46-4fd3-9258-b751e8ab9259> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4884|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/9af9b61e-783f-453c-8af7-2d4d31df6dba> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/ba150883-5b1d-4ae0-ad98-50fc326426cc> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/048da654-3955-49d4-883a-eba2fbbbbb8b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0009792 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4887|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/c4b7c7d0-5c5f-4823-9c63-1eb704fe0c09> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/9e4b999a-5841-4840-bd8e-fad196d03918> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/4f7bb755-d290-4e43-aaef-7f60f373df8e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4882|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/ab6ce8df-0a1d-4605-9baf-12f87aeb884f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/35ac22df-211a-441f-b334-9d3a7137538a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/330047ed-0db2-4c2a-8f87-60566db9a686> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/39416fe1-2428-467e-8940-e3bc9967b2d8> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/aad5bbbb-5f9e-48d0-8b67-abe636fa4f5e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/6ac6dc8c-b0ca-42c6-ad8d-f853eaa6aefb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0006974 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4883|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/d2f52705-1051-40e9-9cb7-858e291d9cfa> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/ddfc2018-bdf2-48bb-aeb9-2198a1563646> .
+    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4884|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/80adb464-2de0-4343-bbb0-c0d1eb1b7c8a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/40998102-3f76-4d7f-bc85-174dc9ba8603> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/a8a1066c-443f-4704-8d33-d84f72a97b25> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/0a696d4b-760c-4dd8-9760-68c4f6c01197> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0009792 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4887|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/c4b7c7d0-5c5f-4823-9c63-1eb704fe0c09> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/b2251459-de95-49bb-a1b0-4a04584029cb> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/db6563bb-6156-40a3-abc2-b326ff0ceef2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0006974 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4883|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/d2f52705-1051-40e9-9cb7-858e291d9cfa> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/a02877cc-969d-479d-9c6d-140fc00e460b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/f4760f04-d28d-4ae6-8901-66d7bf39b260> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/e00d3308-0268-4d41-9b7e-69ee0efec6e9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004291/883c67b9-5869-4e90-a09b-175ea02b1900>,
-        <http://model.geneontology.org/WB_WBGene00004291/8b0ec8ad-de1f-4180-a8b4-5092696d7f4f>,
-        <http://model.geneontology.org/WB_WBGene00004291/8ffa4c13-a41a-4408-8e7f-0eccd9a40868>,
-        <http://model.geneontology.org/WB_WBGene00004291/ad148b47-58fc-4829-bf12-c692abd85312>,
-        <http://model.geneontology.org/WB_WBGene00004291/d80f0b2d-6508-48f1-84e3-094663f84bee>,
-        <http://model.geneontology.org/WB_WBGene00004291/efb79bda-3de9-4876-96dc-0b0a78987ba4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/ccd72fb6-3ddf-4642-9fbc-36f3aa99ac1c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4884|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/80adb464-2de0-4343-bbb0-c0d1eb1b7c8a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/80cbcf70-e1a3-4282-b18a-b2e91faa27ef> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/5a843500-a818-4d85-a70c-5676aafa2bed> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4882|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/330047ed-0db2-4c2a-8f87-60566db9a686> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/e314aaae-1f5d-4af0-a746-fce471ce0f67> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/32164ca9-cf6d-4fa8-8747-373065ba7a62>,
+        <http://model.geneontology.org/WB_WBGene00004291/3d484872-a241-4d07-8b20-f5167aa83dfe>,
+        <http://model.geneontology.org/WB_WBGene00004291/4399e451-e98d-4062-bf16-2c28d4a48c46>,
+        <http://model.geneontology.org/WB_WBGene00004291/651afac0-265f-455d-b310-40a1369f6cd5>,
+        <http://model.geneontology.org/WB_WBGene00004291/aa3137d9-07da-4b87-a824-01ef1c8c4f2c>,
+        <http://model.geneontology.org/WB_WBGene00004291/f49eaed4-8c4f-4a0a-9874-06251bc26b2d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4885|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000316 WB:WBGene00001860  2021-05-13 WB  id=WBOA:4886|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
@@ -470,6 +466,30 @@ obo:RO_0002418 a owl:ObjectProperty .
         "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000316 WB:WBGene00001868  2021-05-13 WB  id=WBOA:4890|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004291  RO:0002264 GO:0045132 WB:WBPaper00000565|PMID:7152245 ECO:0000316 WB:WBGene00006818  2021-05-13 WB  id=WBOA:4891|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/8bef0ef1-f8a1-405d-a801-2984197e82b9> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/7fc6e130-212e-4c04-8cea-fc5d5109ad08> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/a788d49a-0ab0-415e-9982-f328ec1757c8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/772a8bd1-3d7e-49d5-be27-276727d15a08> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/3d08a8a8-e06e-42ec-bfa9-5bc82eaf8b05> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0006974 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4883|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/573d76b1-4fdd-4da8-9a4a-656679621f4b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/e70fa7b6-e706-4acc-a358-e288b9bec1c1> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004291/2a861899-5d9e-4773-8001-647d3252821a> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004291  RO:0002264 GO:0006974 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089074  2021-05-13 WB  id=WBOA:4883|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004291/573d76b1-4fdd-4da8-9a4a-656679621f4b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004291/3693f92e-814a-4740-b2eb-30f0c769597b> .
 

--- a/models/WB_WBGene00004293.ttl
+++ b/models/WB_WBGene00004293.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004293> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "rad-7 (WB:WBGene00004293)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004293> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004293/248e6280-39d1-48c7-992e-28853b634922> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004293/1875a407-2f49-45c2-bfcb-be0e4dab7313> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089077" ;
+    ns1:evidence-with "WB:WBVar00089077" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/4ca41160-4df6-421e-88f7-28a3b89db7a2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004293/93b7bfb8-1047-4b33-a904-80165698911b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089077" ;
+    ns1:evidence-with "WB:WBVar00089077" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/a1aa482e-2e25-43bf-abfe-b0212daf0532> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004293/d783f34e-a63b-49c8-a3f1-ddd59782365d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089077" ;
+    ns1:evidence-with "WB:WBVar00089077" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/e06233f7-1805-4162-9def-eaff967950fd> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004293/e0725586-08f7-4908-a40b-d8a35cc52acc> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089077" ;
+    ns1:evidence-with "WB:WBVar00089077" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/464f2ace-a29a-4f95-9c50-8aaec6cad179> a WB:WBGene00004293,
+<http://model.geneontology.org/WB_WBGene00004293/2b98cbb8-73af-4226-8895-273d86aa4412> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004293/87832c44-93d8-4cfa-b8fc-bb44a96757b6> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004293/f60975db-3fca-4fd6-9d39-c948fdc212ae> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004293/666bfb2e-a679-40bd-9644-4575e1a382b0> a WB:WBGene00004293,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/536d67fd-abf2-4c6d-a27a-da64f2a63d06> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004293/680f988a-3a96-448a-82e6-0c633ea2210f> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004293/464f2ace-a29a-4f95-9c50-8aaec6cad179> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004293/855b030b-044a-4ff6-b381-bff4e0909ed9> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004293/666bfb2e-a679-40bd-9644-4575e1a382b0> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004293/e676313f-1ded-44e9-843d-4de8b01e0f50> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/855b030b-044a-4ff6-b381-bff4e0909ed9> a GO:0000003,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004293/86974dc4-edc2-47ea-8995-070b3b71e1b4> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004293/ae5cc95b-2dad-4460-bfaf-a066ced95452> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004293/b3b52a50-0344-49b4-b9e9-ab5b94a0c5e1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004293/ae5cc95b-2dad-4460-bfaf-a066ced95452> a WB:WBGene00004293,
+<http://model.geneontology.org/WB_WBGene00004293/87832c44-93d8-4cfa-b8fc-bb44a96757b6> a WB:WBGene00004293,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004293/b3b52a50-0344-49b4-b9e9-ab5b94a0c5e1> a GO:0009411,
+<http://model.geneontology.org/WB_WBGene00004293/e676313f-1ded-44e9-843d-4de8b01e0f50> a GO:0000003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004293/f60975db-3fca-4fd6-9d39-c948fdc212ae> a GO:0009411,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004293/a1aa482e-2e25-43bf-abfe-b0212daf0532> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004293/1875a407-2f49-45c2-bfcb-be0e4dab7313> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4898|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/536d67fd-abf2-4c6d-a27a-da64f2a63d06> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/464f2ace-a29a-4f95-9c50-8aaec6cad179> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004293/e06233f7-1805-4162-9def-eaff967950fd> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4897|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/86974dc4-edc2-47ea-8995-070b3b71e1b4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/ae5cc95b-2dad-4460-bfaf-a066ced95452> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004293/248e6280-39d1-48c7-992e-28853b634922> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4897|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/86974dc4-edc2-47ea-8995-070b3b71e1b4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/b3b52a50-0344-49b4-b9e9-ab5b94a0c5e1> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004293/4ca41160-4df6-421e-88f7-28a3b89db7a2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4898|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/536d67fd-abf2-4c6d-a27a-da64f2a63d06> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/855b030b-044a-4ff6-b381-bff4e0909ed9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/680f988a-3a96-448a-82e6-0c633ea2210f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/e676313f-1ded-44e9-843d-4de8b01e0f50> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004293/e0725586-08f7-4908-a40b-d8a35cc52acc> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4897|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/2b98cbb8-73af-4226-8895-273d86aa4412> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/87832c44-93d8-4cfa-b8fc-bb44a96757b6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004293/93b7bfb8-1047-4b33-a904-80165698911b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4897|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/2b98cbb8-73af-4226-8895-273d86aa4412> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/f60975db-3fca-4fd6-9d39-c948fdc212ae> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004293/d783f34e-a63b-49c8-a3f1-ddd59782365d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004293  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089077  2021-05-13 WB  id=WBOA:4898|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004293/680f988a-3a96-448a-82e6-0c633ea2210f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004293/666bfb2e-a679-40bd-9644-4575e1a382b0> .
 

--- a/models/WB_WBGene00004295.ttl
+++ b/models/WB_WBGene00004295.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004295> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "rad-9 (WB:WBGene00004295)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004295> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004295/44a6f302-b920-4f48-9113-ff91fac89215> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004295/7302e825-b5b3-4667-bf15-fc4695b18ee5> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089078" ;
+    ns1:evidence-with "WB:WBVar00089078" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/7c187a02-4017-4fe3-a0ae-6570293e76b2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004295/98965fb3-54b2-48fd-83d3-eb206256b3ac> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089078" ;
+    ns1:evidence-with "WB:WBVar00089078" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/842da146-ff27-47e4-b952-4d0d4cc88414> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004295/cb0c0b21-a314-462d-9d6b-cfa710710a63> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089078" ;
+    ns1:evidence-with "WB:WBVar00089078" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/b70e6cb7-0267-4f1d-a1ea-0903b2452be7> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004295/cb5dbfce-5b65-40a2-9e8d-707fb2102797> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089078" ;
+    ns1:evidence-with "WB:WBVar00089078" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/f8a07af4-585b-40f7-97aa-39dce525a8a3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004295/db1dfd8a-91ae-411d-8642-f3303531d0b0> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089078" ;
+    ns1:evidence-with "WB:WBVar00089078" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/fd2338de-458f-4df4-8762-a48f779d6631> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004295/ee2fa36e-5e9f-4029-a964-307e0aba4af5> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089078" ;
+    ns1:evidence-with "WB:WBVar00089078" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7152245" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/3ad49da8-97a8-4445-a68c-155fffbc3f81> a GO:0009411,
+<http://model.geneontology.org/WB_WBGene00004295/23661421-3517-4ebb-82a7-a9928de8783d> a GO:0009411,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/44e8226f-e6e2-4d38-9c09-ea3adc7307ec> a GO:0000003,
+<http://model.geneontology.org/WB_WBGene00004295/2735c1f9-b9aa-44ad-967b-12109b51242d> a GO:0000003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/70c014fd-61d2-4012-a2bc-ff0130dddda8> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004295/a288e271-4eb3-4a7f-93e9-137695a0b8fc> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004295/3ad49da8-97a8-4445-a68c-155fffbc3f81> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004295/72338e80-d794-459f-be50-e9c23fdea279> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004295/f09a664c-7898-4052-a373-cf73febd72eb> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004295/db23ec11-6006-44e2-bc9f-b0eb9e1e2157> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004295/7ff9f3c7-b10f-4afa-9fb1-c93d15ca689b> a WB:WBGene00004295,
+<http://model.geneontology.org/WB_WBGene00004295/2c760319-f368-416f-b277-f1298aabfcfb> a WB:WBGene00004295,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/a288e271-4eb3-4a7f-93e9-137695a0b8fc> a WB:WBGene00004295,
+<http://model.geneontology.org/WB_WBGene00004295/33c14c40-d072-46c2-96a7-b37ad330e9c5> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004295/655a371f-2d15-4053-9d37-de1750339b8f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004295/2735c1f9-b9aa-44ad-967b-12109b51242d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004295/4f11b91a-c496-4d6d-a8eb-01e34cda7d41> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/db23ec11-6006-44e2-bc9f-b0eb9e1e2157> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004295/655a371f-2d15-4053-9d37-de1750339b8f> a WB:WBGene00004295,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/f09a664c-7898-4052-a373-cf73febd72eb> a WB:WBGene00004295,
+<http://model.geneontology.org/WB_WBGene00004295/769ebd6d-1dbb-40c3-aa26-0b313ed7640b> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004295/2c760319-f368-416f-b277-f1298aabfcfb> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004295/23661421-3517-4ebb-82a7-a9928de8783d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004295/d7813f94-b214-4b3c-84df-372506f9586a> a WB:WBGene00004295,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004295/f5520619-503a-4c73-836e-fd3941104c55> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004295/ed5cf4d3-36df-4990-ac52-dcdc4cf101aa> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004295/7ff9f3c7-b10f-4afa-9fb1-c93d15ca689b> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004295/44e8226f-e6e2-4d38-9c09-ea3adc7307ec> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004295/d7813f94-b214-4b3c-84df-372506f9586a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004295/4f11b91a-c496-4d6d-a8eb-01e34cda7d41> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004295/f8a07af4-585b-40f7-97aa-39dce525a8a3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004295/db1dfd8a-91ae-411d-8642-f3303531d0b0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4904|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/f5520619-503a-4c73-836e-fd3941104c55> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/44e8226f-e6e2-4d38-9c09-ea3adc7307ec> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004295/842da146-ff27-47e4-b952-4d0d4cc88414> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0009792 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4905|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/72338e80-d794-459f-be50-e9c23fdea279> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/db23ec11-6006-44e2-bc9f-b0eb9e1e2157> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004295/b70e6cb7-0267-4f1d-a1ea-0903b2452be7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4903|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/70c014fd-61d2-4012-a2bc-ff0130dddda8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/a288e271-4eb3-4a7f-93e9-137695a0b8fc> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004295/7c187a02-4017-4fe3-a0ae-6570293e76b2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0009792 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4905|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/72338e80-d794-459f-be50-e9c23fdea279> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/f09a664c-7898-4052-a373-cf73febd72eb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/ed5cf4d3-36df-4990-ac52-dcdc4cf101aa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/d7813f94-b214-4b3c-84df-372506f9586a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004295/fd2338de-458f-4df4-8762-a48f779d6631> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004295/7302e825-b5b3-4667-bf15-fc4695b18ee5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0009792 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4905|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/ed5cf4d3-36df-4990-ac52-dcdc4cf101aa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/4f11b91a-c496-4d6d-a8eb-01e34cda7d41> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004295/ee2fa36e-5e9f-4029-a964-307e0aba4af5> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4904|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/f5520619-503a-4c73-836e-fd3941104c55> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/7ff9f3c7-b10f-4afa-9fb1-c93d15ca689b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/33c14c40-d072-46c2-96a7-b37ad330e9c5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/655a371f-2d15-4053-9d37-de1750339b8f> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004295/44a6f302-b920-4f48-9113-ff91fac89215> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004295/cb0c0b21-a314-462d-9d6b-cfa710710a63> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4903|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/70c014fd-61d2-4012-a2bc-ff0130dddda8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/3ad49da8-97a8-4445-a68c-155fffbc3f81> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/769ebd6d-1dbb-40c3-aa26-0b313ed7640b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/23661421-3517-4ebb-82a7-a9928de8783d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004295/cb5dbfce-5b65-40a2-9e8d-707fb2102797> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0009411 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4903|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/769ebd6d-1dbb-40c3-aa26-0b313ed7640b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/2c760319-f368-416f-b277-f1298aabfcfb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004295/98965fb3-54b2-48fd-83d3-eb206256b3ac> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004295  RO:0002264 GO:0000003 WB:WBPaper00000565|PMID:7152245 ECO:0000315 WB:WBVar00089078  2021-05-13 WB  id=WBOA:4904|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004295/33c14c40-d072-46c2-96a7-b37ad330e9c5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004295/2735c1f9-b9aa-44ad-967b-12109b51242d> .
 

--- a/models/WB_WBGene00004362.ttl
+++ b/models/WB_WBGene00004362.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004362> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "ric-1 (WB:WBGene00004362)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004362> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004362/369e28d7-a136-4138-9395-a427d073c0f1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004362/262d3579-2b07-499e-9875-89db7b2af1e7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143055" ;
+    ns1:evidence-with "WB:WBVar00143055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7498734" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004362/f1071437-82b0-4b6d-81ee-19a7ba5c2cf0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004362/739c9f39-5863-4764-b86d-f436a754696d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143055" ;
+    ns1:evidence-with "WB:WBVar00143055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7498734" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004362/2c748d76-3037-48b6-b020-e14409e3b7ed> a WB:WBGene00004362,
+<http://model.geneontology.org/WB_WBGene00004362/480755fc-bcf0-42bc-8181-8dad5000fead> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004362/64509243-0d1e-403e-8b20-e200bca27db7> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004362/aa66f5bb-fff1-48f1-bbfb-7cbb9eddd19d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004362/6c61d02f-22f4-490f-8cd5-d531c227dc47> a GO:0007271,
+<http://model.geneontology.org/WB_WBGene00004362/64509243-0d1e-403e-8b20-e200bca27db7> a WB:WBGene00004362,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004362/d3a140f4-ac57-4696-a9a0-0921039cbe1d> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004362/aa66f5bb-fff1-48f1-bbfb-7cbb9eddd19d> a GO:0007271,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004362/2c748d76-3037-48b6-b020-e14409e3b7ed> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004362/6c61d02f-22f4-490f-8cd5-d531c227dc47> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004362/369e28d7-a136-4138-9395-a427d073c0f1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004362/739c9f39-5863-4764-b86d-f436a754696d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004362  RO:0002264 GO:0007271 WB:WBPaper00002195|PMID:7498734 ECO:0000315 WB:WBVar00143055  2021-05-13 WB  id=WBOA:8190|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004362/d3a140f4-ac57-4696-a9a0-0921039cbe1d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004362/6c61d02f-22f4-490f-8cd5-d531c227dc47> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004362/f1071437-82b0-4b6d-81ee-19a7ba5c2cf0> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004362  RO:0002264 GO:0007271 WB:WBPaper00002195|PMID:7498734 ECO:0000315 WB:WBVar00143055  2021-05-13 WB  id=WBOA:8190|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004362/d3a140f4-ac57-4696-a9a0-0921039cbe1d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004362/2c748d76-3037-48b6-b020-e14409e3b7ed> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004362/480755fc-bcf0-42bc-8181-8dad5000fead> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004362/64509243-0d1e-403e-8b20-e200bca27db7> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004362/262d3579-2b07-499e-9875-89db7b2af1e7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004362  RO:0002264 GO:0007271 WB:WBPaper00002195|PMID:7498734 ECO:0000315 WB:WBVar00143055  2021-05-13 WB  id=WBOA:8190|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004362/480755fc-bcf0-42bc-8181-8dad5000fead> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004362/aa66f5bb-fff1-48f1-bbfb-7cbb9eddd19d> .
 

--- a/models/WB_WBGene00004784.ttl
+++ b/models/WB_WBGene00004784.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004784> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "seu-2 (WB:WBGene00004784)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004784> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004784/1e58eab1-aa36-4a9f-856e-9b7c6cbd3481> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004784/c8237977-95e9-4ca1-a357-eb80e4a8268c> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006745" ;
+    ns1:evidence-with "WB:WBGene00006745" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9473333" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004784/e014bee9-8210-46c1-b91b-a9cef51c0f20> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004784/ebca59b0-23ec-4339-9c58-459e972d6df0> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006745" ;
+    ns1:evidence-with "WB:WBGene00006745" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9473333" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004784/7a560c34-6b45-45f6-b455-96112c3e8141> a WB:WBGene00004784,
+<http://model.geneontology.org/WB_WBGene00004784/1fed70f8-11e0-4098-ba03-b4d0b1eacc43> a WB:WBGene00004784,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004784/89133789-6c68-4033-ba7c-7720f0ddfb86> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004784/33e8c966-a675-4497-a0f0-506c0ffdf846> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004784/7a560c34-6b45-45f6-b455-96112c3e8141> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004784/9edd646b-04b2-496a-97de-928b6006290d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004784/1fed70f8-11e0-4098-ba03-b4d0b1eacc43> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004784/7beb3e78-d207-4da4-83a0-9a18ea3d6f99> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004784/9edd646b-04b2-496a-97de-928b6006290d> a GO:0033563,
+<http://model.geneontology.org/WB_WBGene00004784/7beb3e78-d207-4da4-83a0-9a18ea3d6f99> a GO:0033563,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004784/e014bee9-8210-46c1-b91b-a9cef51c0f20> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004784/c8237977-95e9-4ca1-a357-eb80e4a8268c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004784  RO:0002264 GO:0033563 WB:WBPaper00003014|PMID:9473333 ECO:0000316 WB:WBGene00006745  2021-05-13 WB  id=WBOA:8092|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004784/89133789-6c68-4033-ba7c-7720f0ddfb86> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004784/7a560c34-6b45-45f6-b455-96112c3e8141> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004784/33e8c966-a675-4497-a0f0-506c0ffdf846> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004784/1fed70f8-11e0-4098-ba03-b4d0b1eacc43> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004784/1e58eab1-aa36-4a9f-856e-9b7c6cbd3481> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004784/ebca59b0-23ec-4339-9c58-459e972d6df0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004784  RO:0002264 GO:0033563 WB:WBPaper00003014|PMID:9473333 ECO:0000316 WB:WBGene00006745  2021-05-13 WB  id=WBOA:8092|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004784/89133789-6c68-4033-ba7c-7720f0ddfb86> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004784/9edd646b-04b2-496a-97de-928b6006290d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004784/33e8c966-a675-4497-a0f0-506c0ffdf846> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004784/7beb3e78-d207-4da4-83a0-9a18ea3d6f99> .
 

--- a/models/WB_WBGene00004785.ttl
+++ b/models/WB_WBGene00004785.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004785> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "seu-3 (WB:WBGene00004785)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004785> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004785/51abd239-da07-4907-92f0-442ba5dfee95> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004785/5d067ee9-0bd9-42a8-96fd-ab7a2fc67a7b> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006745" ;
+    ns1:evidence-with "WB:WBGene00006745" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9473333" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004785/5f4e7ca4-12a9-49f1-b993-f5d25273afcc> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004785/ec3f392b-65e3-4e5c-9f55-24d8f4ad641a> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006745" ;
+    ns1:evidence-with "WB:WBGene00006745" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9473333" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004785/562d1d34-df5b-4e27-a39c-05f116186e98> a GO:0033563,
+<http://model.geneontology.org/WB_WBGene00004785/61eafd64-9b0f-488e-ad52-77b3d15202e7> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004785/f4dacaa7-e7f9-4f7a-b78c-e96e0c581431> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004785/8ef69ea0-0bf8-4380-b4ea-bf3900538df6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004785/9cd96773-14fe-4338-a9e2-ad34ced85630> a WB:WBGene00004785,
+<http://model.geneontology.org/WB_WBGene00004785/8ef69ea0-0bf8-4380-b4ea-bf3900538df6> a GO:0033563,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004785/c9e808df-73af-4d0e-ad85-575153b04c67> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004785/f4dacaa7-e7f9-4f7a-b78c-e96e0c581431> a WB:WBGene00004785,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004785/9cd96773-14fe-4338-a9e2-ad34ced85630> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004785/562d1d34-df5b-4e27-a39c-05f116186e98> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004785/5f4e7ca4-12a9-49f1-b993-f5d25273afcc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004785/ec3f392b-65e3-4e5c-9f55-24d8f4ad641a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004785  RO:0002264 GO:0033563 WB:WBPaper00003014|PMID:9473333 ECO:0000316 WB:WBGene00006745  2021-05-13 WB  id=WBOA:8093|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004785/c9e808df-73af-4d0e-ad85-575153b04c67> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004785/9cd96773-14fe-4338-a9e2-ad34ced85630> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004785/61eafd64-9b0f-488e-ad52-77b3d15202e7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004785/f4dacaa7-e7f9-4f7a-b78c-e96e0c581431> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004785/51abd239-da07-4907-92f0-442ba5dfee95> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004785/5d067ee9-0bd9-42a8-96fd-ab7a2fc67a7b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004785  RO:0002264 GO:0033563 WB:WBPaper00003014|PMID:9473333 ECO:0000316 WB:WBGene00006745  2021-05-13 WB  id=WBOA:8093|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004785/c9e808df-73af-4d0e-ad85-575153b04c67> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004785/562d1d34-df5b-4e27-a39c-05f116186e98> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004785/61eafd64-9b0f-488e-ad52-77b3d15202e7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004785/8ef69ea0-0bf8-4380-b4ea-bf3900538df6> .
 

--- a/models/WB_WBGene00004828.ttl
+++ b/models/WB_WBGene00004828.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004828> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sle-1 (WB:WBGene00004828)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004828> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004828/4a601fc7-0d54-4f24-b535-0291e413b08b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004828/0530159e-92ed-436b-99dc-19db7aed7c9f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004828/903d5cb0-429d-4a5d-ac54-593fd6997e99> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00004828/aa12315b-ae6a-4bc7-89c8-b82394525ea8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004828/378889fb-1c93-45a9-835c-cce01b4c9a97> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004828/c5dad9a8-6046-4ba1-bc45-463b3a6699da> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004828/553b93a5-ff19-487c-966f-a8be53396f82> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004828/d7b715ed-2549-4979-bbbc-8e67cd006cc5> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00004828/914df5db-d611-4ed3-8163-256c8e86b0ef> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004828/11b80736-d7fc-4eab-b40d-2dbed2a13d5b> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004828/e72df5e4-5065-480a-9daf-dad68d04a18e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004828/9cc2d19f-f7fb-4029-9490-0ea90c4e63b5> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004828/b3a8191b-fa25-4c14-ac1f-5701dd6ec8a8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004828/3f803ad4-554d-47c3-87d0-d827f9dad384> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004828/9cc2d19f-f7fb-4029-9490-0ea90c4e63b5> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004828/2ee8044a-5f96-4c35-8fc6-828b19261e01> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004828/b9b49b62-7fab-4aa3-99de-28b881227440> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004828/ebf532e2-5d36-4f93-be69-209b5dd05727> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004828/a4f831d8-5319-4942-883d-8494b85b6b82> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00004828/3f803ad4-554d-47c3-87d0-d827f9dad384> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004828/cdff4e16-dcf2-4c04-a56d-e73ab919bc47> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004828/b3a8191b-fa25-4c14-ac1f-5701dd6ec8a8> a WB:WBGene00004828,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004828/d77f8c22-e459-40f9-97f9-2c0bd6ab5f70> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004828/a4f831d8-5319-4942-883d-8494b85b6b82> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004828/d77f8c22-e459-40f9-97f9-2c0bd6ab5f70> a WB:WBGene00004828,
+<http://model.geneontology.org/WB_WBGene00004828/b9b49b62-7fab-4aa3-99de-28b881227440> a WB:WBGene00004828,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004828/e72df5e4-5065-480a-9daf-dad68d04a18e> a WB:WBGene00004828,
+<http://model.geneontology.org/WB_WBGene00004828/ebf532e2-5d36-4f93-be69-209b5dd05727> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004828/903d5cb0-429d-4a5d-ac54-593fd6997e99> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004828/d7b715ed-2549-4979-bbbc-8e67cd006cc5> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004828  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5273|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/914df5db-d611-4ed3-8163-256c8e86b0ef> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/9cc2d19f-f7fb-4029-9490-0ea90c4e63b5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/11b80736-d7fc-4eab-b40d-2dbed2a13d5b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/3f803ad4-554d-47c3-87d0-d827f9dad384> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004828/4a601fc7-0d54-4f24-b535-0291e413b08b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004828/378889fb-1c93-45a9-835c-cce01b4c9a97> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004828  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5272|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/cdff4e16-dcf2-4c04-a56d-e73ab919bc47> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/d77f8c22-e459-40f9-97f9-2c0bd6ab5f70> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004828/aa12315b-ae6a-4bc7-89c8-b82394525ea8> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004828  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5272|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/cdff4e16-dcf2-4c04-a56d-e73ab919bc47> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/a4f831d8-5319-4942-883d-8494b85b6b82> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/2ee8044a-5f96-4c35-8fc6-828b19261e01> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/ebf532e2-5d36-4f93-be69-209b5dd05727> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004828/c5dad9a8-6046-4ba1-bc45-463b3a6699da> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004828/553b93a5-ff19-487c-966f-a8be53396f82> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004828  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5272|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/2ee8044a-5f96-4c35-8fc6-828b19261e01> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/b9b49b62-7fab-4aa3-99de-28b881227440> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004828/0530159e-92ed-436b-99dc-19db7aed7c9f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004828  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5273|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/914df5db-d611-4ed3-8163-256c8e86b0ef> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/e72df5e4-5065-480a-9daf-dad68d04a18e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004828/11b80736-d7fc-4eab-b40d-2dbed2a13d5b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004828/b3a8191b-fa25-4c14-ac1f-5701dd6ec8a8> .
 

--- a/models/WB_WBGene00004864.ttl
+++ b/models/WB_WBGene00004864.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,118 +29,124 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004864> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-12 (WB:WBGene00004864)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004864> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004864/59477e7e-ed30-4445-8457-e8ed5eca0455> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004864/2f46874a-e8b2-46a1-b2e8-235a73605d7b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
+    ns1:evidence-with "WB:WBVar00275177" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004864/33e49765-bc51-489a-834b-6a39d64b68fe> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000936" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000936" .
 
-<http://model.geneontology.org/WB_WBGene00004864/6c3a5bda-4eef-46d5-98ce-71e811741483> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004864/392ef80a-9738-46cd-a82c-81257e42f4a7> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
+    ns1:evidence-with "WB:WBGene00000936" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000936" .
 
-<http://model.geneontology.org/WB_WBGene00004864/833755cf-5d72-46c9-a668-0678605a4ae1> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004864/49b179ae-e416-4ba6-8227-4242c33f8f23> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
+    ns1:evidence-with "WB:WBVar00275177" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004864/897f0132-b7d1-4792-a22e-bd3fd3d5ecc3> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003055" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000936" .
 
-<http://model.geneontology.org/WB_WBGene00004864/b823440d-0663-4d6f-bbfc-9b1305f919d6> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004864/bacab03e-d762-4203-9d9d-5504acc01d54> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
+    ns1:evidence-with "WB:WBGene00003055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00000936" .
 
-<http://model.geneontology.org/WB_WBGene00004864/c55142a8-3f76-470a-b86b-7abbca9d3e39> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004864/13e5f0d0-9d58-4c81-bf6c-48ebd7f4610e> a GO:0003674,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275177" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004864/e52161d5-d6c6-4ac2-bd83-2e5c689f20e2> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275177" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004864/00dfc521-0a42-471f-9c8b-d0a97338d00e> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004864/83dd2124-72bc-4c86-868a-58c020150caa> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004864/2d1d592b-d0de-47fa-bc46-b23d22b8e971> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004864/ff06d4b3-1941-48a5-82c1-5ddace66c665> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004864/29a44f42-3da1-49b9-a6dd-b7204ff46bf5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004864/2d1d592b-d0de-47fa-bc46-b23d22b8e971> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004864/29a44f42-3da1-49b9-a6dd-b7204ff46bf5> a GO:0007179,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004864/2f1b9e8f-102a-4262-aa34-ebd333e4a2e8> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004864/9377b79d-82aa-45a9-ab4c-3cf120e23b82> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004864/c3e626ae-777d-4707-b10e-9a0eddb632c7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004864/83dd2124-72bc-4c86-868a-58c020150caa> a WB:WBGene00004864,
+<http://model.geneontology.org/WB_WBGene00004864/64929619-1e73-49a8-ac46-9548179915e4> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004864/9377b79d-82aa-45a9-ab4c-3cf120e23b82> a WB:WBGene00004864,
+<http://model.geneontology.org/WB_WBGene00004864/9ba1fdd9-7050-4205-9d42-3a3faff8f4bb> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004864/ce36339d-16c3-452d-9632-00a9903c4217> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004864/64929619-1e73-49a8-ac46-9548179915e4> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004864/ce36339d-16c3-452d-9632-00a9903c4217> a WB:WBGene00004864,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004864/c3e626ae-777d-4707-b10e-9a0eddb632c7> a GO:0007179,
+<http://model.geneontology.org/WB_WBGene00004864/ff06d4b3-1941-48a5-82c1-5ddace66c665> a WB:WBGene00004864,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -148,54 +154,54 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004864/c55142a8-3f76-470a-b86b-7abbca9d3e39> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004864/33e49765-bc51-489a-834b-6a39d64b68fe>,
+        <http://model.geneontology.org/WB_WBGene00004864/897f0132-b7d1-4792-a22e-bd3fd3d5ecc3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275177  2021-05-13 WB  id=WBOA:5356|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/00dfc521-0a42-471f-9c8b-d0a97338d00e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/2d1d592b-d0de-47fa-bc46-b23d22b8e971> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004864/59477e7e-ed30-4445-8457-e8ed5eca0455>,
-        <http://model.geneontology.org/WB_WBGene00004864/6c3a5bda-4eef-46d5-98ce-71e811741483> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5358|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=WB:WBGene00000936|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00004864  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5357|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=WB:WBGene00000936|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/2f1b9e8f-102a-4262-aa34-ebd333e4a2e8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/c3e626ae-777d-4707-b10e-9a0eddb632c7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004864/e52161d5-d6c6-4ac2-bd83-2e5c689f20e2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275177  2021-05-13 WB  id=WBOA:5356|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/00dfc521-0a42-471f-9c8b-d0a97338d00e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/83dd2124-72bc-4c86-868a-58c020150caa> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004864/833755cf-5d72-46c9-a668-0678605a4ae1>,
-        <http://model.geneontology.org/WB_WBGene00004864/b823440d-0663-4d6f-bbfc-9b1305f919d6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5358|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=WB:WBGene00000936|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004864  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5357|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=WB:WBGene00000936|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/2f1b9e8f-102a-4262-aa34-ebd333e4a2e8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/9377b79d-82aa-45a9-ab4c-3cf120e23b82> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/13e5f0d0-9d58-4c81-bf6c-48ebd7f4610e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/ff06d4b3-1941-48a5-82c1-5ddace66c665> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004864/392ef80a-9738-46cd-a82c-81257e42f4a7>,
+        <http://model.geneontology.org/WB_WBGene00004864/bacab03e-d762-4203-9d9d-5504acc01d54> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5358|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=WB:WBGene00000936|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00004864  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5357|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=WB:WBGene00000936|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/13e5f0d0-9d58-4c81-bf6c-48ebd7f4610e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/29a44f42-3da1-49b9-a6dd-b7204ff46bf5> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004864/2f46874a-e8b2-46a1-b2e8-235a73605d7b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275177  2021-05-13 WB  id=WBOA:5356|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/9ba1fdd9-7050-4205-9d42-3a3faff8f4bb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/ce36339d-16c3-452d-9632-00a9903c4217> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004864/49b179ae-e416-4ba6-8227-4242c33f8f23> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004864  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275177  2021-05-13 WB  id=WBOA:5356|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004864/9ba1fdd9-7050-4205-9d42-3a3faff8f4bb> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004864/64929619-1e73-49a8-ac46-9548179915e4> .
 

--- a/models/WB_WBGene00004865.ttl
+++ b/models/WB_WBGene00004865.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,130 +29,138 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004865> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-13 (WB:WBGene00004865)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004865> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004865/08df65b0-a1bd-4a62-9fb1-e020671a2cfc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004865/1a9c6824-2e49-4489-89f1-40bb9898c3d1> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275167" ;
+    ns1:evidence-with "WB:WBVar00275167" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/1903766a-eade-44b5-b318-eb299de761b9> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004865/28f4b290-cd28-4c37-992d-2956984f3b86> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
+    ns1:evidence-with "WB:WBGene00003055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/3692b649-b0f8-4347-832d-abdac49529e2> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004865/37af9cdc-cb40-4373-9706-31ca44c7eebe> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
+    ns1:evidence-with "WB:WBGene00000936" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/52d14238-51c9-48ba-bb80-85b65a154de1> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004865/44c0eb01-19ea-415d-b2c4-b60a2e722c04> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
+    ns1:evidence-with "WB:WBGene00003055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/9e5af8fd-eb1b-4f45-9a2b-70675d2cbf8c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004865/474987a5-a6e2-4526-8d34-ae1800496173> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275181" ;
+    ns1:evidence-with "WB:WBVar00275181" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/ad7305a0-cd8a-41a0-8180-d746c0f8442b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004865/5c005cba-1d75-4c4a-85dd-090ad0646b98> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275167" ;
+    ns1:evidence-with "WB:WBGene00000936" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/bd5a7c14-0562-42fd-8fe1-7295acbe8ed1> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004865/ce2d1369-4861-4e4a-a449-dd8a2691f4bc> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
+    ns1:evidence-with "WB:WBVar00275181" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/d0e3daea-a497-45cd-a7c0-a4a5b498d918> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004865/e5dc73ee-b2c8-43e5-a065-361fead41764> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275181" ;
+    ns1:evidence-with "WB:WBVar00275167" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/58ea0a9b-7570-4381-9463-f42bdd782bb7> a GO:0007179,
+<http://model.geneontology.org/WB_WBGene00004865/3ba48b07-8a00-4618-af42-8fc7249c2840> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004865/b628993f-4c5e-4478-8767-41df64618856> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004865/77ae2a95-7520-4695-a94b-09d2d10fe1ee> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004865/6934a444-8510-4416-97f4-99553bf18f7b> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004865/d6f5319e-f206-41b6-8e4b-8b2d00b14f52> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004865/bf9bbe36-d47f-4205-acb4-6657824b4f08> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004865/77ae2a95-7520-4695-a94b-09d2d10fe1ee> a GO:0007179,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/754c0a85-f249-4406-8b2c-eb656f6f7a47> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004865/b628993f-4c5e-4478-8767-41df64618856> a WB:WBGene00004865,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/884ebb6a-f925-40ce-8ab4-4e0fc067b765> a WB:WBGene00004865,
+<http://model.geneontology.org/WB_WBGene00004865/bf9bbe36-d47f-4205-acb4-6657824b4f08> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004865/9855c485-3e23-44be-b63b-7ce9037e8140> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004865/884ebb6a-f925-40ce-8ab4-4e0fc067b765> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004865/58ea0a9b-7570-4381-9463-f42bdd782bb7> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004865/c2954b2c-ed61-45a9-a2af-cd2f7ab03540> a WB:WBGene00004865,
+<http://model.geneontology.org/WB_WBGene00004865/d6f5319e-f206-41b6-8e4b-8b2d00b14f52> a WB:WBGene00004865,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004865/e1950994-451c-4380-afa7-91f0a7e3af39> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004865/c2954b2c-ed61-45a9-a2af-cd2f7ab03540> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004865/754c0a85-f249-4406-8b2c-eb656f6f7a47> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -160,58 +168,58 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004865/ad7305a0-cd8a-41a0-8180-d746c0f8442b>,
-        <http://model.geneontology.org/WB_WBGene00004865/d0e3daea-a497-45cd-a7c0-a4a5b498d918> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004865/28f4b290-cd28-4c37-992d-2956984f3b86>,
+        <http://model.geneontology.org/WB_WBGene00004865/5c005cba-1d75-4c4a-85dd-090ad0646b98> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004865  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275167  2021-05-13 WB  id=WBOA:89566|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00004865  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275181  2021-05-13 WB  id=WBOA:5359|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/e1950994-451c-4380-afa7-91f0a7e3af39> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/754c0a85-f249-4406-8b2c-eb656f6f7a47> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004865/1903766a-eade-44b5-b318-eb299de761b9>,
-        <http://model.geneontology.org/WB_WBGene00004865/bd5a7c14-0562-42fd-8fe1-7295acbe8ed1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004865  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5361|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004865  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5360|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/9855c485-3e23-44be-b63b-7ce9037e8140> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/884ebb6a-f925-40ce-8ab4-4e0fc067b765> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/3ba48b07-8a00-4618-af42-8fc7249c2840> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/b628993f-4c5e-4478-8767-41df64618856> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004865/3692b649-b0f8-4347-832d-abdac49529e2>,
-        <http://model.geneontology.org/WB_WBGene00004865/52d14238-51c9-48ba-bb80-85b65a154de1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004865/474987a5-a6e2-4526-8d34-ae1800496173>,
+        <http://model.geneontology.org/WB_WBGene00004865/e5dc73ee-b2c8-43e5-a065-361fead41764> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004865  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5361|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00004865  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5360|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00004865  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275167  2021-05-13 WB  id=WBOA:89566|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00004865  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275181  2021-05-13 WB  id=WBOA:5359|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/9855c485-3e23-44be-b63b-7ce9037e8140> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/58ea0a9b-7570-4381-9463-f42bdd782bb7> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/6934a444-8510-4416-97f4-99553bf18f7b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/bf9bbe36-d47f-4205-acb4-6657824b4f08> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004865/08df65b0-a1bd-4a62-9fb1-e020671a2cfc>,
-        <http://model.geneontology.org/WB_WBGene00004865/9e5af8fd-eb1b-4f45-9a2b-70675d2cbf8c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004865/1a9c6824-2e49-4489-89f1-40bb9898c3d1>,
+        <http://model.geneontology.org/WB_WBGene00004865/ce2d1369-4861-4e4a-a449-dd8a2691f4bc> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004865  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275167  2021-05-13 WB  id=WBOA:89566|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004865  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275181  2021-05-13 WB  id=WBOA:5359|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/e1950994-451c-4380-afa7-91f0a7e3af39> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/c2954b2c-ed61-45a9-a2af-cd2f7ab03540> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/6934a444-8510-4416-97f4-99553bf18f7b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/d6f5319e-f206-41b6-8e4b-8b2d00b14f52> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004865/37af9cdc-cb40-4373-9706-31ca44c7eebe>,
+        <http://model.geneontology.org/WB_WBGene00004865/44c0eb01-19ea-415d-b2c4-b60a2e722c04> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004865  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5361|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00004865  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5360|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004865/3ba48b07-8a00-4618-af42-8fc7249c2840> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004865/77ae2a95-7520-4695-a94b-09d2d10fe1ee> .
 

--- a/models/WB_WBGene00004866.ttl
+++ b/models/WB_WBGene00004866.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,156 +29,164 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004866> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-14 (WB:WBGene00004866)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004866> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004866/164e7608-1c1b-4646-927a-0026c56296ea> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004866/08cc3e0a-620a-44d0-b5bc-b8c0993e40a5> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275168" ;
+    ns1:evidence-with "WB:WBVar00275168" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/40d9981d-6e0f-4a76-a907-a5a355cf47dd> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004866/8448289f-f99e-40dc-8346-6c38cea27e45> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
+    ns1:evidence-with "WB:WBGene00000936" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/51f1f011-348f-4cee-a1a8-4338c09519f6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004866/93f6b978-869a-488c-944e-7f04caabcfaa> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275168" ;
+    ns1:evidence-with "WB:WBGene00000936" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/816b6c5d-f46b-47ab-9aaa-bb9f7871f68c> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004866/9529c59f-1496-4660-be48-7632959ec83f> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
+    ns1:evidence-with "WB:WBVar00275168" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/84508a16-a9ac-49f1-8027-d507085f7f3d> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004866/958fbac8-ba5b-4676-87a5-7d8f358d16d4> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
+    ns1:evidence-with "WB:WBGene00003055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/c0780a05-3c02-4636-9154-18e50a50ccf3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004866/ac380219-590d-4851-ae14-86ec2ade70df> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275168" ;
+    ns1:evidence-with "WB:WBVar00275168" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/d014d37c-1fe1-4ac7-97f7-135b5d2a9dd0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004866/bde945cf-e7bc-49e4-829b-e3814821214c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275168" ;
+    ns1:evidence-with "WB:WBVar00275168" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/d35234ce-c00b-407e-8599-cd6ca503a5bb> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004866/c05df29a-6829-4480-919b-fca0e9e865b4> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
+    ns1:evidence-with "WB:WBGene00003055" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/010e123d-ee22-43ba-a195-2850026318aa> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004866/44f96729-404c-40f6-877e-bc12720a4087> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004866/5fd6a7ab-175a-4130-b67e-cec61bd95720> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004866/f1095e19-f24f-4823-b98f-27792b705d11> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004866/8e680a1a-be19-4e7e-9a43-743bd72fa770> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004866/5f4a9469-28ca-4eed-9326-877a20f196d6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/1f46a2b7-b83a-47ac-9486-7c8ef5efa30f> a WB:WBGene00004866,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004866/2c555ddd-add4-4bf3-b1b8-95d1eb3eb7f6> a GO:0045138,
+<http://model.geneontology.org/WB_WBGene00004866/5f4a9469-28ca-4eed-9326-877a20f196d6> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/45a40a03-743a-4ed4-a91e-429c7452bb5a> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004866/606d417b-4c4f-4777-bc58-dc6839512dc9> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004866/8c9170e0-d28a-435d-8403-a38e95860bba> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004866/2c555ddd-add4-4bf3-b1b8-95d1eb3eb7f6> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004866/ff08b1e2-0b15-4e3d-ba1f-eeed18dd3129> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004866/8a22d1a2-c089-476e-9ed0-94d87bfe3759> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/5fd6a7ab-175a-4130-b67e-cec61bd95720> a WB:WBGene00004866,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004866/778d92df-bfdc-45f0-820e-4ae08a0c33b5> a GO:0007179,
+<http://model.geneontology.org/WB_WBGene00004866/85bd23cc-8082-49ce-a19c-0e64ac97a5de> a WB:WBGene00004866,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/8c9170e0-d28a-435d-8403-a38e95860bba> a WB:WBGene00004866,
+<http://model.geneontology.org/WB_WBGene00004866/8a22d1a2-c089-476e-9ed0-94d87bfe3759> a GO:0045138,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004866/8de75442-f14d-4bd3-930a-bcb3c12607ac> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004866/1f46a2b7-b83a-47ac-9486-7c8ef5efa30f> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004866/778d92df-bfdc-45f0-820e-4ae08a0c33b5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004866/f1095e19-f24f-4823-b98f-27792b705d11> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004866/8e680a1a-be19-4e7e-9a43-743bd72fa770> a WB:WBGene00004866,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004866/bf1fd79e-1821-4363-98a2-8ed6215afed2> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004866/85bd23cc-8082-49ce-a19c-0e64ac97a5de> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004866/ed4c46a1-15cb-4441-b4a0-0821eeb47ff6> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004866/ed4c46a1-15cb-4441-b4a0-0821eeb47ff6> a GO:0007179,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004866/ff08b1e2-0b15-4e3d-ba1f-eeed18dd3129> a WB:WBGene00004866,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -186,78 +194,78 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004866/40d9981d-6e0f-4a76-a907-a5a355cf47dd>,
-        <http://model.geneontology.org/WB_WBGene00004866/84508a16-a9ac-49f1-8027-d507085f7f3d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004866/8448289f-f99e-40dc-8346-6c38cea27e45>,
+        <http://model.geneontology.org/WB_WBGene00004866/958fbac8-ba5b-4676-87a5-7d8f358d16d4> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5365|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00004866  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5364|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/8de75442-f14d-4bd3-930a-bcb3c12607ac> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/1f46a2b7-b83a-47ac-9486-7c8ef5efa30f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004866/d014d37c-1fe1-4ac7-97f7-135b5d2a9dd0> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5362|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/010e123d-ee22-43ba-a195-2850026318aa> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/5fd6a7ab-175a-4130-b67e-cec61bd95720> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004866/c0780a05-3c02-4636-9154-18e50a50ccf3> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5362|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/010e123d-ee22-43ba-a195-2850026318aa> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/f1095e19-f24f-4823-b98f-27792b705d11> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004866/51f1f011-348f-4cee-a1a8-4338c09519f6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5363|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/45a40a03-743a-4ed4-a91e-429c7452bb5a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/8c9170e0-d28a-435d-8403-a38e95860bba> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004866/816b6c5d-f46b-47ab-9aaa-bb9f7871f68c>,
-        <http://model.geneontology.org/WB_WBGene00004866/d35234ce-c00b-407e-8599-cd6ca503a5bb> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5365|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004866  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5364|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/8de75442-f14d-4bd3-930a-bcb3c12607ac> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/778d92df-bfdc-45f0-820e-4ae08a0c33b5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/bf1fd79e-1821-4363-98a2-8ed6215afed2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/ed4c46a1-15cb-4441-b4a0-0821eeb47ff6> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004866/164e7608-1c1b-4646-927a-0026c56296ea> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004866/9529c59f-1496-4660-be48-7632959ec83f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5363|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/606d417b-4c4f-4777-bc58-dc6839512dc9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/ff08b1e2-0b15-4e3d-ba1f-eeed18dd3129> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004866/bde945cf-e7bc-49e4-829b-e3814821214c> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5362|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/44f96729-404c-40f6-877e-bc12720a4087> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/5f4a9469-28ca-4eed-9326-877a20f196d6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004866/93f6b978-869a-488c-944e-7f04caabcfaa>,
+        <http://model.geneontology.org/WB_WBGene00004866/c05df29a-6829-4480-919b-fca0e9e865b4> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5365|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00004866  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5364|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/bf1fd79e-1821-4363-98a2-8ed6215afed2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/85bd23cc-8082-49ce-a19c-0e64ac97a5de> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004866/ac380219-590d-4851-ae14-86ec2ade70df> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5362|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/44f96729-404c-40f6-877e-bc12720a4087> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/8e680a1a-be19-4e7e-9a43-743bd72fa770> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004866/08cc3e0a-620a-44d0-b5bc-b8c0993e40a5> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004866  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275168  2021-05-13 WB  id=WBOA:5363|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/45a40a03-743a-4ed4-a91e-429c7452bb5a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/2c555ddd-add4-4bf3-b1b8-95d1eb3eb7f6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004866/606d417b-4c4f-4777-bc58-dc6839512dc9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004866/8a22d1a2-c089-476e-9ed0-94d87bfe3759> .
 

--- a/models/WB_WBGene00004868.ttl
+++ b/models/WB_WBGene00004868.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004868> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-16 (WB:WBGene00004868)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004868> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004868/05ce5f58-48c9-4ca1-ae0f-a46be8cfeb05> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004868/039e48ec-464d-4650-bde1-5106e601bfe4> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275170" ;
+    ns1:evidence-with "WB:WBVar00275170" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/7145e161-ca24-41e7-b82c-3b71b70c0800> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004868/6f960203-70e5-430a-bfb1-1aa22c7e7afa> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275170" ;
+    ns1:evidence-with "WB:WBVar00275170" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/90c6a509-6931-4ece-b00b-3410f9e1da8d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004868/9a9d5c39-4f0e-4fd5-848f-25b62a8ab1b6> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275170" ;
+    ns1:evidence-with "WB:WBVar00275170" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/d98a78b1-6054-43f4-b8df-60b8940e9732> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004868/d15d4feb-2ae0-441d-b4d3-fb0f7930be86> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275170" ;
+    ns1:evidence-with "WB:WBVar00275170" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/38080056-b786-4227-a61a-458e7b5b082c> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004868/07c87a7b-399f-474e-89f1-df8f2265ccc3> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004868/7fcfce08-f515-465e-bf07-917911595a62> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004868/f058fba2-5b05-48a4-96a8-6a6b6cd613fb> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004868/2ccb3265-2738-4a76-b1b6-9a446d60f6e1> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/7a374e6b-70aa-43db-a988-0d2a95848558> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004868/fd27228e-1788-4207-a3c8-8809974979a6> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004868/c38e528a-a94c-4da1-97b2-634ca7a8bba1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004868/a0747faa-b88c-4e0d-9d46-7d3bf1fa9009> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004868/d0b61d4c-d0c6-4d78-a11c-787d8b1a43f1> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004868/38080056-b786-4227-a61a-458e7b5b082c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004868/c38e528a-a94c-4da1-97b2-634ca7a8bba1> a GO:0045138,
+<http://model.geneontology.org/WB_WBGene00004868/3f42b98e-0acf-47f1-9072-7ba310ecd3aa> a WB:WBGene00004868,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/d0b61d4c-d0c6-4d78-a11c-787d8b1a43f1> a WB:WBGene00004868,
+<http://model.geneontology.org/WB_WBGene00004868/7fcfce08-f515-465e-bf07-917911595a62> a WB:WBGene00004868,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004868/fd27228e-1788-4207-a3c8-8809974979a6> a WB:WBGene00004868,
+<http://model.geneontology.org/WB_WBGene00004868/854bb75c-4443-4e1f-a9f0-603d4bdabe2f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004868/3f42b98e-0acf-47f1-9072-7ba310ecd3aa> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004868/2ccb3265-2738-4a76-b1b6-9a446d60f6e1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004868/f058fba2-5b05-48a4-96a8-6a6b6cd613fb> a GO:0045138,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004868/90c6a509-6931-4ece-b00b-3410f9e1da8d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004868/d15d4feb-2ae0-441d-b4d3-fb0f7930be86> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004868  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275170  2021-05-13 WB  id=WBOA:5366|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/a0747faa-b88c-4e0d-9d46-7d3bf1fa9009> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/d0b61d4c-d0c6-4d78-a11c-787d8b1a43f1> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004868/d98a78b1-6054-43f4-b8df-60b8940e9732> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004868  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275170  2021-05-13 WB  id=WBOA:5367|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/7a374e6b-70aa-43db-a988-0d2a95848558> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/fd27228e-1788-4207-a3c8-8809974979a6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/07c87a7b-399f-474e-89f1-df8f2265ccc3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/7fcfce08-f515-465e-bf07-917911595a62> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004868/05ce5f58-48c9-4ca1-ae0f-a46be8cfeb05> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004868/6f960203-70e5-430a-bfb1-1aa22c7e7afa> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004868  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275170  2021-05-13 WB  id=WBOA:5366|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/a0747faa-b88c-4e0d-9d46-7d3bf1fa9009> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/38080056-b786-4227-a61a-458e7b5b082c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004868/7145e161-ca24-41e7-b82c-3b71b70c0800> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004868  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275170  2021-05-13 WB  id=WBOA:5367|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/7a374e6b-70aa-43db-a988-0d2a95848558> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/c38e528a-a94c-4da1-97b2-634ca7a8bba1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/07c87a7b-399f-474e-89f1-df8f2265ccc3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/f058fba2-5b05-48a4-96a8-6a6b6cd613fb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004868/039e48ec-464d-4650-bde1-5106e601bfe4> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004868  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275170  2021-05-13 WB  id=WBOA:5366|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/854bb75c-4443-4e1f-a9f0-603d4bdabe2f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/3f42b98e-0acf-47f1-9072-7ba310ecd3aa> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004868/9a9d5c39-4f0e-4fd5-848f-25b62a8ab1b6> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004868  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275170  2021-05-13 WB  id=WBOA:5366|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004868/854bb75c-4443-4e1f-a9f0-603d4bdabe2f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004868/2ccb3265-2738-4a76-b1b6-9a446d60f6e1> .
 

--- a/models/WB_WBGene00004869.ttl
+++ b/models/WB_WBGene00004869.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004869> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-17 (WB:WBGene00004869)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004869> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004869/2cfe129b-014c-4785-924a-d7365b7b75aa> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004869/80bde895-24f3-4c33-9d79-0af7753d769a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275171" ;
+    ns1:evidence-with "WB:WBVar00275171" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004869/b8cf5bb5-3388-4443-b3fc-b0c0c660d053> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004869/e0dfb3ff-643f-4da7-87cd-3381d3066e21> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275171" ;
+    ns1:evidence-with "WB:WBVar00275171" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004869/33e151b2-3d0a-4fda-a11d-e444b880f83a> a WB:WBGene00004869,
+<http://model.geneontology.org/WB_WBGene00004869/3435413f-bfe6-447b-b650-3432e7661ac9> a WB:WBGene00004869,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004869/cae0c5e9-bd9f-4b32-92a5-5b2895c37c24> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004869/3b250598-dd76-48e2-9472-a14d1a8912e2> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004869/33e151b2-3d0a-4fda-a11d-e444b880f83a> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004869/cd3d8675-58bb-4cac-bd2a-7e9853964606> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004869/3435413f-bfe6-447b-b650-3432e7661ac9> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004869/785a2208-35d6-4126-83d4-aef5b369b59f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004869/cd3d8675-58bb-4cac-bd2a-7e9853964606> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004869/785a2208-35d6-4126-83d4-aef5b369b59f> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004869/2cfe129b-014c-4785-924a-d7365b7b75aa> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004869/80bde895-24f3-4c33-9d79-0af7753d769a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004869  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275171  2021-05-13 WB  id=WBOA:5368|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004869/cae0c5e9-bd9f-4b32-92a5-5b2895c37c24> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004869/33e151b2-3d0a-4fda-a11d-e444b880f83a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004869/3b250598-dd76-48e2-9472-a14d1a8912e2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004869/3435413f-bfe6-447b-b650-3432e7661ac9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004869/b8cf5bb5-3388-4443-b3fc-b0c0c660d053> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004869/e0dfb3ff-643f-4da7-87cd-3381d3066e21> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004869  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275171  2021-05-13 WB  id=WBOA:5368|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004869/cae0c5e9-bd9f-4b32-92a5-5b2895c37c24> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004869/cd3d8675-58bb-4cac-bd2a-7e9853964606> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004869/3b250598-dd76-48e2-9472-a14d1a8912e2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004869/785a2208-35d6-4126-83d4-aef5b369b59f> .
 

--- a/models/WB_WBGene00004870.ttl
+++ b/models/WB_WBGene00004870.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004870> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-18 (WB:WBGene00004870)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004870> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004870/15ac571e-8964-43b6-8e11-919433d7f68c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004870/bdcc5abe-01e8-4047-bd5c-27e5decc08ce> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275176" ;
+    ns1:evidence-with "WB:WBVar00275176" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004870/24441ff1-272f-4877-b6f0-7083913a781d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004870/d85bc20d-886c-4619-be8e-e4a668d22c82> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275176" ;
+    ns1:evidence-with "WB:WBVar00275176" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004870/d2f9cbfa-2760-4ba4-bd80-b816d06e700c> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004870/7f242d88-abf0-4604-ac82-c844d9669eee> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004870/de640f03-9705-4280-9289-8edb86d99110> a WB:WBGene00004870,
+<http://model.geneontology.org/WB_WBGene00004870/87b0cbf4-c43c-4f1a-9ab6-65ada047def8> a WB:WBGene00004870,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004870/fff589f9-0f92-4dc7-b932-a628c1c70030> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004870/d2fc0cb8-cc7c-40d2-a5b6-e80754cecb52> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004870/de640f03-9705-4280-9289-8edb86d99110> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004870/d2f9cbfa-2760-4ba4-bd80-b816d06e700c> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004870/87b0cbf4-c43c-4f1a-9ab6-65ada047def8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004870/7f242d88-abf0-4604-ac82-c844d9669eee> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004870/15ac571e-8964-43b6-8e11-919433d7f68c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004870/bdcc5abe-01e8-4047-bd5c-27e5decc08ce> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004870  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275176  2021-05-13 WB  id=WBOA:5369|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004870/fff589f9-0f92-4dc7-b932-a628c1c70030> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004870/d2f9cbfa-2760-4ba4-bd80-b816d06e700c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004870/24441ff1-272f-4877-b6f0-7083913a781d> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004870  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275176  2021-05-13 WB  id=WBOA:5369|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004870/fff589f9-0f92-4dc7-b932-a628c1c70030> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004870/de640f03-9705-4280-9289-8edb86d99110> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004870/d2fc0cb8-cc7c-40d2-a5b6-e80754cecb52> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004870/87b0cbf4-c43c-4f1a-9ab6-65ada047def8> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004870/d85bc20d-886c-4619-be8e-e4a668d22c82> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004870  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275176  2021-05-13 WB  id=WBOA:5369|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004870/d2fc0cb8-cc7c-40d2-a5b6-e80754cecb52> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004870/7f242d88-abf0-4604-ac82-c844d9669eee> .
 

--- a/models/WB_WBGene00004871.ttl
+++ b/models/WB_WBGene00004871.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,114 +29,120 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004871> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-19 (WB:WBGene00004871)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004871> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004871/38a1d88f-d2fd-4100-977e-4d6edd9910e1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004871/1b0e6c33-9ce7-41ee-b9f6-18e98efd81f7> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275180" ;
+    ns1:evidence-with "WB:WBVar00275180" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/3d1ae2d2-338f-4c80-91fc-8e9f753f2ac5> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/3d636268-7531-4b5b-a339-25078c613b33> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/b212e63c-7b34-4165-ac04-a854d58fee89> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00000936" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/d2b2754a-db20-4670-9c8a-e537b5cda679> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00003055" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/ddc6d5b0-6332-4eef-b687-45011e189979> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275180" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:12717735" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/4d3f69ce-3c83-47af-9cd1-3f2e0331aa28> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004871/5d1a3763-390e-484e-869d-e97be550ccce> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004871/69f03f39-1f63-4689-a6fb-e99a91fd2f58> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004871/5d1a3763-390e-484e-869d-e97be550ccce> a WB:WBGene00004871,
+<http://model.geneontology.org/WB_WBGene00004871/435aaa43-43f5-4838-a12a-6df5fa260d84> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003055" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/7524d595-8053-4da2-95ea-82df267d6f50> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000936" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/8824bc9e-d710-4155-bde4-98f78f8890a3> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00003055" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/d0f57828-32a3-47fc-8cf3-869bf9fcc36e> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00275180" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/ecefbcf1-155d-4f2b-a3c9-f7eaca20db31> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00000936" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/0f7015d8-8bad-48c0-bd88-45ce9de24a15> a GO:0007179,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004871/69f03f39-1f63-4689-a6fb-e99a91fd2f58> a GO:0007179,
+<http://model.geneontology.org/WB_WBGene00004871/613ab35a-599a-4683-9865-948a6fbb408a> a WB:WBGene00004871,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004871/871d7f09-f1db-41c5-97b3-db2bf6204ce7> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004871/d0a681c5-f5ae-411c-89b4-e9e30b54c028> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004871/baf3fd9a-9371-4e32-9515-60a7cdc58431> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004871/baf3fd9a-9371-4e32-9515-60a7cdc58431> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00004871/c2a27dc9-273c-4ea6-a0bc-a8b22e42cf7a> a WB:WBGene00004871,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004871/d0a681c5-f5ae-411c-89b4-e9e30b54c028> a WB:WBGene00004871,
+<http://model.geneontology.org/WB_WBGene00004871/d6f7331c-af4d-4c27-b51e-a2fc588b1e54> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/db53063f-f8f8-4e5b-8a11-bd9c8439181f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004871/613ab35a-599a-4683-9865-948a6fbb408a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004871/d6f7331c-af4d-4c27-b51e-a2fc588b1e54> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004871/e74c62ab-382a-403c-953e-a67871f02d82> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004871/c2a27dc9-273c-4ea6-a0bc-a8b22e42cf7a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004871/0f7015d8-8bad-48c0-bd88-45ce9de24a15> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -144,54 +150,54 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004871/b212e63c-7b34-4165-ac04-a854d58fee89>,
-        <http://model.geneontology.org/WB_WBGene00004871/d2b2754a-db20-4670-9c8a-e537b5cda679> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004871/435aaa43-43f5-4838-a12a-6df5fa260d84>,
+        <http://model.geneontology.org/WB_WBGene00004871/7524d595-8053-4da2-95ea-82df267d6f50> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004871  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5372|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
-        "WB:WBGene00004871  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5371|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/4d3f69ce-3c83-47af-9cd1-3f2e0331aa28> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/69f03f39-1f63-4689-a6fb-e99a91fd2f58> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004871/3d1ae2d2-338f-4c80-91fc-8e9f753f2ac5>,
-        <http://model.geneontology.org/WB_WBGene00004871/3d636268-7531-4b5b-a339-25078c613b33> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004871  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5372|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
         "WB:WBGene00004871  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5371|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/4d3f69ce-3c83-47af-9cd1-3f2e0331aa28> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/5d1a3763-390e-484e-869d-e97be550ccce> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/e74c62ab-382a-403c-953e-a67871f02d82> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/c2a27dc9-273c-4ea6-a0bc-a8b22e42cf7a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004871/38a1d88f-d2fd-4100-977e-4d6edd9910e1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004871/8824bc9e-d710-4155-bde4-98f78f8890a3>,
+        <http://model.geneontology.org/WB_WBGene00004871/ecefbcf1-155d-4f2b-a3c9-f7eaca20db31> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004871  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00000936  2021-05-13 WB  id=WBOA:5372|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13",
+        "WB:WBGene00004871  RO:0002264 GO:0007179 WB:WBPaper00005858|PMID:12717735 ECO:0000316 WB:WBGene00003055  2021-05-13 WB  id=WBOA:5371|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/e74c62ab-382a-403c-953e-a67871f02d82> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/0f7015d8-8bad-48c0-bd88-45ce9de24a15> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004871/d0f57828-32a3-47fc-8cf3-869bf9fcc36e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004871  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275180  2021-05-13 WB  id=WBOA:5370|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/871d7f09-f1db-41c5-97b3-db2bf6204ce7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/baf3fd9a-9371-4e32-9515-60a7cdc58431> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/db53063f-f8f8-4e5b-8a11-bd9c8439181f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/d6f7331c-af4d-4c27-b51e-a2fc588b1e54> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004871/ddc6d5b0-6332-4eef-b687-45011e189979> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004871/1b0e6c33-9ce7-41ee-b9f6-18e98efd81f7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004871  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275180  2021-05-13 WB  id=WBOA:5370|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/871d7f09-f1db-41c5-97b3-db2bf6204ce7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/d0a681c5-f5ae-411c-89b4-e9e30b54c028> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004871/db53063f-f8f8-4e5b-8a11-bd9c8439181f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004871/613ab35a-599a-4683-9865-948a6fbb408a> .
 

--- a/models/WB_WBGene00004872.ttl
+++ b/models/WB_WBGene00004872.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004872> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sma-20 (WB:WBGene00004872)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004872> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004872/11344f83-b2f1-4481-9c7c-d9242e828eb6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004872/040f2d7c-aaf2-441d-b211-32ff7462fc28> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275158" ;
+    ns1:evidence-with "WB:WBVar00275158" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/1dae2a47-3fab-48d6-9a4b-417d63eabf9e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004872/3896ce3f-e4e3-4e4e-918e-c04402ac0a2f> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275158" ;
+    ns1:evidence-with "WB:WBVar00275158" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/5288a3f4-55bc-4b40-b94e-591d3003b161> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004872/50f0c89b-6d5e-4408-8545-2d02d10e700e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275158" ;
+    ns1:evidence-with "WB:WBVar00275158" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/9ca5be94-4388-4aa9-975d-975435bb15ed> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004872/71312723-d899-416f-ac7c-86989f12845c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275158" ;
+    ns1:evidence-with "WB:WBVar00275158" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/b04ef944-b913-482b-90e0-74bfb413f50e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004872/bfc25462-0d39-4787-a452-7f55f52af5a1> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275158" ;
+    ns1:evidence-with "WB:WBVar00275158" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/daeeced3-595d-4a86-9431-469b77ea9a4a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004872/ca904080-1d5e-4c86-bd38-f1d7f9461e08> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275158" ;
+    ns1:evidence-with "WB:WBVar00275158" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12717735" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/0b7358d0-274c-44fa-8155-b113c935357b> a WB:WBGene00004872,
+<http://model.geneontology.org/WB_WBGene00004872/0496937b-173c-491e-be38-5c5092d77296> a WB:WBGene00004872,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/1702aedc-0980-4720-9090-f8e2eee510ae> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004872/4aa4a750-6325-4acb-9e6e-3af297636cf8> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004872/0b7358d0-274c-44fa-8155-b113c935357b> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004872/5862dda1-ff8c-4846-9e42-4ce5ab8eb2ab> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004872/95f2b778-3f01-483a-8d93-1a7d6ab295db> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004872/93f4cadf-2338-451f-b4d3-c7dad4d8be22> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/5862dda1-ff8c-4846-9e42-4ce5ab8eb2ab> a GO:0035264,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004872/769e16a9-c408-4913-8b35-2a4b7d338053> a WB:WBGene00004872,
+<http://model.geneontology.org/WB_WBGene00004872/76cd4dc6-9732-4f46-9029-f6a9136677f0> a GO:0040024,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/76ada4f8-4e84-433c-a516-e8e9c3966f97> a GO:0045138,
+<http://model.geneontology.org/WB_WBGene00004872/93f4cadf-2338-451f-b4d3-c7dad4d8be22> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/80e7cfe3-2277-44f0-9308-2856673e21c0> a WB:WBGene00004872,
+<http://model.geneontology.org/WB_WBGene00004872/95f2b778-3f01-483a-8d93-1a7d6ab295db> a WB:WBGene00004872,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/a034b52d-bacb-4c1c-9901-ec90d330f0f6> a GO:0040024,
+<http://model.geneontology.org/WB_WBGene00004872/a55d9593-08d3-4e7d-a17a-ca3bebaa0aba> a WB:WBGene00004872,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/a656e1ee-cbb8-4174-b2d7-8267622f66ee> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004872/a6cbe503-265a-4ec5-b929-1c0bddabce4e> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004872/769e16a9-c408-4913-8b35-2a4b7d338053> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004872/76ada4f8-4e84-433c-a516-e8e9c3966f97> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004872/a55d9593-08d3-4e7d-a17a-ca3bebaa0aba> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004872/76cd4dc6-9732-4f46-9029-f6a9136677f0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004872/e5930798-a767-47c1-802f-d625fc9a1726> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004872/b039648c-4fbe-4841-8dfb-5d6c129cfffc> a GO:0045138,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004872/80e7cfe3-2277-44f0-9308-2856673e21c0> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004872/a034b52d-bacb-4c1c-9901-ec90d330f0f6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004872/f984dcc4-683a-434b-892e-21f474fd374f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004872/0496937b-173c-491e-be38-5c5092d77296> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004872/b039648c-4fbe-4841-8dfb-5d6c129cfffc> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004872/5288a3f4-55bc-4b40-b94e-591d3003b161> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004872/ca904080-1d5e-4c86-bd38-f1d7f9461e08> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0040024 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5375|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/e5930798-a767-47c1-802f-d625fc9a1726> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/80e7cfe3-2277-44f0-9308-2856673e21c0> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/a6cbe503-265a-4ec5-b929-1c0bddabce4e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/a55d9593-08d3-4e7d-a17a-ca3bebaa0aba> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004872/daeeced3-595d-4a86-9431-469b77ea9a4a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004872/50f0c89b-6d5e-4408-8545-2d02d10e700e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5373|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/4aa4a750-6325-4acb-9e6e-3af297636cf8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/95f2b778-3f01-483a-8d93-1a7d6ab295db> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004872/3896ce3f-e4e3-4e4e-918e-c04402ac0a2f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5373|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/4aa4a750-6325-4acb-9e6e-3af297636cf8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/93f4cadf-2338-451f-b4d3-c7dad4d8be22> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004872/bfc25462-0d39-4787-a452-7f55f52af5a1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5374|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/a656e1ee-cbb8-4174-b2d7-8267622f66ee> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/76ada4f8-4e84-433c-a516-e8e9c3966f97> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/f984dcc4-683a-434b-892e-21f474fd374f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/b039648c-4fbe-4841-8dfb-5d6c129cfffc> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004872/9ca5be94-4388-4aa9-975d-975435bb15ed> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004872/71312723-d899-416f-ac7c-86989f12845c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5374|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/a656e1ee-cbb8-4174-b2d7-8267622f66ee> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/769e16a9-c408-4913-8b35-2a4b7d338053> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004872/11344f83-b2f1-4481-9c7c-d9242e828eb6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0040024 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5375|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/e5930798-a767-47c1-802f-d625fc9a1726> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/a034b52d-bacb-4c1c-9901-ec90d330f0f6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/a6cbe503-265a-4ec5-b929-1c0bddabce4e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/76cd4dc6-9732-4f46-9029-f6a9136677f0> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004872/1dae2a47-3fab-48d6-9a4b-417d63eabf9e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004872/040f2d7c-aaf2-441d-b211-32ff7462fc28> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5373|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0045138 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5374|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/1702aedc-0980-4720-9090-f8e2eee510ae> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/0b7358d0-274c-44fa-8155-b113c935357b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004872/b04ef944-b913-482b-90e0-74bfb413f50e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004872  RO:0002264 GO:0035264 WB:WBPaper00005858|PMID:12717735 ECO:0000315 WB:WBVar00275158  2021-05-13 WB  id=WBOA:5373|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/1702aedc-0980-4720-9090-f8e2eee510ae> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/5862dda1-ff8c-4846-9e42-4ce5ab8eb2ab> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004872/f984dcc4-683a-434b-892e-21f474fd374f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004872/0496937b-173c-491e-be38-5c5092d77296> .
 

--- a/models/WB_WBGene00004935.ttl
+++ b/models/WB_WBGene00004935.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004935> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sog-2 (WB:WBGene00004935)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004935> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004935/2580bbe7-65cc-4a1b-8a82-22fe99356945> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004935/0b7dbd08-dee8-46b5-9123-0b76a3fe2f74> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/617a7aaa-373b-401e-8648-d5f3ad4c935b> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004935/1652a6db-7248-49f7-91fb-d69418dae753> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/7b1e385f-a558-4a03-99b7-b45351d185a1> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004935/3cc90050-3246-49a1-b8ca-28bbf0a2111e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/870cb890-26b9-411a-aa17-b5b5cf2b27d5> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004935/707c6883-dee1-432f-8620-1476ca3f772a> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/253fe05e-face-4144-94b3-53b46ca50425> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004935/114505c8-80f1-4647-a817-d54201d1382d> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004935/9f150cef-86cb-462d-bd04-decbac047038> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004935/2fb84d63-d625-46ec-8d20-26b9afb2361e> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004935/d8d37983-3df1-4f3a-bdeb-95d9bbdd5442> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004935/b9f51c27-7475-4501-ac39-c27d5cb61078> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/2fb84d63-d625-46ec-8d20-26b9afb2361e> a GO:0009792,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004935/9f150cef-86cb-462d-bd04-decbac047038> a WB:WBGene00004935,
+<http://model.geneontology.org/WB_WBGene00004935/2b123acb-9ccd-4b09-89c8-32a5aab2dfce> a GO:0007281,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/a2aabe03-ec06-4fb5-9f9d-b0a5aba3b168> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004935/b5955f8c-5f71-46ea-b881-a046e7a497bf> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004935/f41c07be-f04e-464e-aa25-003c7d4ec300> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004935/b5955f8c-5f71-46ea-b881-a046e7a497bf> a WB:WBGene00004935,
+<http://model.geneontology.org/WB_WBGene00004935/970af398-50b7-4258-9983-6be2cd68009e> a WB:WBGene00004935,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004935/f41c07be-f04e-464e-aa25-003c7d4ec300> a GO:0007281,
+<http://model.geneontology.org/WB_WBGene00004935/b401b01c-e89b-4ef5-940f-ae6b21056ba4> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004935/970af398-50b7-4258-9983-6be2cd68009e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004935/2b123acb-9ccd-4b09-89c8-32a5aab2dfce> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004935/b9f51c27-7475-4501-ac39-c27d5cb61078> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004935/d8d37983-3df1-4f3a-bdeb-95d9bbdd5442> a WB:WBGene00004935,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004935/2580bbe7-65cc-4a1b-8a82-22fe99356945> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004935/3cc90050-3246-49a1-b8ca-28bbf0a2111e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7939|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/a2aabe03-ec06-4fb5-9f9d-b0a5aba3b168> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/f41c07be-f04e-464e-aa25-003c7d4ec300> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004935/617a7aaa-373b-401e-8648-d5f3ad4c935b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7948|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/253fe05e-face-4144-94b3-53b46ca50425> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/2fb84d63-d625-46ec-8d20-26b9afb2361e> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004935/7b1e385f-a558-4a03-99b7-b45351d185a1> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7948|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/253fe05e-face-4144-94b3-53b46ca50425> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/9f150cef-86cb-462d-bd04-decbac047038> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004935/870cb890-26b9-411a-aa17-b5b5cf2b27d5> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7939|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/a2aabe03-ec06-4fb5-9f9d-b0a5aba3b168> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/b5955f8c-5f71-46ea-b881-a046e7a497bf> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/b401b01c-e89b-4ef5-940f-ae6b21056ba4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/970af398-50b7-4258-9983-6be2cd68009e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004935/0b7dbd08-dee8-46b5-9123-0b76a3fe2f74> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7948|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/114505c8-80f1-4647-a817-d54201d1382d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/b9f51c27-7475-4501-ac39-c27d5cb61078> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004935/707c6883-dee1-432f-8620-1476ca3f772a> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7939|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/b401b01c-e89b-4ef5-940f-ae6b21056ba4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/2b123acb-9ccd-4b09-89c8-32a5aab2dfce> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004935/1652a6db-7248-49f7-91fb-d69418dae753> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004935  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7948|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004935/114505c8-80f1-4647-a817-d54201d1382d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004935/d8d37983-3df1-4f3a-bdeb-95d9bbdd5442> .
 

--- a/models/WB_WBGene00004936.ttl
+++ b/models/WB_WBGene00004936.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004936> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sog-3 (WB:WBGene00004936)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004936> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004936/08f2b354-d66b-450f-a71b-362624d44a86> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004936/5e56f1c9-0d60-4228-93b3-5b931098f443> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/1d9b075c-0cb6-4aa0-a013-49c41b8611a9> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004936/c0abe5ee-4f0c-4a0e-8a10-21462d5c4568> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/6556d47b-e9c0-4efc-98b4-cc35f90d99a5> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004936/eb674c7d-1203-422c-b362-6a4ed725d9d6> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/dcbbe450-fb74-4326-a566-8163aec99b7e> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004936/f112a716-2892-4989-bb8e-977f8c9e39b3> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/25c1c5f3-6fe7-41af-870c-7f2dd8cfa50f> a WB:WBGene00004936,
+<http://model.geneontology.org/WB_WBGene00004936/278e08af-afb4-4a5f-ac90-0cc4e5cc91b0> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/51388aad-1aaf-4845-91fb-82c26b97623c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004936/25c1c5f3-6fe7-41af-870c-7f2dd8cfa50f> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004936/af5f80d0-5e86-4580-8cf3-25330c859750> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004936/794f73cc-5042-4c0b-90c3-24e5d22346ec> a GO:0007281,
+<http://model.geneontology.org/WB_WBGene00004936/396f2f43-f9f2-43dd-86b8-b9d1f3990a79> a WB:WBGene00004936,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/af5f80d0-5e86-4580-8cf3-25330c859750> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004936/9ad0db8b-dd5f-42ff-bb69-b143d4972acd> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004936/def84fce-cb09-439e-bcbd-b5a82f312d1e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004936/fff67202-2f78-45c4-9d33-fc716813844a> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004936/a66eb2c2-ac0d-4b15-8d42-d5aa072a4181> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004936/396f2f43-f9f2-43dd-86b8-b9d1f3990a79> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004936/278e08af-afb4-4a5f-ac90-0cc4e5cc91b0> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004936/def84fce-cb09-439e-bcbd-b5a82f312d1e> a WB:WBGene00004936,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004936/c1669c6e-cc81-4999-abf0-98cfdede40e1> a WB:WBGene00004936,
+<http://model.geneontology.org/WB_WBGene00004936/fff67202-2f78-45c4-9d33-fc716813844a> a GO:0007281,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004936/e7c9fd4f-580f-462f-b52f-91eddb67857b> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004936/c1669c6e-cc81-4999-abf0-98cfdede40e1> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004936/794f73cc-5042-4c0b-90c3-24e5d22346ec> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004936/6556d47b-e9c0-4efc-98b4-cc35f90d99a5> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004936/5e56f1c9-0d60-4228-93b3-5b931098f443> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7949|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/51388aad-1aaf-4845-91fb-82c26b97623c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/25c1c5f3-6fe7-41af-870c-7f2dd8cfa50f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004936/dcbbe450-fb74-4326-a566-8163aec99b7e> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7940|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/e7c9fd4f-580f-462f-b52f-91eddb67857b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/794f73cc-5042-4c0b-90c3-24e5d22346ec> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004936/08f2b354-d66b-450f-a71b-362624d44a86> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7949|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/51388aad-1aaf-4845-91fb-82c26b97623c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/af5f80d0-5e86-4580-8cf3-25330c859750> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004936/1d9b075c-0cb6-4aa0-a013-49c41b8611a9> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7940|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/e7c9fd4f-580f-462f-b52f-91eddb67857b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/c1669c6e-cc81-4999-abf0-98cfdede40e1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/9ad0db8b-dd5f-42ff-bb69-b143d4972acd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/def84fce-cb09-439e-bcbd-b5a82f312d1e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004936/eb674c7d-1203-422c-b362-6a4ed725d9d6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7940|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/9ad0db8b-dd5f-42ff-bb69-b143d4972acd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/fff67202-2f78-45c4-9d33-fc716813844a> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004936/c0abe5ee-4f0c-4a0e-8a10-21462d5c4568> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7949|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/a66eb2c2-ac0d-4b15-8d42-d5aa072a4181> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/278e08af-afb4-4a5f-ac90-0cc4e5cc91b0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004936/f112a716-2892-4989-bb8e-977f8c9e39b3> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004936  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7949|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004936/a66eb2c2-ac0d-4b15-8d42-d5aa072a4181> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004936/396f2f43-f9f2-43dd-86b8-b9d1f3990a79> .
 

--- a/models/WB_WBGene00004937.ttl
+++ b/models/WB_WBGene00004937.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004937> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sog-4 (WB:WBGene00004937)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004937> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004937/36dd22d1-eb39-4b05-a84d-bb6d64b3cb14> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004937/0d0e74af-6e12-4b85-aa95-95639828862c> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/690ce673-830b-463d-af17-5b4002f35dac> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004937/707c2faa-be1c-4738-a948-92de93c3d6c4> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/76b220f2-ea9c-4110-8ac0-81c5e1c96c4d> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004937/86345e1a-dd85-4cc1-8eec-9024b96c12a9> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/f4d9b70f-50d6-478e-be28-4b5f03f759c9> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004937/c41eddc0-8b6b-4fe4-8f2d-7d306d0896b3> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/2a0a02a1-eed2-4ec5-8a9a-1ea24ba22e98> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004937/21587653-bf39-466c-b225-56a1c84d2a9d> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004937/e8480f1d-21c5-4383-8282-efcd2b709730> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004937/dc29cdaa-26d7-4a86-acf5-3cd90b55bb53> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004937/fa9ea1a2-3aaf-4f86-a974-d74e4126df6b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004937/437cd489-b47f-494f-9e7e-2e075e0acf3d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/5af9fb59-f051-4dfc-ad7d-9caea13b9894> a GO:0009792,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004937/b6ee691a-7b16-4ed1-b593-f15b0404e30e> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004937/c7ef54b2-24e5-4b9f-aaee-38f2cf9a11c3> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004937/5af9fb59-f051-4dfc-ad7d-9caea13b9894> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004937/c7ef54b2-24e5-4b9f-aaee-38f2cf9a11c3> a WB:WBGene00004937,
+<http://model.geneontology.org/WB_WBGene00004937/437cd489-b47f-494f-9e7e-2e075e0acf3d> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/dc29cdaa-26d7-4a86-acf5-3cd90b55bb53> a GO:0007281,
+<http://model.geneontology.org/WB_WBGene00004937/59ac0be2-db73-4052-886c-45e0fd75ab95> a GO:0007281,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004937/e8480f1d-21c5-4383-8282-efcd2b709730> a WB:WBGene00004937,
+<http://model.geneontology.org/WB_WBGene00004937/e90fd29f-8800-4f45-bb4b-02a4bf344e3d> a WB:WBGene00004937,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004937/ecc7dfa6-0858-48d4-9d17-a2423b22e2cf> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004937/e90fd29f-8800-4f45-bb4b-02a4bf344e3d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004937/59ac0be2-db73-4052-886c-45e0fd75ab95> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004937/fa9ea1a2-3aaf-4f86-a974-d74e4126df6b> a WB:WBGene00004937,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004937/f4d9b70f-50d6-478e-be28-4b5f03f759c9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004937/86345e1a-dd85-4cc1-8eec-9024b96c12a9> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004937  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7941|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/2a0a02a1-eed2-4ec5-8a9a-1ea24ba22e98> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/dc29cdaa-26d7-4a86-acf5-3cd90b55bb53> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004937/36dd22d1-eb39-4b05-a84d-bb6d64b3cb14> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004937  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7950|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/b6ee691a-7b16-4ed1-b593-f15b0404e30e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/5af9fb59-f051-4dfc-ad7d-9caea13b9894> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/21587653-bf39-466c-b225-56a1c84d2a9d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/437cd489-b47f-494f-9e7e-2e075e0acf3d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004937/690ce673-830b-463d-af17-5b4002f35dac> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004937/707c2faa-be1c-4738-a948-92de93c3d6c4> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004937  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7950|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/b6ee691a-7b16-4ed1-b593-f15b0404e30e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/c7ef54b2-24e5-4b9f-aaee-38f2cf9a11c3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/21587653-bf39-466c-b225-56a1c84d2a9d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/fa9ea1a2-3aaf-4f86-a974-d74e4126df6b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004937/76b220f2-ea9c-4110-8ac0-81c5e1c96c4d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004937/c41eddc0-8b6b-4fe4-8f2d-7d306d0896b3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004937  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7941|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/ecc7dfa6-0858-48d4-9d17-a2423b22e2cf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/59ac0be2-db73-4052-886c-45e0fd75ab95> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004937/0d0e74af-6e12-4b85-aa95-95639828862c> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004937  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7941|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/2a0a02a1-eed2-4ec5-8a9a-1ea24ba22e98> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/e8480f1d-21c5-4383-8282-efcd2b709730> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004937/ecc7dfa6-0858-48d4-9d17-a2423b22e2cf> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004937/e90fd29f-8800-4f45-bb4b-02a4bf344e3d> .
 

--- a/models/WB_WBGene00004938.ttl
+++ b/models/WB_WBGene00004938.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004938> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sog-5 (WB:WBGene00004938)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004938> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004938/685ece71-36cc-4219-b225-f93cb426d896> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004938/0d50c091-ee11-474e-b8d0-f2d42e1bc529> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/8363d20b-dc8e-45f1-849a-3cfd0b252c2b> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004938/3c59eaf9-6a40-4d31-8dc7-d20d9483bef9> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/b34e3344-16a9-4a76-a766-99d44888a011> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004938/c3cbf770-c917-400c-8019-dbab82ebb095> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/d844460b-ddf6-4953-bbc5-f406462c3a35> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004938/e8ad674d-db6a-4a40-92ff-e013226e9730> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/058c53f5-e890-4966-a319-011d48145de4> a GO:0007281,
+<http://model.geneontology.org/WB_WBGene00004938/28d04992-da86-4eba-97ef-cc01352d80a6> a WB:WBGene00004938,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/2273d251-d740-4c20-bb64-bcd58bde2910> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004938/3aa57102-4716-4ec7-933c-509651e4e132> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/64ece310-454c-4d4b-b4ec-95219951cf9c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004938/d51ba8a3-2115-41c6-8785-de9700c7fc3b> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004938/058c53f5-e890-4966-a319-011d48145de4> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004938/c435d56e-8825-4e1c-b449-f9812f0dae2a> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004938/fe6052e7-b4cc-47e1-808e-9e80da214203> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004938/2273d251-d740-4c20-bb64-bcd58bde2910> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004938/d51ba8a3-2115-41c6-8785-de9700c7fc3b> a WB:WBGene00004938,
+<http://model.geneontology.org/WB_WBGene00004938/4da82d87-df8a-44ac-9add-2b1692adf330> a GO:0007281,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004938/fe6052e7-b4cc-47e1-808e-9e80da214203> a WB:WBGene00004938,
+<http://model.geneontology.org/WB_WBGene00004938/829d2149-0681-4217-8151-e6efcf62edd7> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004938/28d04992-da86-4eba-97ef-cc01352d80a6> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004938/3aa57102-4716-4ec7-933c-509651e4e132> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004938/a6a7020a-ba37-496b-b74a-0d4cdb567aa9> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004938/bc7fb2c9-3213-4145-a347-d9afba75662f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004938/4da82d87-df8a-44ac-9add-2b1692adf330> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004938/bc7fb2c9-3213-4145-a347-d9afba75662f> a WB:WBGene00004938,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004938/b34e3344-16a9-4a76-a766-99d44888a011> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004938/e8ad674d-db6a-4a40-92ff-e013226e9730> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004938  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7942|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/64ece310-454c-4d4b-b4ec-95219951cf9c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/d51ba8a3-2115-41c6-8785-de9700c7fc3b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/a6a7020a-ba37-496b-b74a-0d4cdb567aa9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/bc7fb2c9-3213-4145-a347-d9afba75662f> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004938/685ece71-36cc-4219-b225-f93cb426d896> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004938/0d50c091-ee11-474e-b8d0-f2d42e1bc529> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004938  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7951|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/c435d56e-8825-4e1c-b449-f9812f0dae2a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/2273d251-d740-4c20-bb64-bcd58bde2910> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/829d2149-0681-4217-8151-e6efcf62edd7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/3aa57102-4716-4ec7-933c-509651e4e132> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004938/d844460b-ddf6-4953-bbc5-f406462c3a35> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004938/c3cbf770-c917-400c-8019-dbab82ebb095> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004938  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7942|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/64ece310-454c-4d4b-b4ec-95219951cf9c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/058c53f5-e890-4966-a319-011d48145de4> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/a6a7020a-ba37-496b-b74a-0d4cdb567aa9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/4da82d87-df8a-44ac-9add-2b1692adf330> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004938/8363d20b-dc8e-45f1-849a-3cfd0b252c2b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004938/3c59eaf9-6a40-4d31-8dc7-d20d9483bef9> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004938  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7951|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/c435d56e-8825-4e1c-b449-f9812f0dae2a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/fe6052e7-b4cc-47e1-808e-9e80da214203> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004938/829d2149-0681-4217-8151-e6efcf62edd7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004938/28d04992-da86-4eba-97ef-cc01352d80a6> .
 

--- a/models/WB_WBGene00004939.ttl
+++ b/models/WB_WBGene00004939.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004939> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sog-6 (WB:WBGene00004939)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004939> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004939/0943ccbf-7a99-4c33-b57d-740ede585511> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004939/09362747-80f7-4562-848a-c73cc36325b5> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/14487fc6-34e3-4dc7-a604-f02e6d590654> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004939/23bcbffd-2a3a-4ad3-912d-d56d32c4dc6f> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/8823f7cd-1809-4cbc-9fcf-6bcc8d6d8296> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004939/48e24349-d3aa-4783-bd73-ae891a2b17b5> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/fbaccd47-6ce0-4c7c-8acd-8318dc42280f> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004939/545b2b49-4b36-406d-b908-aa1d60186bd0> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004939/247a2295-7573-41ec-b5f8-37e73aa18737> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004939/ce02c1a4-68d4-4aac-bdd8-29e9d9e51d5b> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004939/defcf9db-de43-45f4-8be8-c9067b8ff0d4> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/805ee046-293c-4b79-893d-47a3eac3ee1b> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004939/acc3d757-fe24-470b-89c1-96f16dc04d60> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004939/a0cda19e-882a-457f-a837-f8b8527d1ebb> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004939/a0cda19e-882a-457f-a837-f8b8527d1ebb> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004939/315533b4-fe3a-4b2c-a5ed-bdc214851d59> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/acc3d757-fe24-470b-89c1-96f16dc04d60> a WB:WBGene00004939,
+<http://model.geneontology.org/WB_WBGene00004939/7e7a200d-c9e1-41f0-b7bf-a93231984962> a WB:WBGene00004939,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/ce02c1a4-68d4-4aac-bdd8-29e9d9e51d5b> a WB:WBGene00004939,
+<http://model.geneontology.org/WB_WBGene00004939/b08b9099-9529-4977-8002-9dd670313da9> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004939/7e7a200d-c9e1-41f0-b7bf-a93231984962> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004939/315533b4-fe3a-4b2c-a5ed-bdc214851d59> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004939/d274bed1-4053-416b-b136-313f156553f9> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004939/e42f2be0-4da2-4d59-9a55-5c45926da50f> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004939/fa5e4b39-985d-4484-899e-67811f430f7c> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004939/e42f2be0-4da2-4d59-9a55-5c45926da50f> a WB:WBGene00004939,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004939/defcf9db-de43-45f4-8be8-c9067b8ff0d4> a GO:0007281,
+<http://model.geneontology.org/WB_WBGene00004939/fa5e4b39-985d-4484-899e-67811f430f7c> a GO:0007281,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004939/14487fc6-34e3-4dc7-a604-f02e6d590654> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004939/23bcbffd-2a3a-4ad3-912d-d56d32c4dc6f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7952|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/805ee046-293c-4b79-893d-47a3eac3ee1b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/a0cda19e-882a-457f-a837-f8b8527d1ebb> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004939/fbaccd47-6ce0-4c7c-8acd-8318dc42280f> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7943|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/247a2295-7573-41ec-b5f8-37e73aa18737> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/ce02c1a4-68d4-4aac-bdd8-29e9d9e51d5b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004939/8823f7cd-1809-4cbc-9fcf-6bcc8d6d8296> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7943|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/247a2295-7573-41ec-b5f8-37e73aa18737> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/defcf9db-de43-45f4-8be8-c9067b8ff0d4> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004939/0943ccbf-7a99-4c33-b57d-740ede585511> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7952|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/805ee046-293c-4b79-893d-47a3eac3ee1b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/acc3d757-fe24-470b-89c1-96f16dc04d60> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/b08b9099-9529-4977-8002-9dd670313da9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/7e7a200d-c9e1-41f0-b7bf-a93231984962> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004939/09362747-80f7-4562-848a-c73cc36325b5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7943|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/d274bed1-4053-416b-b136-313f156553f9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/fa5e4b39-985d-4484-899e-67811f430f7c> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004939/48e24349-d3aa-4783-bd73-ae891a2b17b5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7943|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/d274bed1-4053-416b-b136-313f156553f9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/e42f2be0-4da2-4d59-9a55-5c45926da50f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004939/545b2b49-4b36-406d-b908-aa1d60186bd0> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004939  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7952|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004939/b08b9099-9529-4977-8002-9dd670313da9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004939/315533b4-fe3a-4b2c-a5ed-bdc214851d59> .
 

--- a/models/WB_WBGene00004943.ttl
+++ b/models/WB_WBGene00004943.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004943> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "sog-10 (WB:WBGene00004943)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004943> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004943/32ca0646-0732-4291-8a9e-18631a5038b0> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004943/0765a69f-b6b2-4db8-b262-9ff83788fc1f> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/5b34d0fb-7b36-41d1-8c35-f4ef4af1e5e4> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004943/145f8802-e03b-4a80-b66d-108f39c9e37b> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241022" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/711e7e3b-818b-4948-9293-15218bf3397b> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004943/18f61ca8-eece-452e-b600-256632b7749a> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/7c4be490-4654-4942-9318-0fb3f33569f5> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004943/b5f97c6f-54af-4594-a66d-bd56396f17ac> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00241022" ;
+    ns1:evidence-with "WB:WBVar00241022" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/85a6458d-1ae2-45a3-8059-9a0b9ce6fa2a> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004943/ecc5b373-806d-4273-93da-bfd4a49e081e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBGene00001609" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/af075ee4-d0a8-418a-bcde-a0c47db9954a> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00004943/f7487df1-ee3a-4a04-8073-d3eb9707be11> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00001609" ;
+    ns1:evidence-with "WB:WBVar00241022" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:8307319" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/2d190d14-07b5-4ead-a889-bd3de33075bb> a GO:0007281,
+<http://model.geneontology.org/WB_WBGene00004943/0825fb2a-f905-4e55-85e9-f9583a60e6f1> a GO:0042006,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/331b6203-c240-4d14-b1e2-82a5a4917fda> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00004943/545430df-5455-4f1c-bc3f-b41a307941f5> a GO:0007281,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/3ba3245a-5f2b-490d-a0cd-66182b8e9d6d> a WB:WBGene00004943,
+<http://model.geneontology.org/WB_WBGene00004943/68a40494-57bd-4f32-a9da-5c4cc4901273> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004943/6a53d584-ff32-49a6-9a2b-6eb5785a55ab> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004943/545430df-5455-4f1c-bc3f-b41a307941f5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004943/6a53d584-ff32-49a6-9a2b-6eb5785a55ab> a WB:WBGene00004943,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/59fc585d-554b-4537-a9e1-00ab1747ff6a> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004943/f949f200-e4e6-4ec6-808a-2df8037fc66e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004943/c79e60d9-4f01-49dd-a4a5-c8fa75b26808> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004943/abfb7fc8-5f46-4565-8f4e-88383b4e6279> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004943/f1c3455c-b711-44ee-80cd-813bd74e94b2> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004943/331b6203-c240-4d14-b1e2-82a5a4917fda> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004943/b55a2319-08c1-487d-9d3b-f0eabb1b645a> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004943/3ba3245a-5f2b-490d-a0cd-66182b8e9d6d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004943/2d190d14-07b5-4ead-a889-bd3de33075bb> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00004943/c79e60d9-4f01-49dd-a4a5-c8fa75b26808> a GO:0042006,
+<http://model.geneontology.org/WB_WBGene00004943/86b387c1-a94e-40ef-9ed0-2e6be4c6ac83> a WB:WBGene00004943,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/f1c3455c-b711-44ee-80cd-813bd74e94b2> a WB:WBGene00004943,
+<http://model.geneontology.org/WB_WBGene00004943/acae24d6-a399-4f61-b715-a157a07671e6> a WB:WBGene00004943,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004943/f949f200-e4e6-4ec6-808a-2df8037fc66e> a WB:WBGene00004943,
+<http://model.geneontology.org/WB_WBGene00004943/ce6b55c1-5c17-4539-85ca-f5bcd4a32416> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004943/acae24d6-a399-4f61-b715-a157a07671e6> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004943/fbe6def7-88ae-46e5-8046-4bc3efad4a06> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004943/fbe6def7-88ae-46e5-8046-4bc3efad4a06> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00004943/ffff7f21-974b-42c9-8ed9-bb081e6b0a44> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004943/86b387c1-a94e-40ef-9ed0-2e6be4c6ac83> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004943/0825fb2a-f905-4e55-85e9-f9583a60e6f1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004943/5b34d0fb-7b36-41d1-8c35-f4ef4af1e5e4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004943/f7487df1-ee3a-4a04-8073-d3eb9707be11> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0042006 WB:WBPaper00001833|PMID:8307319 ECO:0000315 WB:WBVar00241022  2021-05-13 WB  id=WBOA:7945|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/59fc585d-554b-4537-a9e1-00ab1747ff6a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/c79e60d9-4f01-49dd-a4a5-c8fa75b26808> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004943/af075ee4-d0a8-418a-bcde-a0c47db9954a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7946|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/abfb7fc8-5f46-4565-8f4e-88383b4e6279> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/f1c3455c-b711-44ee-80cd-813bd74e94b2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004943/711e7e3b-818b-4948-9293-15218bf3397b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7946|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/abfb7fc8-5f46-4565-8f4e-88383b4e6279> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/331b6203-c240-4d14-b1e2-82a5a4917fda> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004943/32ca0646-0732-4291-8a9e-18631a5038b0> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7944|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/b55a2319-08c1-487d-9d3b-f0eabb1b645a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/3ba3245a-5f2b-490d-a0cd-66182b8e9d6d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004943/85a6458d-1ae2-45a3-8059-9a0b9ce6fa2a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7944|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/b55a2319-08c1-487d-9d3b-f0eabb1b645a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/2d190d14-07b5-4ead-a889-bd3de33075bb> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004943/7c4be490-4654-4942-9318-0fb3f33569f5> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0042006 WB:WBPaper00001833|PMID:8307319 ECO:0000315 WB:WBVar00241022  2021-05-13 WB  id=WBOA:7945|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/59fc585d-554b-4537-a9e1-00ab1747ff6a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/f949f200-e4e6-4ec6-808a-2df8037fc66e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/ffff7f21-974b-42c9-8ed9-bb081e6b0a44> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/86b387c1-a94e-40ef-9ed0-2e6be4c6ac83> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004943/18f61ca8-eece-452e-b600-256632b7749a> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7946|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/ce6b55c1-5c17-4539-85ca-f5bcd4a32416> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/fbe6def7-88ae-46e5-8046-4bc3efad4a06> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004943/145f8802-e03b-4a80-b66d-108f39c9e37b> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7944|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/68a40494-57bd-4f32-a9da-5c4cc4901273> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/545430df-5455-4f1c-bc3f-b41a307941f5> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004943/ecc5b373-806d-4273-93da-bfd4a49e081e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0009792 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7946|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/ce6b55c1-5c17-4539-85ca-f5bcd4a32416> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/acae24d6-a399-4f61-b715-a157a07671e6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004943/b5f97c6f-54af-4594-a66d-bd56396f17ac> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0042006 WB:WBPaper00001833|PMID:8307319 ECO:0000315 WB:WBVar00241022  2021-05-13 WB  id=WBOA:7945|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/ffff7f21-974b-42c9-8ed9-bb081e6b0a44> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/0825fb2a-f905-4e55-85e9-f9583a60e6f1> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004943/0765a69f-b6b2-4db8-b262-9ff83788fc1f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004943  RO:0002264 GO:0007281 WB:WBPaper00001833|PMID:8307319 ECO:0000316 WB:WBGene00001609  2021-05-13 WB  id=WBOA:7944|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004943/68a40494-57bd-4f32-a9da-5c4cc4901273> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004943/6a53d584-ff32-49a6-9a2b-6eb5785a55ab> .
 

--- a/models/WB_WBGene00004961.ttl
+++ b/models/WB_WBGene00004961.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004961> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "spe-7 (WB:WBGene00004961)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004961> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004961/b760c980-a069-4032-96fc-b54b951c2733> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004961/8af2c444-93de-4623-b938-ac99fbcca347> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089121" ;
+    ns1:evidence-with "WB:WBVar00089121" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:6500256" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004961/f088b71e-4292-4b00-95e5-eb38d52788ed> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004961/d1b44871-aa6a-4f45-acdb-15eef15eefdf> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00089121" ;
+    ns1:evidence-with "WB:WBVar00089121" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:6500256" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004961/413d46eb-5ef3-411e-9120-d90270e20354> a WB:WBGene00004961,
+<http://model.geneontology.org/WB_WBGene00004961/22f803dc-2a13-4b68-9993-58e1d59fb5d8> a WB:WBGene00004961,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004961/e0298a8a-134a-4551-86fb-5dd1e6a230c7> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004961/47915030-d1f1-419b-8bd1-9c6a39fc5983> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004961/413d46eb-5ef3-411e-9120-d90270e20354> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004961/fcce4dcb-a8d6-4ae1-ad9b-40527e8fccc1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004961/22f803dc-2a13-4b68-9993-58e1d59fb5d8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004961/d62eecdc-82a1-4cf8-bbf0-70adeb38e74f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004961/fcce4dcb-a8d6-4ae1-ad9b-40527e8fccc1> a GO:0007283,
+<http://model.geneontology.org/WB_WBGene00004961/d62eecdc-82a1-4cf8-bbf0-70adeb38e74f> a GO:0007283,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004961/f088b71e-4292-4b00-95e5-eb38d52788ed> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004961/8af2c444-93de-4623-b938-ac99fbcca347> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00004961  RO:0002264 GO:0007283 WB:WBPaper00000715|PMID:6500256 ECO:0000315 WB:WBVar00089121  2021-05-13 WB  id=WBOA:9584|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004961/e0298a8a-134a-4551-86fb-5dd1e6a230c7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004961/413d46eb-5ef3-411e-9120-d90270e20354> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004961/b760c980-a069-4032-96fc-b54b951c2733> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004961  RO:0002264 GO:0007283 WB:WBPaper00000715|PMID:6500256 ECO:0000315 WB:WBVar00089121  2021-05-13 WB  id=WBOA:9584|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004961/e0298a8a-134a-4551-86fb-5dd1e6a230c7> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004961/fcce4dcb-a8d6-4ae1-ad9b-40527e8fccc1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004961/47915030-d1f1-419b-8bd1-9c6a39fc5983> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004961/d62eecdc-82a1-4cf8-bbf0-70adeb38e74f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004961/d1b44871-aa6a-4f45-acdb-15eef15eefdf> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00004961  RO:0002264 GO:0007283 WB:WBPaper00000715|PMID:6500256 ECO:0000315 WB:WBVar00089121  2021-05-13 WB  id=WBOA:9584|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004961/47915030-d1f1-419b-8bd1-9c6a39fc5983> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004961/22f803dc-2a13-4b68-9993-58e1d59fb5d8> .
 

--- a/models/WB_WBGene00004967.ttl
+++ b/models/WB_WBGene00004967.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00004967> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "spe-13 (WB:WBGene00004967)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00004967> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00004967/0efb97ac-e982-465f-a15a-90e15720e640> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004967/12e0f111-a7c2-4f93-a2d5-e0ec8974f8cb> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087800" ;
+    ns1:evidence-with "WB:WBVar00087800" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3197956" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004967/c3d2c8bb-47a0-4ec9-b4f4-86e258ad268d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00004967/664e8d38-e836-4372-99a9-e58128d5ec39> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00087800" ;
+    ns1:evidence-with "WB:WBVar00087800" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:3197956" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00004967/0e888c09-4ccb-41b1-aabf-9d0865676e90> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00004967/678ed3a8-481e-4553-8dbc-14e147a8fe38> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004967/500b5827-223a-40ab-b987-fe2f84a1d963> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004967/3aa6aa4e-1cbb-426d-b85e-fc390ba79bbd> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00004967/f257ee65-bcce-4eb3-8ec0-0888ae6af85d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00004967/77137205-77f6-40ce-87e3-bb958bea86b1> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004967/3aa6aa4e-1cbb-426d-b85e-fc390ba79bbd> a GO:0007338,
+<http://model.geneontology.org/WB_WBGene00004967/77137205-77f6-40ce-87e3-bb958bea86b1> a GO:0007338,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00004967/500b5827-223a-40ab-b987-fe2f84a1d963> a WB:WBGene00004967,
+<http://model.geneontology.org/WB_WBGene00004967/f257ee65-bcce-4eb3-8ec0-0888ae6af85d> a WB:WBGene00004967,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004967/0efb97ac-e982-465f-a15a-90e15720e640> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004967/12e0f111-a7c2-4f93-a2d5-e0ec8974f8cb> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004967  RO:0002264 GO:0007338 WB:WBPaper00001075|PMID:3197956 ECO:0000315 WB:WBVar00087800  2021-05-13 WB  id=WBOA:10278|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004967/0e888c09-4ccb-41b1-aabf-9d0865676e90> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004967/500b5827-223a-40ab-b987-fe2f84a1d963> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004967/678ed3a8-481e-4553-8dbc-14e147a8fe38> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004967/f257ee65-bcce-4eb3-8ec0-0888ae6af85d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00004967/c3d2c8bb-47a0-4ec9-b4f4-86e258ad268d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00004967/664e8d38-e836-4372-99a9-e58128d5ec39> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00004967  RO:0002264 GO:0007338 WB:WBPaper00001075|PMID:3197956 ECO:0000315 WB:WBVar00087800  2021-05-13 WB  id=WBOA:10278|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004967/0e888c09-4ccb-41b1-aabf-9d0865676e90> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004967/3aa6aa4e-1cbb-426d-b85e-fc390ba79bbd> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00004967/678ed3a8-481e-4553-8dbc-14e147a8fe38> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00004967/77137205-77f6-40ce-87e3-bb958bea86b1> .
 

--- a/models/WB_WBGene00006293.ttl
+++ b/models/WB_WBGene00006293.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,136 +29,142 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006293> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-8 (WB:WBGene00006293)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006293> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006293/0d3da322-0a72-4900-9a12-e9edfe1d3b95> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006293/32bcdd9d-880a-4083-b8b1-5c376784f74a> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/369eba0a-fa0d-4125-a07e-bc37c752faa5> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006293/3c6ecc66-9d90-46db-a1c4-87ba305dcf61> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006293/54702860-2726-40c0-a670-2bf54bee5d31> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006293/8867898c-2aa3-43e0-95af-8284d3c1c8d8> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006293/97fca562-1ab2-4684-9e37-c7bbef4d14ac> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006293/6e0eaabb-9abe-4cc0-9f00-ee438f447d69> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006293/f3a233a7-048f-40c7-bc0b-eeab2322de26> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006293/77439c23-f43a-4dc4-ba2a-ed07b88255e3> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006293/975aeaa0-48f3-465a-9509-476296c904c1> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006293/a15d3d50-be16-4aa4-82e0-518ab0079e71> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006293/0b908cb3-976b-464f-b669-d5c7486b95fd> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006293/d88b2bb3-28fe-4474-8d56-e42e6d98a0a9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006293/4fbe62a6-6b5c-4266-ac43-cd957a666530> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006293/27507dfa-997e-4fd7-8fba-2848dcb1da2c> a WB:WBGene00006293,
+<http://model.geneontology.org/WB_WBGene00006293/0250b81a-163c-467d-b1fd-4234e3ae05ef> a WB:WBGene00006293,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/4fbe62a6-6b5c-4266-ac43-cd957a666530> a GO:0040025,
+<http://model.geneontology.org/WB_WBGene00006293/13c7cd32-26c1-409e-89e5-69d0ce530444> a WB:WBGene00006293,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/7edf075a-dd66-4741-a0a2-4c6c69d3f4d2> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006293/20be5a69-2caa-4290-9a1f-396651ab4523> a GO:0040025,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/903209ad-c35c-4f73-863d-76ff42f783bc> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006293/aeccb69e-db56-40c1-9b17-6b4343dbd10b> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006293/c36335bf-c954-492d-8ae2-81e8d539b864> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006293/aeccb69e-db56-40c1-9b17-6b4343dbd10b> a WB:WBGene00006293,
+<http://model.geneontology.org/WB_WBGene00006293/3aefd368-fd58-4ec8-bc7e-5826bf6a3814> a WB:WBGene00006293,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/c024d2f3-bb0d-4ddd-be4f-94ab7e0b51a4> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006293/7e602e00-706d-4a10-b830-52727bcb35b4> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006293/27507dfa-997e-4fd7-8fba-2848dcb1da2c> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006293/7edf075a-dd66-4741-a0a2-4c6c69d3f4d2> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006293/3aefd368-fd58-4ec8-bc7e-5826bf6a3814> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006293/b627c8b5-49a1-4bd7-9376-54ae7d29ce9a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/c36335bf-c954-492d-8ae2-81e8d539b864> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006293/99e65bcc-6cb5-4a0e-99e4-1cdd67a0e6ce> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006293/13c7cd32-26c1-409e-89e5-69d0ce530444> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006293/20be5a69-2caa-4290-9a1f-396651ab4523> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006293/b627c8b5-49a1-4bd7-9376-54ae7d29ce9a> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006293/d88b2bb3-28fe-4474-8d56-e42e6d98a0a9> a WB:WBGene00006293,
+<http://model.geneontology.org/WB_WBGene00006293/f072ae7d-9813-48b6-8568-0266bc7a7eee> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006293/f973b359-f3d6-47b4-850c-8cf9620f31e5> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006293/0250b81a-163c-467d-b1fd-4234e3ae05ef> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006293/f072ae7d-9813-48b6-8568-0266bc7a7eee> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -166,74 +172,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006293/77439c23-f43a-4dc4-ba2a-ed07b88255e3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006293/32bcdd9d-880a-4083-b8b1-5c376784f74a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5622|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/0b908cb3-976b-464f-b669-d5c7486b95fd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/d88b2bb3-28fe-4474-8d56-e42e6d98a0a9> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006293/975aeaa0-48f3-465a-9509-476296c904c1> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5621|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/903209ad-c35c-4f73-863d-76ff42f783bc> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/c36335bf-c954-492d-8ae2-81e8d539b864> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006293/a15d3d50-be16-4aa4-82e0-518ab0079e71> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5620|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/c024d2f3-bb0d-4ddd-be4f-94ab7e0b51a4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/7edf075a-dd66-4741-a0a2-4c6c69d3f4d2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006293/0d3da322-0a72-4900-9a12-e9edfe1d3b95> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5620|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/c024d2f3-bb0d-4ddd-be4f-94ab7e0b51a4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/27507dfa-997e-4fd7-8fba-2848dcb1da2c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/f973b359-f3d6-47b4-850c-8cf9620f31e5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/0250b81a-163c-467d-b1fd-4234e3ae05ef> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006293/369eba0a-fa0d-4125-a07e-bc37c752faa5> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006293/54702860-2726-40c0-a670-2bf54bee5d31> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5621|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/903209ad-c35c-4f73-863d-76ff42f783bc> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/aeccb69e-db56-40c1-9b17-6b4343dbd10b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006293/6e0eaabb-9abe-4cc0-9f00-ee438f447d69> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5622|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/0b908cb3-976b-464f-b669-d5c7486b95fd> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/4fbe62a6-6b5c-4266-ac43-cd957a666530> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/99e65bcc-6cb5-4a0e-99e4-1cdd67a0e6ce> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/20be5a69-2caa-4290-9a1f-396651ab4523> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006293/3c6ecc66-9d90-46db-a1c4-87ba305dcf61> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5622|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/99e65bcc-6cb5-4a0e-99e4-1cdd67a0e6ce> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/13c7cd32-26c1-409e-89e5-69d0ce530444> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006293/f3a233a7-048f-40c7-bc0b-eeab2322de26> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5621|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/7e602e00-706d-4a10-b830-52727bcb35b4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/b627c8b5-49a1-4bd7-9376-54ae7d29ce9a> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006293/97fca562-1ab2-4684-9e37-c7bbef4d14ac> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5621|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/7e602e00-706d-4a10-b830-52727bcb35b4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/3aefd368-fd58-4ec8-bc7e-5826bf6a3814> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006293/8867898c-2aa3-43e0-95af-8284d3c1c8d8> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006293  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5620|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006293/f973b359-f3d6-47b4-850c-8cf9620f31e5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006293/f072ae7d-9813-48b6-8568-0266bc7a7eee> .
 

--- a/models/WB_WBGene00006294.ttl
+++ b/models/WB_WBGene00006294.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006294> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-9 (WB:WBGene00006294)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006294> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006294/2f129588-1c36-4c01-8f79-9c53f5bf1f7e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006294/68d9378b-1b0f-4fd9-9b6b-b6fa7cd904e6> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006294/8aa68989-c3d8-4aa0-885f-e9cd8f7a6e50> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006294/f73efb50-927c-480f-9242-6f1be6a371ce> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006294/3833798d-1acb-407c-8e5f-c000722e2377> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006294/f92cf09d-298f-4b50-b089-ec848683b102> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006294/5f3a3b9a-dcdf-4c52-a6b1-72a2a5b9f01a> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006294/e19f6559-9592-4ae2-a159-f023f896b329> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006294/126f7005-7b3e-4b78-92ca-7464e5a7fe59> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006294/1c3ad9ac-8f6f-49ff-ab2e-294b6e37907a> a WB:WBGene00006294,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006294/1ef0e00c-e5c3-4b66-bb6c-54d4cccd71c4> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006294/6cd28445-e66f-47e1-87a9-77b49e69b9af> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006294/fbfefe07-6bf0-418d-80be-b91cc03c6f84> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006294/126f7005-7b3e-4b78-92ca-7464e5a7fe59> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006294/b151bf57-7e3e-4c85-9385-c8b7029e44e7> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006294/c4c64e5f-ab73-4e88-866e-e04a668f7fab> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006294/725074de-4a9f-4204-a090-38a44d1b61bf> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006294/91d71841-5e73-4784-84e2-cb34933c9d08> a GO:0000278,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006294/a7f119d3-06d1-4476-95f4-b59f6fbcdb6d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006294/cc4c515a-de9d-4268-a386-e755cada1ba1> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006294/a7f119d3-06d1-4476-95f4-b59f6fbcdb6d> a WB:WBGene00006294,
+<http://model.geneontology.org/WB_WBGene00006294/b151bf57-7e3e-4c85-9385-c8b7029e44e7> a WB:WBGene00006294,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006294/cc4c515a-de9d-4268-a386-e755cada1ba1> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006294/bf078801-0d60-4ab8-a93e-f7ab2671b48d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006294/1c3ad9ac-8f6f-49ff-ab2e-294b6e37907a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006294/91d71841-5e73-4784-84e2-cb34933c9d08> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006294/fbfefe07-6bf0-418d-80be-b91cc03c6f84> a WB:WBGene00006294,
+<http://model.geneontology.org/WB_WBGene00006294/c4c64e5f-ab73-4e88-866e-e04a668f7fab> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006294/3833798d-1acb-407c-8e5f-c000722e2377> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006294/68d9378b-1b0f-4fd9-9b6b-b6fa7cd904e6> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006294  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5623|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/1ef0e00c-e5c3-4b66-bb6c-54d4cccd71c4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/fbfefe07-6bf0-418d-80be-b91cc03c6f84> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/bf078801-0d60-4ab8-a93e-f7ab2671b48d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/1c3ad9ac-8f6f-49ff-ab2e-294b6e37907a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006294/5f3a3b9a-dcdf-4c52-a6b1-72a2a5b9f01a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006294/f92cf09d-298f-4b50-b089-ec848683b102> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006294  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5624|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/6cd28445-e66f-47e1-87a9-77b49e69b9af> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/c4c64e5f-ab73-4e88-866e-e04a668f7fab> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006294/8aa68989-c3d8-4aa0-885f-e9cd8f7a6e50> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006294  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5623|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/1ef0e00c-e5c3-4b66-bb6c-54d4cccd71c4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/126f7005-7b3e-4b78-92ca-7464e5a7fe59> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/bf078801-0d60-4ab8-a93e-f7ab2671b48d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/91d71841-5e73-4784-84e2-cb34933c9d08> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006294/2f129588-1c36-4c01-8f79-9c53f5bf1f7e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006294/f73efb50-927c-480f-9242-6f1be6a371ce> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006294  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5624|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/725074de-4a9f-4204-a090-38a44d1b61bf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/a7f119d3-06d1-4476-95f4-b59f6fbcdb6d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006294/e19f6559-9592-4ae2-a159-f023f896b329> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006294  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5624|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/725074de-4a9f-4204-a090-38a44d1b61bf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/cc4c515a-de9d-4268-a386-e755cada1ba1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006294/6cd28445-e66f-47e1-87a9-77b49e69b9af> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006294/b151bf57-7e3e-4c85-9385-c8b7029e44e7> .
 

--- a/models/WB_WBGene00006295.ttl
+++ b/models/WB_WBGene00006295.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,136 +29,142 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006295> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-10 (WB:WBGene00006295)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006295> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006295/8cdfbb2e-fcca-49c9-82f8-7443fda7d595> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006295/0b88e281-46e3-4a29-9c4c-bd200d37fc94> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/a341a72c-a3d1-4542-8556-cb6868f15c7e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006295/63dc9e1f-f466-42c5-8be7-1ff69b2fba6f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/b95ea0ea-c755-43a1-a9ab-f174176268e5> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006295/7ba27a63-df7b-40b7-be26-5d8b1c4a7646> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006295/8177b429-d91f-4d88-9938-7d26e2fc87b5> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006295/be3127f0-ef21-433a-9f61-e837e3feb256> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006295/a6a6a8e4-4a07-470e-93d0-2a72aff31a6d> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006295/bbb951c8-0eec-4866-bd1a-16e5ab0b60ee> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006295/c81328f6-d3ba-4286-a36d-cd9f68b78b2a> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006295/f2a16694-90dd-4947-9b53-eafd65869eb1> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006295/23f65f1b-d2c1-41e2-96b8-b84120366c5e> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006295/602e08ec-8c6e-4399-b6ee-d396d7c4d092> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006295/452a5732-6a4f-4edd-a441-d26ea47d58cc> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006295/452a5732-6a4f-4edd-a441-d26ea47d58cc> a GO:0000132,
+<http://model.geneontology.org/WB_WBGene00006295/29af54e5-c6ea-4173-89ff-f5216aa7afb2> a WB:WBGene00006295,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/4bc25e1f-ebf8-480a-bf19-4bc35b290ca7> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006295/359981c5-a07b-49d5-8e68-84575c49f041> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006295/5cba11c4-2c95-477b-8b14-a5b8f0e5dc49> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006295/a3389c2a-7b93-4e89-8ae7-8664c1df0a80> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006295/5cba11c4-2c95-477b-8b14-a5b8f0e5dc49> a WB:WBGene00006295,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/58861b12-9fd1-4d90-96e3-2fb9d27ad891> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006295/6bdf2525-c18e-48c3-86b0-3add3f6a6960> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/602e08ec-8c6e-4399-b6ee-d396d7c4d092> a WB:WBGene00006295,
+<http://model.geneontology.org/WB_WBGene00006295/a3389c2a-7b93-4e89-8ae7-8664c1df0a80> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/7120080f-52fe-45b8-b694-619ea498c24d> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006295/ace15a00-4642-457b-92ff-99b8d4eb6727> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006295/ed710511-6fc4-49c5-93c9-e2993b9c33c6> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006295/4bc25e1f-ebf8-480a-bf19-4bc35b290ca7> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006295/fe965ac4-e25f-4e08-8afd-ec882d72023b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006295/6bdf2525-c18e-48c3-86b0-3add3f6a6960> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006295/a977b668-887b-4d4f-a7ce-20c034c19395> a WB:WBGene00006295,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006295/cd916e36-19ee-4e8f-8237-f7136b8eca88> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006295/a977b668-887b-4d4f-a7ce-20c034c19395> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006295/58861b12-9fd1-4d90-96e3-2fb9d27ad891> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006295/ed710511-6fc4-49c5-93c9-e2993b9c33c6> a WB:WBGene00006295,
+<http://model.geneontology.org/WB_WBGene00006295/d3203c77-e01c-43af-99f0-c1a757e739a1> a GO:0000132,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006295/eef98e91-485a-4ee9-8305-7638fe9dbeb7> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006295/29af54e5-c6ea-4173-89ff-f5216aa7afb2> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006295/d3203c77-e01c-43af-99f0-c1a757e739a1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006295/fe965ac4-e25f-4e08-8afd-ec882d72023b> a WB:WBGene00006295,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -166,74 +172,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006295/a341a72c-a3d1-4542-8556-cb6868f15c7e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006295/a6a6a8e4-4a07-470e-93d0-2a72aff31a6d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5625|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/cd916e36-19ee-4e8f-8237-f7136b8eca88> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/a977b668-887b-4d4f-a7ce-20c034c19395> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006295/b95ea0ea-c755-43a1-a9ab-f174176268e5> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5627|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/7120080f-52fe-45b8-b694-619ea498c24d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/ed710511-6fc4-49c5-93c9-e2993b9c33c6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006295/f2a16694-90dd-4947-9b53-eafd65869eb1> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0000132 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5626|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/23f65f1b-d2c1-41e2-96b8-b84120366c5e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/602e08ec-8c6e-4399-b6ee-d396d7c4d092> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/eef98e91-485a-4ee9-8305-7638fe9dbeb7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/29af54e5-c6ea-4173-89ff-f5216aa7afb2> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006295/be3127f0-ef21-433a-9f61-e837e3feb256> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006295/bbb951c8-0eec-4866-bd1a-16e5ab0b60ee> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5627|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/7120080f-52fe-45b8-b694-619ea498c24d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/4bc25e1f-ebf8-480a-bf19-4bc35b290ca7> .
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/ace15a00-4642-457b-92ff-99b8d4eb6727> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/fe965ac4-e25f-4e08-8afd-ec882d72023b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006295/c81328f6-d3ba-4286-a36d-cd9f68b78b2a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006295/63dc9e1f-f466-42c5-8be7-1ff69b2fba6f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5625|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/cd916e36-19ee-4e8f-8237-f7136b8eca88> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/58861b12-9fd1-4d90-96e3-2fb9d27ad891> .
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/359981c5-a07b-49d5-8e68-84575c49f041> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/5cba11c4-2c95-477b-8b14-a5b8f0e5dc49> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006295/8cdfbb2e-fcca-49c9-82f8-7443fda7d595> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006295/0b88e281-46e3-4a29-9c4c-bd200d37fc94> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0000132 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5626|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/23f65f1b-d2c1-41e2-96b8-b84120366c5e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/452a5732-6a4f-4edd-a441-d26ea47d58cc> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/eef98e91-485a-4ee9-8305-7638fe9dbeb7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/d3203c77-e01c-43af-99f0-c1a757e739a1> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006295/8177b429-d91f-4d88-9938-7d26e2fc87b5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5627|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/ace15a00-4642-457b-92ff-99b8d4eb6727> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/6bdf2525-c18e-48c3-86b0-3add3f6a6960> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006295/7ba27a63-df7b-40b7-be26-5d8b1c4a7646> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006295  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5625|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006295/359981c5-a07b-49d5-8e68-84575c49f041> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006295/a3389c2a-7b93-4e89-8ae7-8664c1df0a80> .
 

--- a/models/WB_WBGene00006296.ttl
+++ b/models/WB_WBGene00006296.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,136 +29,142 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006296> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-11 (WB:WBGene00006296)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006296> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006296/207f960b-1c55-4d1f-8f39-399edce0047f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006296/30413a60-4fbe-4641-92bd-bb7102e3cb70> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006296/3c4a6ef3-c1e1-45bb-a1c7-6b84241ee021> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006296/595a90a4-62eb-4612-9008-295e53efd4dd> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006296/804574a4-57d8-4c71-b883-ac3b31f5dd10> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/8e2f837e-06af-4f92-91d0-619d2f1fc524> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006296/892f483a-9d58-4d7e-8ecc-a3b664ddfada> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/b8ba7aa7-958e-4fd0-abe7-fed4779f2d81> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006296/a18f01ed-110d-405e-ae0e-fff760aa509f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006296/ea51f899-29e1-43d6-89ab-a0ab38c15516> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006296/0911bdf3-04de-43c4-be69-be67229f9435> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006296/c548d843-de7e-4ce4-8156-9ffb846e4c12> a ECO:0000315,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006296/2c92f8e4-85cc-48c6-88f9-c152998cc1c3> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006296/eba71545-ff8e-4c02-89bf-e72be6635421> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/2c92f8e4-85cc-48c6-88f9-c152998cc1c3> a WB:WBGene00006296,
+<http://model.geneontology.org/WB_WBGene00006296/ead45570-408b-4e40-8df5-09a09f3f62de> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/317b145d-3502-4fca-9a3b-e40c71e7234a> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006296/0dce7de7-d645-42b5-8596-6e9305423fd3> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006296/de012beb-bbde-4122-8077-81a8d85a6df8> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006296/fad5414d-baaa-4921-a9c5-b671dd9eef90> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006296/bff35d03-fa78-4493-8d82-e2b47e1352fe> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006296/6717c2e6-12d2-4b1c-991a-0aeaabfd35dd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/36097101-3118-4526-9aeb-f1452abf6b7e> a WB:WBGene00006296,
+<http://model.geneontology.org/WB_WBGene00006296/50ff8001-1b64-4051-a8cc-d3427465246b> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006296/812e7252-0978-4c41-b381-db92104fd0b8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006296/5ec779d7-86aa-40fe-8c82-890df2316236> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/77b84449-7408-4923-9c59-4750edeb08cf> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006296/5ec779d7-86aa-40fe-8c82-890df2316236> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/de012beb-bbde-4122-8077-81a8d85a6df8> a WB:WBGene00006296,
+<http://model.geneontology.org/WB_WBGene00006296/6717c2e6-12d2-4b1c-991a-0aeaabfd35dd> a GO:0000132,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/eba71545-ff8e-4c02-89bf-e72be6635421> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006296/812e7252-0978-4c41-b381-db92104fd0b8> a WB:WBGene00006296,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/f25ec7b0-c742-48f3-8d34-51766a7dc35b> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006296/b94ef62d-af52-448c-b8a6-da148fa06ad5> a GO:0000278,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006296/36097101-3118-4526-9aeb-f1452abf6b7e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006296/77b84449-7408-4923-9c59-4750edeb08cf> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006296/fad5414d-baaa-4921-a9c5-b671dd9eef90> a GO:0000132,
+<http://model.geneontology.org/WB_WBGene00006296/bff35d03-fa78-4493-8d82-e2b47e1352fe> a WB:WBGene00006296,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006296/d2bfecd3-3ffe-485e-916d-600874f89cd4> a WB:WBGene00006296,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006296/f781910e-0ebc-441c-8a49-0ee9cc80b17f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006296/d2bfecd3-3ffe-485e-916d-600874f89cd4> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006296/b94ef62d-af52-448c-b8a6-da148fa06ad5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -166,74 +172,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006296/3c4a6ef3-c1e1-45bb-a1c7-6b84241ee021> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006296/892f483a-9d58-4d7e-8ecc-a3b664ddfada> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5630|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/f25ec7b0-c742-48f3-8d34-51766a7dc35b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/77b84449-7408-4923-9c59-4750edeb08cf> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006296/8e2f837e-06af-4f92-91d0-619d2f1fc524> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5628|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/0911bdf3-04de-43c4-be69-be67229f9435> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/eba71545-ff8e-4c02-89bf-e72be6635421> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006296/595a90a4-62eb-4612-9008-295e53efd4dd> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000132 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5629|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/317b145d-3502-4fca-9a3b-e40c71e7234a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/fad5414d-baaa-4921-a9c5-b671dd9eef90> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006296/207f960b-1c55-4d1f-8f39-399edce0047f> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000132 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5629|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/317b145d-3502-4fca-9a3b-e40c71e7234a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/de012beb-bbde-4122-8077-81a8d85a6df8> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006296/ea51f899-29e1-43d6-89ab-a0ab38c15516> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5630|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/f25ec7b0-c742-48f3-8d34-51766a7dc35b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/36097101-3118-4526-9aeb-f1452abf6b7e> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006296/b8ba7aa7-958e-4fd0-abe7-fed4779f2d81> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5628|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/0911bdf3-04de-43c4-be69-be67229f9435> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/2c92f8e4-85cc-48c6-88f9-c152998cc1c3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/f781910e-0ebc-441c-8a49-0ee9cc80b17f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/d2bfecd3-3ffe-485e-916d-600874f89cd4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006296/ead45570-408b-4e40-8df5-09a09f3f62de> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000132 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5629|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/0dce7de7-d645-42b5-8596-6e9305423fd3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/bff35d03-fa78-4493-8d82-e2b47e1352fe> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006296/c548d843-de7e-4ce4-8156-9ffb846e4c12> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5628|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/f781910e-0ebc-441c-8a49-0ee9cc80b17f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/b94ef62d-af52-448c-b8a6-da148fa06ad5> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006296/804574a4-57d8-4c71-b883-ac3b31f5dd10> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0000132 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5629|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/0dce7de7-d645-42b5-8596-6e9305423fd3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/6717c2e6-12d2-4b1c-991a-0aeaabfd35dd> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006296/a18f01ed-110d-405e-ae0e-fff760aa509f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5630|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/50ff8001-1b64-4051-a8cc-d3427465246b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/812e7252-0978-4c41-b381-db92104fd0b8> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006296/30413a60-4fbe-4641-92bd-bb7102e3cb70> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006296  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5630|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006296/50ff8001-1b64-4051-a8cc-d3427465246b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006296/5ec779d7-86aa-40fe-8c82-890df2316236> .
 

--- a/models/WB_WBGene00006297.ttl
+++ b/models/WB_WBGene00006297.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006297> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-12 (WB:WBGene00006297)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006297> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006297/18def745-0af1-483c-b516-06e4be2b633c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006297/3a15c588-2945-476d-8fbe-3308c2036526> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006297/5d603bad-9874-45d7-a994-fe9baf779f29> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006297/d3ef0cd8-e9c7-445a-bf6f-6da6180305c3> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006297/e83cbbbe-2089-48d0-9420-32cc0517005b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006297/4578195f-b392-452f-8f52-a144aa859e70> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006297/6b682159-ccd3-4308-ae87-62d6414bcdc6> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006297/c3c6de66-8c56-4798-991e-18460cc1631f> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006297/0bd12293-03b3-4854-a83b-dc103f301ac5> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006297/5f03d309-9bf7-48ae-b0a1-841c5ba1e5cb> a WB:WBGene00006297,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006297/c23bf316-9369-45e3-88c5-09596a203b9c> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006297/deafeeda-7c11-476b-868f-99c13bbdd326> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006297/35b5f4ba-a447-437e-bfd6-162a7c0ba5ce> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006297/946760ee-fcba-4d06-b832-e5c34fd98edc> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006297/5686797e-2d44-47d2-9d93-c7ced383f0f9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006297/8990d90f-7f8b-4fef-96cb-b9f674317601> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006297/5686797e-2d44-47d2-9d93-c7ced383f0f9> a WB:WBGene00006297,
+<http://model.geneontology.org/WB_WBGene00006297/b144eb34-b949-4557-989e-3348e6fdaab1> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006297/d1e70b19-0981-4f00-9878-843c3508f989> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006297/ece164e6-7fcf-4b4f-a57f-2ea3951fc0cd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006297/8990d90f-7f8b-4fef-96cb-b9f674317601> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006297/d1e70b19-0981-4f00-9878-843c3508f989> a WB:WBGene00006297,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006297/c23bf316-9369-45e3-88c5-09596a203b9c> a WB:WBGene00006297,
+<http://model.geneontology.org/WB_WBGene00006297/ece164e6-7fcf-4b4f-a57f-2ea3951fc0cd> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006297/deafeeda-7c11-476b-868f-99c13bbdd326> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006297/f256572b-28f8-4c13-8fe0-64a39c2d8bac> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006297/5f03d309-9bf7-48ae-b0a1-841c5ba1e5cb> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006297/946760ee-fcba-4d06-b832-e5c34fd98edc> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006297/5d603bad-9874-45d7-a994-fe9baf779f29> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006297/3a15c588-2945-476d-8fbe-3308c2036526> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5631|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/0bd12293-03b3-4854-a83b-dc103f301ac5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/deafeeda-7c11-476b-868f-99c13bbdd326> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006297/e83cbbbe-2089-48d0-9420-32cc0517005b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5632|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/35b5f4ba-a447-437e-bfd6-162a7c0ba5ce> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/8990d90f-7f8b-4fef-96cb-b9f674317601> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006297/18def745-0af1-483c-b516-06e4be2b633c> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5631|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/0bd12293-03b3-4854-a83b-dc103f301ac5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/c23bf316-9369-45e3-88c5-09596a203b9c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006297/d3ef0cd8-e9c7-445a-bf6f-6da6180305c3> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5632|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/35b5f4ba-a447-437e-bfd6-162a7c0ba5ce> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/5686797e-2d44-47d2-9d93-c7ced383f0f9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/f256572b-28f8-4c13-8fe0-64a39c2d8bac> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/5f03d309-9bf7-48ae-b0a1-841c5ba1e5cb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006297/4578195f-b392-452f-8f52-a144aa859e70> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5631|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/b144eb34-b949-4557-989e-3348e6fdaab1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/ece164e6-7fcf-4b4f-a57f-2ea3951fc0cd> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006297/6b682159-ccd3-4308-ae87-62d6414bcdc6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5631|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/b144eb34-b949-4557-989e-3348e6fdaab1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/d1e70b19-0981-4f00-9878-843c3508f989> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006297/c3c6de66-8c56-4798-991e-18460cc1631f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006297  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5632|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006297/f256572b-28f8-4c13-8fe0-64a39c2d8bac> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006297/946760ee-fcba-4d06-b832-e5c34fd98edc> .
 

--- a/models/WB_WBGene00006298.ttl
+++ b/models/WB_WBGene00006298.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006298> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-13 (WB:WBGene00006298)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006298> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006298/61ac3128-c45f-4429-8f69-bc745e7e9147> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006298/1ccf7448-53d3-431c-97c3-5a4fc60d2708> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006298/683ed3be-0455-491f-8a35-878745672e48> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006298/5544b32b-4fab-423e-b266-0378876e993f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006298/952f3ba8-d514-4005-b724-01230c353082> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006298/f0fa548f-6d12-4b19-bbcd-285cdad4d778> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006298/0cf7da16-87b2-45d6-8a0e-26bf316eb298> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006298/5e3d17ff-113c-4c9d-a57a-86d1097b0bb7> a ECO:0000315,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006298/62e2e127-9c22-4dd4-a526-3080ac26e683> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006298/bd078279-f7e1-4585-80a2-14c8a02677c7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006298/51b8705f-b820-40ba-9bb2-fdbca971c77d> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006298/7f57c0c1-3b4c-4287-867b-e9a1fc0586b4> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006298/62e2e127-9c22-4dd4-a526-3080ac26e683> a WB:WBGene00006298,
+<http://model.geneontology.org/WB_WBGene00006298/0ead1549-2fd9-42b7-ae3e-3cc89aee5ef4> a WB:WBGene00006298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006298/9fcfff11-c060-41af-a014-3fff373578c3> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006298/2ff8d04d-022b-4d9c-a346-6b4493c0be42> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006298/f7281902-0048-4768-ab09-274ef120c492> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006298/51b8705f-b820-40ba-9bb2-fdbca971c77d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006298/bd078279-f7e1-4585-80a2-14c8a02677c7> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006298/88134c57-fab3-4239-b006-e5ed82b8f6ff> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006298/0ead1549-2fd9-42b7-ae3e-3cc89aee5ef4> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006298/d2a6e28c-b6f7-4ec1-bbf0-0b5008506738> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006298/f7281902-0048-4768-ab09-274ef120c492> a WB:WBGene00006298,
+<http://model.geneontology.org/WB_WBGene00006298/baab5117-4aa4-46af-86e8-fa080a446e0b> a WB:WBGene00006298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006298/d140d572-79b7-4693-9222-ba7b937e1dfd> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006298/baab5117-4aa4-46af-86e8-fa080a446e0b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006298/2ff8d04d-022b-4d9c-a346-6b4493c0be42> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006298/d2a6e28c-b6f7-4ec1-bbf0-0b5008506738> a GO:0000278,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006298/61ac3128-c45f-4429-8f69-bc745e7e9147> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006298/1ccf7448-53d3-431c-97c3-5a4fc60d2708> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006298  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5634|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/0cf7da16-87b2-45d6-8a0e-26bf316eb298> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/62e2e127-9c22-4dd4-a526-3080ac26e683> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/d140d572-79b7-4693-9222-ba7b937e1dfd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/baab5117-4aa4-46af-86e8-fa080a446e0b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006298/952f3ba8-d514-4005-b724-01230c353082> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006298/5e3d17ff-113c-4c9d-a57a-86d1097b0bb7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006298  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5633|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/9fcfff11-c060-41af-a014-3fff373578c3> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/51b8705f-b820-40ba-9bb2-fdbca971c77d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/88134c57-fab3-4239-b006-e5ed82b8f6ff> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/d2a6e28c-b6f7-4ec1-bbf0-0b5008506738> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006298/f0fa548f-6d12-4b19-bbcd-285cdad4d778> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006298/7f57c0c1-3b4c-4287-867b-e9a1fc0586b4> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006298  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5634|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/0cf7da16-87b2-45d6-8a0e-26bf316eb298> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/bd078279-f7e1-4585-80a2-14c8a02677c7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006298/683ed3be-0455-491f-8a35-878745672e48> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006298  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5633|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/9fcfff11-c060-41af-a014-3fff373578c3> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/f7281902-0048-4768-ab09-274ef120c492> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/88134c57-fab3-4239-b006-e5ed82b8f6ff> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/0ead1549-2fd9-42b7-ae3e-3cc89aee5ef4> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006298/5544b32b-4fab-423e-b266-0378876e993f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006298  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5634|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006298/d140d572-79b7-4693-9222-ba7b937e1dfd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006298/2ff8d04d-022b-4d9c-a346-6b4493c0be42> .
 

--- a/models/WB_WBGene00006299.ttl
+++ b/models/WB_WBGene00006299.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006299> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-14 (WB:WBGene00006299)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006299> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006299/2308ca9f-ef42-4c1c-a924-780065cdc965> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006299/09c29ca2-e718-438a-8488-07002ccaaa1e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006299/6adf5b6b-3803-485f-be06-dd5286ea9a78> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006299/188c0f9e-f4e8-4c7a-ac83-3f566fe84b1d> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006299/e67ba8dc-4950-4fca-805c-cd0b7fe1759f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006299/8fc07fb1-f609-4595-ad6a-64982cf2524f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006299/eb458fa5-c88a-4446-b272-821705ab3c4a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006299/abd47a69-64e1-4a5e-a998-e4173245de3f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006299/0238b2d3-192b-4f98-ab32-e34b1f35104f> a WB:WBGene00006299,
+<http://model.geneontology.org/WB_WBGene00006299/0fcb2200-a1cc-4cf6-8465-238e67ed93f8> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006299/5e1ad49f-5159-4064-b5e6-a0ccf1fe33d9> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006299/9f98a4e2-d666-42c2-958d-68957a53677e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006299/5338502e-5214-4717-a8e5-6e12e9445413> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006299/0eb367fc-8e2b-45a5-9f0e-8341871b8335> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006299/0238b2d3-192b-4f98-ab32-e34b1f35104f> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006299/10e2c1ad-b388-4f3c-8a72-e138c704194d> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006299/10e2c1ad-b388-4f3c-8a72-e138c704194d> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006299/5e1ad49f-5159-4064-b5e6-a0ccf1fe33d9> a WB:WBGene00006299,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006299/2c6c9d32-f72e-4f53-995f-cc38388346b3> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006299/9b47dde8-5894-4046-a729-f09db3d69013> a WB:WBGene00006299,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006299/d2d1df8a-4ef0-42ff-b46a-62dc8affe095> a WB:WBGene00006299,
+<http://model.geneontology.org/WB_WBGene00006299/9f98a4e2-d666-42c2-958d-68957a53677e> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006299/fcd43359-5ad7-4ff2-940b-4d53e080ac90> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006299/c41301ac-8003-4634-a0d8-952cde4dc60c> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006299/d2d1df8a-4ef0-42ff-b46a-62dc8affe095> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006299/2c6c9d32-f72e-4f53-995f-cc38388346b3> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006299/9b47dde8-5894-4046-a729-f09db3d69013> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006299/5338502e-5214-4717-a8e5-6e12e9445413> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006299/e67ba8dc-4950-4fca-805c-cd0b7fe1759f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006299/09c29ca2-e718-438a-8488-07002ccaaa1e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006299  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5636|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/fcd43359-5ad7-4ff2-940b-4d53e080ac90> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/d2d1df8a-4ef0-42ff-b46a-62dc8affe095> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006299/2308ca9f-ef42-4c1c-a924-780065cdc965> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006299  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5635|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/0eb367fc-8e2b-45a5-9f0e-8341871b8335> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/10e2c1ad-b388-4f3c-8a72-e138c704194d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006299/eb458fa5-c88a-4446-b272-821705ab3c4a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006299  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5635|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/0eb367fc-8e2b-45a5-9f0e-8341871b8335> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/0238b2d3-192b-4f98-ab32-e34b1f35104f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/c41301ac-8003-4634-a0d8-952cde4dc60c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/9b47dde8-5894-4046-a729-f09db3d69013> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006299/6adf5b6b-3803-485f-be06-dd5286ea9a78> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006299/8fc07fb1-f609-4595-ad6a-64982cf2524f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006299  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5636|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/fcd43359-5ad7-4ff2-940b-4d53e080ac90> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/2c6c9d32-f72e-4f53-995f-cc38388346b3> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/0fcb2200-a1cc-4cf6-8465-238e67ed93f8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/9f98a4e2-d666-42c2-958d-68957a53677e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006299/abd47a69-64e1-4a5e-a998-e4173245de3f> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006299  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5635|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/c41301ac-8003-4634-a0d8-952cde4dc60c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/5338502e-5214-4717-a8e5-6e12e9445413> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006299/188c0f9e-f4e8-4c7a-ac83-3f566fe84b1d> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006299  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5636|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006299/0fcb2200-a1cc-4cf6-8465-238e67ed93f8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006299/5e1ad49f-5159-4064-b5e6-a0ccf1fe33d9> .
 

--- a/models/WB_WBGene00006300.ttl
+++ b/models/WB_WBGene00006300.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006300> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-15 (WB:WBGene00006300)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006300> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006300/48a4f8ef-03a0-4cdd-817e-a8f06020c78e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006300/27ee30e8-32b0-4b54-8a45-9878923ddabe> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006300/79bf3a41-950f-4836-bbb2-f0ed13bc2f62> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006300/3242613d-089b-43cb-8684-91dc63f5d5ea> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006300/c63003ce-2f24-442a-a1d7-23bca50280aa> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006300/7495ea8e-1a3a-4ce9-bb23-e2c56b5e7a91> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006300/b502eefb-9a3e-4e36-86d3-7454221a9cc3> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006300/f6b632bb-da0c-4456-9736-54120db7eb23> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006300/4fe6a8ff-738c-4f44-aacb-0d5d91127256> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006300/8291290a-94c8-482b-830e-13f73ebdb41e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006300/a80ea229-03ad-4e9e-a5b1-9595d0fbfe0b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006300/0142df5a-cc26-40f6-bba0-0abbc7036066> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006300/60aaa4f7-bac8-4ede-9721-ae469360961a> a WB:WBGene00006300,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006300/029d432b-631f-4a40-bd22-96ca2c5414b0> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006300/8805be80-dfc1-4697-89d4-2e111a6e886c> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006300/b7e55a8a-4b63-43c0-92f6-05dab1f1c019> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006300/2050596d-c53c-41c2-ab31-5f8fb35a4079> a WB:WBGene00006300,
+<http://model.geneontology.org/WB_WBGene00006300/8291290a-94c8-482b-830e-13f73ebdb41e> a WB:WBGene00006300,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006300/8805be80-dfc1-4697-89d4-2e111a6e886c> a WB:WBGene00006300,
+<http://model.geneontology.org/WB_WBGene00006300/a80ea229-03ad-4e9e-a5b1-9595d0fbfe0b> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006300/b7e55a8a-4b63-43c0-92f6-05dab1f1c019> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006300/c68f5e64-f5af-460c-8b40-523fa5d8a11e> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006300/60aaa4f7-bac8-4ede-9721-ae469360961a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006300/eacb43ba-3f58-42e1-aa62-3d8baf8b71ad> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006300/eacb43ba-3f58-42e1-aa62-3d8baf8b71ad> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006300/c37c0e51-aadd-498d-8eaf-ace168339142> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006300/2050596d-c53c-41c2-ab31-5f8fb35a4079> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006300/0142df5a-cc26-40f6-bba0-0abbc7036066> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006300/79bf3a41-950f-4836-bbb2-f0ed13bc2f62> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006300/7495ea8e-1a3a-4ce9-bb23-e2c56b5e7a91> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006300  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5638|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/029d432b-631f-4a40-bd22-96ca2c5414b0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/8805be80-dfc1-4697-89d4-2e111a6e886c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006300/48a4f8ef-03a0-4cdd-817e-a8f06020c78e> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006300  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5637|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/c37c0e51-aadd-498d-8eaf-ace168339142> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/2050596d-c53c-41c2-ab31-5f8fb35a4079> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006300/f6b632bb-da0c-4456-9736-54120db7eb23> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006300  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5637|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/c37c0e51-aadd-498d-8eaf-ace168339142> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/0142df5a-cc26-40f6-bba0-0abbc7036066> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/4fe6a8ff-738c-4f44-aacb-0d5d91127256> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/a80ea229-03ad-4e9e-a5b1-9595d0fbfe0b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006300/c63003ce-2f24-442a-a1d7-23bca50280aa> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006300/3242613d-089b-43cb-8684-91dc63f5d5ea> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006300  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5638|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/c68f5e64-f5af-460c-8b40-523fa5d8a11e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/60aaa4f7-bac8-4ede-9721-ae469360961a> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006300/b502eefb-9a3e-4e36-86d3-7454221a9cc3> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006300  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5638|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/029d432b-631f-4a40-bd22-96ca2c5414b0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/b7e55a8a-4b63-43c0-92f6-05dab1f1c019> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/c68f5e64-f5af-460c-8b40-523fa5d8a11e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/eacb43ba-3f58-42e1-aa62-3d8baf8b71ad> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006300/27ee30e8-32b0-4b54-8a45-9878923ddabe> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006300  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5637|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006300/4fe6a8ff-738c-4f44-aacb-0d5d91127256> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006300/8291290a-94c8-482b-830e-13f73ebdb41e> .
 

--- a/models/WB_WBGene00006301.ttl
+++ b/models/WB_WBGene00006301.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,136 +29,142 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006301> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-16 (WB:WBGene00006301)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006301> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006301/3c273ef1-f033-4d21-b176-49078996585c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006301/1b85eacb-635c-44d9-b28f-f949723aaff9> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/43e14785-3eb7-404a-833b-dd34f4407dd3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006301/2775dd71-72f8-4c14-99c2-a7c05e6c10d7> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006301/6609646b-97d1-4432-b99d-8cdc0c45b990> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006301/964b6783-eaa6-40dd-ad14-065f0c9c81fb> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006301/aaae1efd-ac6f-413f-a3e1-b9e323764f7f> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006301/f665e524-6e37-45ff-b572-71d6fd2d63e0> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006301/5cca982a-efd6-4e94-98eb-ccb8b49e1133> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006301/77bcd387-49d4-4916-8d95-12f3b64027d6> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006301/843fc643-cb60-40cd-a61c-95b637f93c55> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006301/2bb929b5-8a89-4f54-8592-68c878ba1ccb> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006301/9a87ddf5-0570-4538-9f99-e11166377b7e> a ECO:0000315,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006301/faccb1a6-3acf-4a5a-ad94-cfd1d2bb0be7> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006301/7d285e49-3323-46d4-ae42-dbccd445e7fe> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/498f3d16-8ef1-4f11-942f-416ecb190f54> a GO:0040025,
+<http://model.geneontology.org/WB_WBGene00006301/1e2b1f96-e2d5-4ada-b9fb-a65708a0187e> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006301/47c01d94-80e5-4e36-a4b6-fe0144498786> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006301/591e36c9-0120-4c1d-9937-b32f3d72ef41> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/622802e3-7b35-4187-9e37-1d526c382ace> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006301/22586f33-57c8-4ef7-b487-926a5324eda6> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/7b56a63e-c0a1-48b9-bc8e-d7b6bba45edd> a WB:WBGene00006301,
+<http://model.geneontology.org/WB_WBGene00006301/47c01d94-80e5-4e36-a4b6-fe0144498786> a WB:WBGene00006301,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/7d285e49-3323-46d4-ae42-dbccd445e7fe> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006301/591e36c9-0120-4c1d-9937-b32f3d72ef41> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/9b905fb8-0c28-42c9-8731-42ae01089183> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006301/6e108722-a1d3-4057-b0f2-44d59d056fba> a GO:0040025,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006301/7b56a63e-c0a1-48b9-bc8e-d7b6bba45edd> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006301/622802e3-7b35-4187-9e37-1d526c382ace> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/a161bda0-9a80-41a7-a5c0-5694d47aa81e> a WB:WBGene00006301,
+<http://model.geneontology.org/WB_WBGene00006301/82afd1ba-f078-4a0f-88d0-566365595c2a> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006301/e0720699-86b2-4a81-b9fb-324169e7d7bc> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006301/6e108722-a1d3-4057-b0f2-44d59d056fba> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/d795a550-de74-4c47-94fb-64ea26c33878> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006301/88fe4be7-d96a-49fc-96af-614152a95e2a> a WB:WBGene00006301,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006301/a161bda0-9a80-41a7-a5c0-5694d47aa81e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006301/498f3d16-8ef1-4f11-942f-416ecb190f54> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006301/faccb1a6-3acf-4a5a-ad94-cfd1d2bb0be7> a WB:WBGene00006301,
+<http://model.geneontology.org/WB_WBGene00006301/e0720699-86b2-4a81-b9fb-324169e7d7bc> a WB:WBGene00006301,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006301/e12a34ca-f365-4c6f-9f18-407f5fe38811> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006301/88fe4be7-d96a-49fc-96af-614152a95e2a> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006301/22586f33-57c8-4ef7-b487-926a5324eda6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -166,74 +172,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006301/964b6783-eaa6-40dd-ad14-065f0c9c81fb> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006301/5cca982a-efd6-4e94-98eb-ccb8b49e1133> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5639|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/2bb929b5-8a89-4f54-8592-68c878ba1ccb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/faccb1a6-3acf-4a5a-ad94-cfd1d2bb0be7> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006301/3c273ef1-f033-4d21-b176-49078996585c> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5639|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/2bb929b5-8a89-4f54-8592-68c878ba1ccb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/7d285e49-3323-46d4-ae42-dbccd445e7fe> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/1e2b1f96-e2d5-4ada-b9fb-a65708a0187e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/591e36c9-0120-4c1d-9937-b32f3d72ef41> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006301/6609646b-97d1-4432-b99d-8cdc0c45b990> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006301/843fc643-cb60-40cd-a61c-95b637f93c55> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5641|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/d795a550-de74-4c47-94fb-64ea26c33878> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/a161bda0-9a80-41a7-a5c0-5694d47aa81e> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006301/aaae1efd-ac6f-413f-a3e1-b9e323764f7f> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5640|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/9b905fb8-0c28-42c9-8731-42ae01089183> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/622802e3-7b35-4187-9e37-1d526c382ace> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006301/f665e524-6e37-45ff-b572-71d6fd2d63e0> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5640|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/9b905fb8-0c28-42c9-8731-42ae01089183> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/7b56a63e-c0a1-48b9-bc8e-d7b6bba45edd> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/e12a34ca-f365-4c6f-9f18-407f5fe38811> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/88fe4be7-d96a-49fc-96af-614152a95e2a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006301/43e14785-3eb7-404a-833b-dd34f4407dd3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006301/1b85eacb-635c-44d9-b28f-f949723aaff9> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5641|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/d795a550-de74-4c47-94fb-64ea26c33878> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/498f3d16-8ef1-4f11-942f-416ecb190f54> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/82afd1ba-f078-4a0f-88d0-566365595c2a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/6e108722-a1d3-4057-b0f2-44d59d056fba> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006301/77bcd387-49d4-4916-8d95-12f3b64027d6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5641|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/82afd1ba-f078-4a0f-88d0-566365595c2a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/e0720699-86b2-4a81-b9fb-324169e7d7bc> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006301/9a87ddf5-0570-4538-9f99-e11166377b7e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5639|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/1e2b1f96-e2d5-4ada-b9fb-a65708a0187e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/47c01d94-80e5-4e36-a4b6-fe0144498786> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006301/2775dd71-72f8-4c14-99c2-a7c05e6c10d7> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006301  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5640|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006301/e12a34ca-f365-4c6f-9f18-407f5fe38811> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006301/22586f33-57c8-4ef7-b487-926a5324eda6> .
 

--- a/models/WB_WBGene00006302.ttl
+++ b/models/WB_WBGene00006302.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,136 +29,142 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006302> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-17 (WB:WBGene00006302)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006302> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006302/068405f3-0a25-4ded-b8c5-e006b39a7b50> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006302/22778be2-4009-416d-a4ae-43bf4e665f49> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006302/271fe972-57ae-42af-b20b-ac29e6eb8cca> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006302/322c4b8c-bb8a-412f-b202-ced6ab062fd2> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/3f690d57-a048-4904-a49b-d83d98173567> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006302/66119f53-83fc-4c3a-b13a-2749baaf54bd> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006302/7e2a7ab9-454b-43ec-afce-af828d15cf5b> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006302/82c7782b-f7ce-443c-b43e-ae841c5f7c93> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006302/ac5bf657-3b98-4392-9fd1-f413be94471b> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/e4e8bdf3-7da2-4d70-83a2-e0751fa80855> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006302/cabb1450-4b52-4764-a1d6-03614b6c106e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/efb955c4-11dc-4e16-b1be-5039ca526f28> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006302/168dd4a1-062a-4bee-bf69-b95a46e56a23> a GO:0003674,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:9649522" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006302/107f9ce4-4928-4aa8-871b-6889a1b945dc> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006302/506911da-76c3-497c-a952-8c84b0198040> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006302/60917ff2-936e-41d2-889d-46f40811d297> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006302/f634e0cb-8ef6-45a3-bd7f-1883ed2e6343> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006302/8fe84807-ec53-4c5e-b32b-7084c4d5426d> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/1ece1695-4c4e-4bd2-acba-40e29a1eebf2> a WB:WBGene00006302,
+<http://model.geneontology.org/WB_WBGene00006302/4af862db-ae33-438c-bb2c-087531c08dcc> a WB:WBGene00006302,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/3b4e6404-bf26-4964-ab94-ecced8e20c55> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006302/553b3c38-9aca-492b-97d4-e89d5eaa2a1e> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006302/4af862db-ae33-438c-bb2c-087531c08dcc> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006302/61db4234-808e-4c2e-9724-be9b2629d8b1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006302/560a4c90-3e72-4abf-942a-efe68f9f13d2> a WB:WBGene00006302,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/506911da-76c3-497c-a952-8c84b0198040> a WB:WBGene00006302,
+<http://model.geneontology.org/WB_WBGene00006302/61db4234-808e-4c2e-9724-be9b2629d8b1> a GO:0040025,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/58556a98-6b31-440a-8ab5-a02428467935> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006302/1ece1695-4c4e-4bd2-acba-40e29a1eebf2> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006302/a0dc06f1-2954-4087-8e04-46317cfa707b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006302/60917ff2-936e-41d2-889d-46f40811d297> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006302/8fe84807-ec53-4c5e-b32b-7084c4d5426d> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/9402a52e-83ea-49cd-ad37-fe9e66cbeab1> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006302/f79594bd-94c3-4ed4-871e-cf2b7c0b68e9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006302/3b4e6404-bf26-4964-ab94-ecced8e20c55> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006302/a0dc06f1-2954-4087-8e04-46317cfa707b> a GO:0040025,
+<http://model.geneontology.org/WB_WBGene00006302/e3d5539c-5a85-4b59-b142-43d1ca98847e> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006302/f79594bd-94c3-4ed4-871e-cf2b7c0b68e9> a WB:WBGene00006302,
+<http://model.geneontology.org/WB_WBGene00006302/e67e47f4-b7d7-46e8-8c79-25119d3a0f7c> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006302/560a4c90-3e72-4abf-942a-efe68f9f13d2> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006302/e3d5539c-5a85-4b59-b142-43d1ca98847e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006302/f634e0cb-8ef6-45a3-bd7f-1883ed2e6343> a WB:WBGene00006302,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -166,74 +172,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006302/efb955c4-11dc-4e16-b1be-5039ca526f28> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006302/ac5bf657-3b98-4392-9fd1-f413be94471b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5644|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/58556a98-6b31-440a-8ab5-a02428467935> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/1ece1695-4c4e-4bd2-acba-40e29a1eebf2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006302/82c7782b-f7ce-443c-b43e-ae841c5f7c93> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5644|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/58556a98-6b31-440a-8ab5-a02428467935> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/a0dc06f1-2954-4087-8e04-46317cfa707b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/553b3c38-9aca-492b-97d4-e89d5eaa2a1e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/61db4234-808e-4c2e-9724-be9b2629d8b1> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006302/e4e8bdf3-7da2-4d70-83a2-e0751fa80855> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006302/66119f53-83fc-4c3a-b13a-2749baaf54bd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5642|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/9402a52e-83ea-49cd-ad37-fe9e66cbeab1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/3b4e6404-bf26-4964-ab94-ecced8e20c55> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006302/271fe972-57ae-42af-b20b-ac29e6eb8cca> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5642|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/9402a52e-83ea-49cd-ad37-fe9e66cbeab1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/f79594bd-94c3-4ed4-871e-cf2b7c0b68e9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/e67e47f4-b7d7-46e8-8c79-25119d3a0f7c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/560a4c90-3e72-4abf-942a-efe68f9f13d2> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006302/068405f3-0a25-4ded-b8c5-e006b39a7b50> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006302/cabb1450-4b52-4764-a1d6-03614b6c106e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0040025 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5644|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/553b3c38-9aca-492b-97d4-e89d5eaa2a1e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/4af862db-ae33-438c-bb2c-087531c08dcc> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006302/7e2a7ab9-454b-43ec-afce-af828d15cf5b> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5643|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/107f9ce4-4928-4aa8-871b-6889a1b945dc> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/60917ff2-936e-41d2-889d-46f40811d297> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/168dd4a1-062a-4bee-bf69-b95a46e56a23> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/8fe84807-ec53-4c5e-b32b-7084c4d5426d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006302/3f690d57-a048-4904-a49b-d83d98173567> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006302/22778be2-4009-416d-a4ae-43bf4e665f49> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5643|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/107f9ce4-4928-4aa8-871b-6889a1b945dc> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/506911da-76c3-497c-a952-8c84b0198040> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/168dd4a1-062a-4bee-bf69-b95a46e56a23> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/f634e0cb-8ef6-45a3-bd7f-1883ed2e6343> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006302/322c4b8c-bb8a-412f-b202-ced6ab062fd2> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006302  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5642|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006302/e67e47f4-b7d7-46e8-8c79-25119d3a0f7c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006302/e3d5539c-5a85-4b59-b142-43d1ca98847e> .
 

--- a/models/WB_WBGene00006304.ttl
+++ b/models/WB_WBGene00006304.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,96 +29,100 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006304> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "stu-19 (WB:WBGene00006304)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006304> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006304/09da2599-d81d-4a8c-8ed7-ee63727ce739> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006304/15b0ed02-bf32-4c68-9b68-d1a6222120f8> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/814c152b-c2dd-451f-ac8d-4a2debe1c700> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006304/266d6f24-998a-4e3f-bc26-fffb159b4e02> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006304/e119268e-de78-4b27-9ab8-44c8a1d517ef> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006304/79c27e65-63ab-40aa-b9de-78e5f7eeed3e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/f2d7588a-aa01-47aa-b588-83520048899d> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006304/cacadc2c-85ad-47f0-bd69-1f55c2d08fef> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:9649522" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Updated from original GO:0009790. 2018-01-02 kmv" .
 
-<http://model.geneontology.org/WB_WBGene00006304/5790585a-199e-44bc-bac7-b3710fc93aa8> a WB:WBGene00006304,
+<http://model.geneontology.org/WB_WBGene00006304/0f852e18-a093-44ea-8350-f5a002d9fd06> a GO:0000278,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/591f92a8-65d0-4946-879f-7fbbcd063ff2> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006304/1dd74e37-11a4-477f-beb6-3c4ccd85aa31> a WB:WBGene00006304,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006304/6be576f8-f928-46a7-a65e-efbdbb25f5e2> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006304/818d119d-fd99-48d2-85fd-6514938dce91> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/6be576f8-f928-46a7-a65e-efbdbb25f5e2> a WB:WBGene00006304,
+<http://model.geneontology.org/WB_WBGene00006304/6dd419ac-021e-4910-8211-e01acbaf79fd> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006304/f92bd5f2-6eb6-4c30-a744-7b04590a324b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006304/eaade1fa-7cb7-4e88-ae49-254f626ab98c> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/818d119d-fd99-48d2-85fd-6514938dce91> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00006304/db7bec81-fc80-43ac-88e5-8c1a68e1dbaa> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006304/1dd74e37-11a4-477f-beb6-3c4ccd85aa31> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006304/0f852e18-a093-44ea-8350-f5a002d9fd06> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/bd7c4959-43ae-4d64-ac90-38a22a713529> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006304/eaade1fa-7cb7-4e88-ae49-254f626ab98c> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006304/5790585a-199e-44bc-bac7-b3710fc93aa8> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006304/e4d4823e-daa5-4dbf-9cb6-801932fe0301> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006304/e4d4823e-daa5-4dbf-9cb6-801932fe0301> a GO:0000278,
+<http://model.geneontology.org/WB_WBGene00006304/f92bd5f2-6eb6-4c30-a744-7b04590a324b> a WB:WBGene00006304,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -126,50 +130,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006304/814c152b-c2dd-451f-ac8d-4a2debe1c700> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006304/cacadc2c-85ad-47f0-bd69-1f55c2d08fef> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006304  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5649|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/591f92a8-65d0-4946-879f-7fbbcd063ff2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/818d119d-fd99-48d2-85fd-6514938dce91> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/6dd419ac-021e-4910-8211-e01acbaf79fd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/eaade1fa-7cb7-4e88-ae49-254f626ab98c> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006304/e119268e-de78-4b27-9ab8-44c8a1d517ef> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006304/266d6f24-998a-4e3f-bc26-fffb159b4e02> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006304  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5648|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/bd7c4959-43ae-4d64-ac90-38a22a713529> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/e4d4823e-daa5-4dbf-9cb6-801932fe0301> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006304/09da2599-d81d-4a8c-8ed7-ee63727ce739> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006304  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5648|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/bd7c4959-43ae-4d64-ac90-38a22a713529> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/5790585a-199e-44bc-bac7-b3710fc93aa8> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006304/f2d7588a-aa01-47aa-b588-83520048899d> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006304  RO:0002264 GO:0009792 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5649|contributor-id=https://orcid.org/0000-0002-1478-7671|comment=Updated from original GO:0009790. 2018-01-02 kmv|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/591f92a8-65d0-4946-879f-7fbbcd063ff2> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/6be576f8-f928-46a7-a65e-efbdbb25f5e2> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/6dd419ac-021e-4910-8211-e01acbaf79fd> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/f92bd5f2-6eb6-4c30-a744-7b04590a324b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006304/15b0ed02-bf32-4c68-9b68-d1a6222120f8> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006304  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5648|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/db7bec81-fc80-43ac-88e5-8c1a68e1dbaa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/1dd74e37-11a4-477f-beb6-3c4ccd85aa31> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006304/79c27e65-63ab-40aa-b9de-78e5f7eeed3e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006304  RO:0002264 GO:0000278 WB:WBPaper00003120|PMID:9649522 ECO:0000315   2021-05-13 WB  id=WBOA:5648|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006304/db7bec81-fc80-43ac-88e5-8c1a68e1dbaa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006304/0f852e18-a093-44ea-8350-f5a002d9fd06> .
 

--- a/models/WB_WBGene00006799.ttl
+++ b/models/WB_WBGene00006799.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006799> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "unc-65 (WB:WBGene00006799)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006799> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006799/99dec396-ddd1-4f43-b5b5-e2386c69bd5c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006799/6425b515-f8a9-48eb-8fcb-154f73344d93> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143138" ;
+    ns1:evidence-with "WB:WBVar00143138" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7498734" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006799/d4ba4794-cb99-4937-9941-0b7c705fb116> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006799/960a03dd-fd24-4d15-ba00-07ebc6dff21c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143138" ;
+    ns1:evidence-with "WB:WBVar00143138" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:7498734" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00006799/41a727af-bf3a-450b-bd4e-68fd6cc55ad2> a WB:WBGene00006799,
+<http://model.geneontology.org/WB_WBGene00006799/2b0ef287-763c-4c4d-bd7d-97a24388abc8> a WB:WBGene00006799,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006799/6ec9038e-41f2-4fc6-aaab-406ef4efb1d8> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006799/cd7cfda7-8d9d-4d2a-b724-8aee356c7853> a GO:0007271,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006799/41a727af-bf3a-450b-bd4e-68fd6cc55ad2> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006799/ed31d500-3938-47a0-9c5d-47948e27bc40> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006799/ed31d500-3938-47a0-9c5d-47948e27bc40> a GO:0007271,
+<http://model.geneontology.org/WB_WBGene00006799/d60ee137-77d5-4c6c-bf2c-7bfed262bef3> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006799/2b0ef287-763c-4c4d-bd7d-97a24388abc8> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006799/cd7cfda7-8d9d-4d2a-b724-8aee356c7853> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006799/d4ba4794-cb99-4937-9941-0b7c705fb116> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006799/960a03dd-fd24-4d15-ba00-07ebc6dff21c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006799  RO:0002264 GO:0007271 WB:WBPaper00002195|PMID:7498734 ECO:0000315 WB:WBVar00143138  2021-05-13 WB  id=WBOA:8193|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006799/6ec9038e-41f2-4fc6-aaab-406ef4efb1d8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006799/ed31d500-3938-47a0-9c5d-47948e27bc40> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006799/99dec396-ddd1-4f43-b5b5-e2386c69bd5c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006799  RO:0002264 GO:0007271 WB:WBPaper00002195|PMID:7498734 ECO:0000315 WB:WBVar00143138  2021-05-13 WB  id=WBOA:8193|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006799/6ec9038e-41f2-4fc6-aaab-406ef4efb1d8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006799/41a727af-bf3a-450b-bd4e-68fd6cc55ad2> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006799/d60ee137-77d5-4c6c-bf2c-7bfed262bef3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006799/2b0ef287-763c-4c4d-bd7d-97a24388abc8> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006799/6425b515-f8a9-48eb-8fcb-154f73344d93> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006799  RO:0002264 GO:0007271 WB:WBPaper00002195|PMID:7498734 ECO:0000315 WB:WBVar00143138  2021-05-13 WB  id=WBOA:8193|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006799/d60ee137-77d5-4c6c-bf2c-7bfed262bef3> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006799/cd7cfda7-8d9d-4d2a-b724-8aee356c7853> .
 

--- a/models/WB_WBGene00006806.ttl
+++ b/models/WB_WBGene00006806.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,103 +29,107 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006806> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:title "unc-74 (WB:WBGene00006806)" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006806> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006806/2e8857fd-05ab-4343-a9c1-e4b9569a8860> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006806/342b7af1-4a58-4eca-89d0-91bf27f8933b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275214" ;
+    ns1:evidence-with "WB:WBVar00275214" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:11290716" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006806/334beed2-8db6-49c1-9894-bb5d125d39d8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006806/453871ee-0918-4f21-a772-68d3dd5fc1c4> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143565" ;
+    ns1:evidence-with "WB:WBVar00143565" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:11290716" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006806/601526e6-8294-4e26-9747-49c66ffd2818> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006806/905ffa2b-3aa3-4ba0-b340-9f134f713970> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00275214" ;
+    ns1:evidence-with "WB:WBVar00143565" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:11290716" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006806/a7e5c4a3-9032-47c0-98af-8ef250d2c5e1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00006806/ea538229-7e12-47fd-a989-87e3efa173d8> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00143565" ;
+    ns1:evidence-with "WB:WBVar00275214" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dc:source "PMID:11290716" ;
+    dct:created "2021-03-12" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00006806/0261c741-af4c-444f-96f6-933a2a8111aa> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00006806/65ca9819-7a21-4536-bbb1-b4ea80ee53f5> a WB:WBGene00006806,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006806/38f3c429-9c1c-4eda-9fc2-19a14f039251> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006806/2486d424-552b-4388-92c8-51ee187c12ed> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006806/2486d424-552b-4388-92c8-51ee187c12ed> a GO:0018991,
+<http://model.geneontology.org/WB_WBGene00006806/8f4819b0-2215-4394-961a-a3d26367de3d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00006806/65ca9819-7a21-4536-bbb1-b4ea80ee53f5> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00006806/c7c944e5-1b45-4593-adba-67b30dba16db> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006806/38f3c429-9c1c-4eda-9fc2-19a14f039251> a WB:WBGene00006806,
+<http://model.geneontology.org/WB_WBGene00006806/c7c944e5-1b45-4593-adba-67b30dba16db> a GO:0018991,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006806/2e8857fd-05ab-4343-a9c1-e4b9569a8860>,
-        <http://model.geneontology.org/WB_WBGene00006806/a7e5c4a3-9032-47c0-98af-8ef250d2c5e1> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006806/342b7af1-4a58-4eca-89d0-91bf27f8933b>,
+        <http://model.geneontology.org/WB_WBGene00006806/453871ee-0918-4f21-a772-68d3dd5fc1c4> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-03-12" ;
     dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00006806  RO:0002264 GO:0018991 WB:WBPaper00004660|PMID:11290716 ECO:0000315 WB:WBVar00143565  2021-03-12 WB  id=WBOA:89567|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
-        "WB:WBGene00006806  RO:0002264 GO:0018991 WB:WBPaper00004660|PMID:11290716 ECO:0000315 WB:WBVar00275214  2021-03-12 WB  id=WBOA:6429|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006806/0261c741-af4c-444f-96f6-933a2a8111aa> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006806/38f3c429-9c1c-4eda-9fc2-19a14f039251> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006806/334beed2-8db6-49c1-9894-bb5d125d39d8>,
-        <http://model.geneontology.org/WB_WBGene00006806/601526e6-8294-4e26-9747-49c66ffd2818> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-03-12" ;
-    dct:created "2021-03-12" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006806  RO:0002264 GO:0018991 WB:WBPaper00004660|PMID:11290716 ECO:0000315 WB:WBVar00143565  2021-03-12 WB  id=WBOA:89567|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
         "WB:WBGene00006806  RO:0002264 GO:0018991 WB:WBPaper00004660|PMID:11290716 ECO:0000315 WB:WBVar00275214  2021-03-12 WB  id=WBOA:6429|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006806/0261c741-af4c-444f-96f6-933a2a8111aa> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006806/2486d424-552b-4388-92c8-51ee187c12ed> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006806/8f4819b0-2215-4394-961a-a3d26367de3d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006806/c7c944e5-1b45-4593-adba-67b30dba16db> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006806/905ffa2b-3aa3-4ba0-b340-9f134f713970>,
+        <http://model.geneontology.org/WB_WBGene00006806/ea538229-7e12-47fd-a989-87e3efa173d8> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-03-12" ;
+    dct:created "2021-03-12" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00006806  RO:0002264 GO:0018991 WB:WBPaper00004660|PMID:11290716 ECO:0000315 WB:WBVar00143565  2021-03-12 WB  id=WBOA:89567|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12",
+        "WB:WBGene00006806  RO:0002264 GO:0018991 WB:WBPaper00004660|PMID:11290716 ECO:0000315 WB:WBVar00275214  2021-03-12 WB  id=WBOA:6429|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-03-12|modification-date=2021-03-12" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006806/8f4819b0-2215-4394-961a-a3d26367de3d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006806/65ca9819-7a21-4536-bbb1-b4ea80ee53f5> .
 

--- a/models/WB_WBGene00006912.ttl
+++ b/models/WB_WBGene00006912.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,52 +29,53 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006912> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dc:title "vha-3 (WB:WBGene00006912)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006912> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006912/44e7e8d5-fe00-4d7d-83ff-e43c9fd24d70> a WB:WBGene00006912,
+<http://model.geneontology.org/WB_WBGene00006912/4f4bf91e-967a-40b2-bf34-a65221e711f8> a WB:WBGene00006912,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00006912/261ce138-4d12-4042-bcee-435eb3b8ee3f> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00006912/439ae96d-2118-4c01-bf98-4584f835005f> ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00006912/9f66a713-68ee-4a84-961a-1b8e47e0308a> a ECO:0000303,
+<http://model.geneontology.org/WB_WBGene00006912/5203e588-219f-48eb-aeb0-d4cbb7a06312> a ECO:0000303,
         owl:NamedIndividual ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:9712884" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "2020-03-17; updated to NAS; can't find an experimental annotation to make a valid ISS annotation." .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00006912/261ce138-4d12-4042-bcee-435eb3b8ee3f> a GO:0000220,
+<http://model.geneontology.org/WB_WBGene00006912/439ae96d-2118-4c01-bf98-4584f835005f> a GO:0000220,
         owl:NamedIndividual ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006912/9f66a713-68ee-4a84-961a-1b8e47e0308a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006912/5203e588-219f-48eb-aeb0-d4cbb7a06312> ;
     dc:contributor "GOC:cab1" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006912  BFO:0000050 GO:0000220 WB:WBPaper00003195|PMID:9712884 ECO:0000303   2020-05-13 WB  id=WBOA:6618|contributor-id=GOC:cab1|comment=2020-03-17; updated to NAS; can't find an experimental annotation to make a valid ISS annotation.|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006912/44e7e8d5-fe00-4d7d-83ff-e43c9fd24d70> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006912/261ce138-4d12-4042-bcee-435eb3b8ee3f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006912/4f4bf91e-967a-40b2-bf34-a65221e711f8> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006912/439ae96d-2118-4c01-bf98-4584f835005f> .
 

--- a/models/WB_WBGene00006967.ttl
+++ b/models/WB_WBGene00006967.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,51 +29,52 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00006967> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2020-05-13" ;
     dc:title "yrn-1 (WB:WBGene00006967)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00006967> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00006967/b2ab0e1c-be19-41ae-9e7b-0f637f2b0a1e> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00006967/3a1db2d4-9a5c-4414-9765-9c5757d1f30e> a WB:WBGene00006967,
+        owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00006967/ab7e0832-e735-4bc0-acd4-34960e4e26a1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00006967/65e5b5e8-d287-48ff-ad94-3f1710a28b50> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:7489501" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00006967/d24a41ea-cebd-4e14-b03d-bd2371767425> a WB:WBGene00006967,
-        owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00006967/6d94b738-da85-4a78-be27-8122f0cdbe92> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00006967/6d94b738-da85-4a78-be27-8122f0cdbe92> a GO:1990904,
+<http://model.geneontology.org/WB_WBGene00006967/ab7e0832-e735-4bc0-acd4-34960e4e26a1> a GO:1990904,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00006967/b2ab0e1c-be19-41ae-9e7b-0f637f2b0a1e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00006967/65e5b5e8-d287-48ff-ad94-3f1710a28b50> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00006967  BFO:0000050 GO:1990904 WB:WBPaper00002296|PMID:7489501 ECO:0000314   2020-05-13 WB  id=WBOA:6716|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006967/d24a41ea-cebd-4e14-b03d-bd2371767425> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006967/6d94b738-da85-4a78-be27-8122f0cdbe92> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00006967/3a1db2d4-9a5c-4414-9765-9c5757d1f30e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00006967/ab7e0832-e735-4bc0-acd4-34960e4e26a1> .
 

--- a/models/WB_WBGene00007002.ttl
+++ b/models/WB_WBGene00007002.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00007002> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "pre-1 (WB:WBGene00007002)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00007002> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00007002/04c5f64b-2e12-4612-9d4c-ff8e4e2cc45f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007002/0a8930f9-00ae-4b2b-ba17-36793a00af5f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "No allele given." .
 
-<http://model.geneontology.org/WB_WBGene00007002/264df923-93b9-4ac1-9a2b-201004045052> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007002/42e64eba-21fc-4c3f-8234-be68d2d83b05> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "No allele given." .
 
-<http://model.geneontology.org/WB_WBGene00007002/8a7a7ed0-7d6c-4b41-9c49-b26c6bc66258> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007002/8887735b-5071-4a1c-99c3-950af5263c36> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "No allele given." .
 
-<http://model.geneontology.org/WB_WBGene00007002/8c0a8a45-176b-4c1d-818f-7f4da1994d9f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007002/8cc3469b-11ab-4cd8-a9c1-30303ebc2b14> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "No allele given." .
 
-<http://model.geneontology.org/WB_WBGene00007002/a0688c15-de98-419c-96e9-53ab5f68b8bc> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007002/c6472eb2-912e-4225-bb62-10061e13e4f4> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "No allele given." .
 
-<http://model.geneontology.org/WB_WBGene00007002/e0a12bcf-efef-4cdc-865e-8d63e6e2c59a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007002/dac49859-06e8-4c25-97c9-7d4f6391e911> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "No allele given." .
 
-<http://model.geneontology.org/WB_WBGene00007002/1e739698-bebf-4279-a36a-d2dfb96b7e7f> a GO:0032504,
+<http://model.geneontology.org/WB_WBGene00007002/12939924-8225-470a-9fc9-6257972fc72d> a WB:WBGene00007002,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/1f99e7c2-3939-4263-b56d-0d12a1284cba> a GO:0008340,
+<http://model.geneontology.org/WB_WBGene00007002/2baaff5e-3b13-4768-b699-b41b50701c06> a GO:0033555,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/4547adb1-8b56-4ae8-922c-38d014e0183c> a WB:WBGene00007002,
+<http://model.geneontology.org/WB_WBGene00007002/2f50c5ef-2a5a-42d2-a113-09f9fe048e47> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007002/ddcfbcb1-1626-4675-96ad-2b983aaf2374> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007002/2baaff5e-3b13-4768-b699-b41b50701c06> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/6530c2bd-0fd3-41cb-8856-3c0e596edd4d> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007002/5f074019-a5f1-4d96-83c4-4b3467541230> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007002/4547adb1-8b56-4ae8-922c-38d014e0183c> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007002/c348d42f-3534-4593-8005-542263727d4f> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007002/7c98ae9b-0c1c-47c5-8fc9-d05c396e253e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007002/78bdaf13-edb9-46fd-aa3b-e33c97a6c4bf> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/74e8a584-1e88-472d-8869-4e54b135125c> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007002/78bdaf13-edb9-46fd-aa3b-e33c97a6c4bf> a GO:0032504,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007002/95dae194-1aa4-4410-b1c5-3d501348afa1> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007002/1e739698-bebf-4279-a36a-d2dfb96b7e7f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/95dae194-1aa4-4410-b1c5-3d501348afa1> a WB:WBGene00007002,
+<http://model.geneontology.org/WB_WBGene00007002/7c98ae9b-0c1c-47c5-8fc9-d05c396e253e> a WB:WBGene00007002,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/b62a9f0c-2fe5-4767-93b7-60c2b3358979> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007002/bf433564-ed96-4ad5-aa89-edbeaef59f6b> a GO:0008340,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007002/dc511500-c5b3-4ade-a89a-453851e81bac> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007002/1f99e7c2-3939-4263-b56d-0d12a1284cba> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/c348d42f-3534-4593-8005-542263727d4f> a GO:0033555,
+<http://model.geneontology.org/WB_WBGene00007002/ddcfbcb1-1626-4675-96ad-2b983aaf2374> a WB:WBGene00007002,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007002/dc511500-c5b3-4ade-a89a-453851e81bac> a WB:WBGene00007002,
+<http://model.geneontology.org/WB_WBGene00007002/ef89bb37-152b-4f5c-b5c8-350e27d4a8fe> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007002/12939924-8225-470a-9fc9-6257972fc72d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007002/bf433564-ed96-4ad5-aa89-edbeaef59f6b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007002/8a7a7ed0-7d6c-4b41-9c49-b26c6bc66258> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007002/42e64eba-21fc-4c3f-8234-be68d2d83b05> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6807|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/6530c2bd-0fd3-41cb-8856-3c0e596edd4d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/c348d42f-3534-4593-8005-542263727d4f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/2f50c5ef-2a5a-42d2-a113-09f9fe048e47> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/2baaff5e-3b13-4768-b699-b41b50701c06> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007002/264df923-93b9-4ac1-9a2b-201004045052> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007002/0a8930f9-00ae-4b2b-ba17-36793a00af5f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6809|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/74e8a584-1e88-472d-8869-4e54b135125c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/1e739698-bebf-4279-a36a-d2dfb96b7e7f> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007002/04c5f64b-2e12-4612-9d4c-ff8e4e2cc45f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6808|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/b62a9f0c-2fe5-4767-93b7-60c2b3358979> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/dc511500-c5b3-4ade-a89a-453851e81bac> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/ef89bb37-152b-4f5c-b5c8-350e27d4a8fe> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/12939924-8225-470a-9fc9-6257972fc72d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007002/e0a12bcf-efef-4cdc-865e-8d63e6e2c59a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007002/dac49859-06e8-4c25-97c9-7d4f6391e911> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6807|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/6530c2bd-0fd3-41cb-8856-3c0e596edd4d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/4547adb1-8b56-4ae8-922c-38d014e0183c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/2f50c5ef-2a5a-42d2-a113-09f9fe048e47> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/ddcfbcb1-1626-4675-96ad-2b983aaf2374> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007002/a0688c15-de98-419c-96e9-53ab5f68b8bc> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007002/8887735b-5071-4a1c-99c3-950af5263c36> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6809|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/74e8a584-1e88-472d-8869-4e54b135125c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/95dae194-1aa4-4410-b1c5-3d501348afa1> .
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/5f074019-a5f1-4d96-83c4-4b3467541230> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/78bdaf13-edb9-46fd-aa3b-e33c97a6c4bf> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007002/8c0a8a45-176b-4c1d-818f-7f4da1994d9f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007002/8cc3469b-11ab-4cd8-a9c1-30303ebc2b14> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6808|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/b62a9f0c-2fe5-4767-93b7-60c2b3358979> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/1f99e7c2-3939-4263-b56d-0d12a1284cba> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/ef89bb37-152b-4f5c-b5c8-350e27d4a8fe> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/bf433564-ed96-4ad5-aa89-edbeaef59f6b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007002/c6472eb2-912e-4225-bb62-10061e13e4f4> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007002  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6809|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=No allele given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007002/5f074019-a5f1-4d96-83c4-4b3467541230> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007002/7c98ae9b-0c1c-47c5-8fc9-d05c396e253e> .
 

--- a/models/WB_WBGene00007003.ttl
+++ b/models/WB_WBGene00007003.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00007003> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "pre-7 (WB:WBGene00007003)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00007003> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00007003/3ec4100f-99f6-4160-b004-39b9eb17d785> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007003/1284908f-21fd-402b-aba0-4ce08065c0ae> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007003/7e162d43-2eda-4c80-81e5-6408c68e2414> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007003/71f93f47-6b72-4b13-8f39-434d47fb984e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007003/b1d58e48-a275-4d50-8c83-af69d80533da> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007003/93d9e3b5-cd1d-4335-9f84-b32c6f481e24> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007003/bb2c98da-91f6-430f-8608-e5eae92c0cf1> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007003/c9d2cee1-3ddf-43bf-bea7-1aa07ada0a3e> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007003/ee257c8b-fd4b-4580-9117-afdb15ce4d36> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007003/e21160ec-7768-41e5-b8a6-d1096ce159fe> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007003/f9f059f7-255c-4157-9fb9-4fdad55abc6e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007003/f38bcaf2-8f6c-4132-97b2-cd40bde8b3ff> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007003/04ad66d8-6dcf-4469-8b1b-1c55bc5cbc59> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007003/07fbbd1e-c59a-4b98-8f0e-9cc5c8d651b9> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007003/9d710d48-b53b-4e3b-a2b7-58937dffacfa> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007003/da319721-39e6-42f1-a4d4-7efeb5cce180> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007003/d23dc018-719a-484e-a701-f59f028ea563> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007003/43494167-8fa5-42ae-ac40-6fed26a850a8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/094067dc-f996-4c4b-8329-0945d2f88923> a WB:WBGene00007003,
+<http://model.geneontology.org/WB_WBGene00007003/43494167-8fa5-42ae-ac40-6fed26a850a8> a GO:0032504,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/66c9bfb7-70f8-44e1-9c6c-e7de950dcaba> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007003/5b8d45f7-59ef-4648-ab6a-f569ccd373a2> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007003/7ebc8d56-0bb3-4015-b796-be92ba06efce> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007003/733fad39-73b8-4ffd-9c1a-cf9d6e88b3c1> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007003/5d98d076-6e9f-46a1-b367-658ff8ea2622> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007003/f7806e76-830b-4cce-90f1-1a5a2dcc14a9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/733fad39-73b8-4ffd-9c1a-cf9d6e88b3c1> a GO:0008340,
+<http://model.geneontology.org/WB_WBGene00007003/5d98d076-6e9f-46a1-b367-658ff8ea2622> a WB:WBGene00007003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/7ebc8d56-0bb3-4015-b796-be92ba06efce> a WB:WBGene00007003,
+<http://model.geneontology.org/WB_WBGene00007003/b1614b7b-6389-4ad0-8679-d34c48ec3ea7> a GO:0033555,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/906757a3-ac21-4e74-a6b9-929a7b5e31cc> a GO:0032504,
+<http://model.geneontology.org/WB_WBGene00007003/c05c701f-aca5-4a66-b27b-546e164de8f5> a WB:WBGene00007003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/9d710d48-b53b-4e3b-a2b7-58937dffacfa> a WB:WBGene00007003,
+<http://model.geneontology.org/WB_WBGene00007003/d23dc018-719a-484e-a701-f59f028ea563> a WB:WBGene00007003,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/c842c019-4134-40e5-976a-01ed87391b16> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007003/f763728a-a058-4d05-9892-c4b563398a4f> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007003/094067dc-f996-4c4b-8329-0945d2f88923> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007003/906757a3-ac21-4e74-a6b9-929a7b5e31cc> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007003/c05c701f-aca5-4a66-b27b-546e164de8f5> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007003/b1614b7b-6389-4ad0-8679-d34c48ec3ea7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007003/da319721-39e6-42f1-a4d4-7efeb5cce180> a GO:0033555,
+<http://model.geneontology.org/WB_WBGene00007003/f7806e76-830b-4cce-90f1-1a5a2dcc14a9> a GO:0008340,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007003/ee257c8b-fd4b-4580-9117-afdb15ce4d36> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007003/1284908f-21fd-402b-aba0-4ce08065c0ae> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6810|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/04ad66d8-6dcf-4469-8b1b-1c55bc5cbc59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/9d710d48-b53b-4e3b-a2b7-58937dffacfa> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007003/f9f059f7-255c-4157-9fb9-4fdad55abc6e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6811|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/66c9bfb7-70f8-44e1-9c6c-e7de950dcaba> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/7ebc8d56-0bb3-4015-b796-be92ba06efce> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007003/bb2c98da-91f6-430f-8608-e5eae92c0cf1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6812|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/c842c019-4134-40e5-976a-01ed87391b16> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/906757a3-ac21-4e74-a6b9-929a7b5e31cc> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007003/7e162d43-2eda-4c80-81e5-6408c68e2414> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6811|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/66c9bfb7-70f8-44e1-9c6c-e7de950dcaba> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/733fad39-73b8-4ffd-9c1a-cf9d6e88b3c1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/5b8d45f7-59ef-4648-ab6a-f569ccd373a2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/f7806e76-830b-4cce-90f1-1a5a2dcc14a9> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007003/3ec4100f-99f6-4160-b004-39b9eb17d785> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007003/71f93f47-6b72-4b13-8f39-434d47fb984e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6810|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/04ad66d8-6dcf-4469-8b1b-1c55bc5cbc59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/da319721-39e6-42f1-a4d4-7efeb5cce180> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007003/b1d58e48-a275-4d50-8c83-af69d80533da> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6812|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/c842c019-4134-40e5-976a-01ed87391b16> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/094067dc-f996-4c4b-8329-0945d2f88923> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/07fbbd1e-c59a-4b98-8f0e-9cc5c8d651b9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/d23dc018-719a-484e-a701-f59f028ea563> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007003/93d9e3b5-cd1d-4335-9f84-b32c6f481e24> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6811|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/5b8d45f7-59ef-4648-ab6a-f569ccd373a2> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/5d98d076-6e9f-46a1-b367-658ff8ea2622> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007003/e21160ec-7768-41e5-b8a6-d1096ce159fe> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6810|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/f763728a-a058-4d05-9892-c4b563398a4f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/b1614b7b-6389-4ad0-8679-d34c48ec3ea7> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007003/f38bcaf2-8f6c-4132-97b2-cd40bde8b3ff> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6810|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/f763728a-a058-4d05-9892-c4b563398a4f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/c05c701f-aca5-4a66-b27b-546e164de8f5> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007003/c9d2cee1-3ddf-43bf-bea7-1aa07ada0a3e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007003  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6812|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007003/07fbbd1e-c59a-4b98-8f0e-9cc5c8d651b9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007003/43494167-8fa5-42ae-ac40-6fed26a850a8> .
 

--- a/models/WB_WBGene00007004.ttl
+++ b/models/WB_WBGene00007004.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00007004> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "pre-33 (WB:WBGene00007004)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00007004> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00007004/12e937fd-77d4-4c74-96ac-e0a208d17dc2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007004/2bc86866-e08a-4806-9c24-5b21f8b66d85> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007004/42046ae6-091f-4b35-a026-e0e527e8b44f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007004/5504e986-f989-40bf-8f6a-03ea625be510> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007004/51dbd363-e07f-40e8-9fa8-de4324bf0ff6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007004/af9c4497-44d9-48e5-8b9a-99a2cea458f3> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007004/60639a2f-dd58-46ab-a42c-4bbd8b20c0a9> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007004/d2e648dc-fb05-44c7-a4a1-b67d5b1654ac> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007004/f4899e65-1f20-4752-8c6f-7a34f174d79f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007004/fabe3824-31ce-4d68-a16f-93e90121479f> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007004/fa1bc478-039b-47cc-b9d6-b4e91b8377d6> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00007004/ff73567f-36e3-4823-bea6-5d2adb374971> a ECO:0000315,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:12700416" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "Allele not given." .
 
-<http://model.geneontology.org/WB_WBGene00007004/07546333-119d-4fa0-81b6-544a33c92c07> a WB:WBGene00007004,
+<http://model.geneontology.org/WB_WBGene00007004/25543e1b-3dc3-4c0c-947f-9e86c2a867c1> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007004/2a81dbfc-0787-4b34-91c2-6c2ea6007aa6> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007004/ec25828e-945e-4511-988b-6db977e6b4f0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/34e6bda6-a1ae-450c-adfe-64474c009e35> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007004/2a81dbfc-0787-4b34-91c2-6c2ea6007aa6> a WB:WBGene00007004,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007004/07546333-119d-4fa0-81b6-544a33c92c07> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007004/6ccd80b4-d5eb-4126-a6b8-de3def5c726d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/44883653-53c2-4295-ba2a-c0c898b02ceb> a GO:0008340,
+<http://model.geneontology.org/WB_WBGene00007004/48ae5880-c6eb-4276-a531-98031a3b99de> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007004/c0e2f6e5-3738-453a-84bd-9a026e47bacf> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007004/7db17fb6-3f98-4634-b9b8-5f0a58c7aee9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/6ccd80b4-d5eb-4126-a6b8-de3def5c726d> a GO:0032504,
+<http://model.geneontology.org/WB_WBGene00007004/5d1d07ea-572e-4ec3-8df8-0ae515f536e1> a WB:WBGene00007004,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/7ea0a7de-7317-488e-9619-e3a46dc069fb> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007004/6dd62480-17d9-433f-a148-120b980d7358> a GO:0032504,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007004/ccbf7656-3037-4e5c-9640-d78a9de816e9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007004/44883653-53c2-4295-ba2a-c0c898b02ceb> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/acd53083-fd7e-4a0d-9f0e-ff89357252cd> a WB:WBGene00007004,
+<http://model.geneontology.org/WB_WBGene00007004/7db17fb6-3f98-4634-b9b8-5f0a58c7aee9> a GO:0033555,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/ccbf7656-3037-4e5c-9640-d78a9de816e9> a WB:WBGene00007004,
+<http://model.geneontology.org/WB_WBGene00007004/c0e2f6e5-3738-453a-84bd-9a026e47bacf> a WB:WBGene00007004,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/d55a799a-b066-4a6f-ba08-9d918b200e13> a GO:0033555,
+<http://model.geneontology.org/WB_WBGene00007004/cd21faa5-0e13-41ea-a9f0-d2cb9c97427f> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007004/5d1d07ea-572e-4ec3-8df8-0ae515f536e1> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007004/6dd62480-17d9-433f-a148-120b980d7358> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007004/de095aa0-6db1-4a8b-8b99-b4b66b8154c0> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007004/ec25828e-945e-4511-988b-6db977e6b4f0> a GO:0008340,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007004/acd53083-fd7e-4a0d-9f0e-ff89357252cd> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007004/d55a799a-b066-4a6f-ba08-9d918b200e13> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007004/12e937fd-77d4-4c74-96ac-e0a208d17dc2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007004/af9c4497-44d9-48e5-8b9a-99a2cea458f3> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6815|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/34e6bda6-a1ae-450c-adfe-64474c009e35> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/07546333-119d-4fa0-81b6-544a33c92c07> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007004/51dbd363-e07f-40e8-9fa8-de4324bf0ff6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6814|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/7ea0a7de-7317-488e-9619-e3a46dc069fb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/ccbf7656-3037-4e5c-9640-d78a9de816e9> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007004/f4899e65-1f20-4752-8c6f-7a34f174d79f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6813|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/de095aa0-6db1-4a8b-8b99-b4b66b8154c0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/d55a799a-b066-4a6f-ba08-9d918b200e13> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007004/fa1bc478-039b-47cc-b9d6-b4e91b8377d6> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6813|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/de095aa0-6db1-4a8b-8b99-b4b66b8154c0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/acd53083-fd7e-4a0d-9f0e-ff89357252cd> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007004/60639a2f-dd58-46ab-a42c-4bbd8b20c0a9> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6815|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/34e6bda6-a1ae-450c-adfe-64474c009e35> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/6ccd80b4-d5eb-4126-a6b8-de3def5c726d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007004/42046ae6-091f-4b35-a026-e0e527e8b44f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6814|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/7ea0a7de-7317-488e-9619-e3a46dc069fb> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/44883653-53c2-4295-ba2a-c0c898b02ceb> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/25543e1b-3dc3-4c0c-947f-9e86c2a867c1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/ec25828e-945e-4511-988b-6db977e6b4f0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007004/fabe3824-31ce-4d68-a16f-93e90121479f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6813|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/48ae5880-c6eb-4276-a531-98031a3b99de> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/c0e2f6e5-3738-453a-84bd-9a026e47bacf> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007004/5504e986-f989-40bf-8f6a-03ea625be510> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6815|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/cd21faa5-0e13-41ea-a9f0-d2cb9c97427f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/5d1d07ea-572e-4ec3-8df8-0ae515f536e1> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007004/2bc86866-e08a-4806-9c24-5b21f8b66d85> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0008340 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6814|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/25543e1b-3dc3-4c0c-947f-9e86c2a867c1> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/2a81dbfc-0787-4b34-91c2-6c2ea6007aa6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007004/ff73567f-36e3-4823-bea6-5d2adb374971> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0032504 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6815|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/cd21faa5-0e13-41ea-a9f0-d2cb9c97427f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/6dd62480-17d9-433f-a148-120b980d7358> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007004/d2e648dc-fb05-44c7-a4a1-b67d5b1654ac> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007004  RO:0002264 GO:0033555 WB:WBPaper00005850|PMID:12700416 ECO:0000315   2021-05-13 WB  id=WBOA:6813|contributor-id=https://orcid.org/0000-0002-1706-4196|comment=Allele not given.|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007004/48ae5880-c6eb-4276-a531-98031a3b99de> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007004/7db17fb6-3f98-4634-b9b8-5f0a58c7aee9> .
 

--- a/models/WB_WBGene00007031.ttl
+++ b/models/WB_WBGene00007031.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00007031> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "erf-1 (WB:WBGene00007031)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00007031> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00007031/5f76b1d6-1ded-44ea-a9de-3b59b5186a2f> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00007031/067008f7-7360-41ec-9e9b-c534c50636c1> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00004048" ;
+    ns1:evidence-with "WB:WBGene00004048" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:15030761" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007031/c4c85316-e0fe-4d4f-893d-63d4dc090cd0> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00007031/c638a197-15f4-4e54-8112-a26a06c9e121> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00004048" ;
+    ns1:evidence-with "WB:WBGene00004048" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:15030761" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00007031/3ddea4cd-fdd4-48a2-82e0-31ce34dfec63> a GO:0045138,
+<http://model.geneontology.org/WB_WBGene00007031/2befae6a-11b4-4b49-95ab-fad1b7d70063> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007031/32eb63a6-5b3e-4c23-9189-1ebb9a6164e6> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007031/83173e77-e924-40bf-a96c-2b331d7bc781> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007031/945e53d7-babb-4767-852a-43ffc71187b4> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007031/32eb63a6-5b3e-4c23-9189-1ebb9a6164e6> a WB:WBGene00007031,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007031/94ca8ac1-a4b3-4381-9b1d-25b9f63591cc> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007031/3ddea4cd-fdd4-48a2-82e0-31ce34dfec63> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007031/94ca8ac1-a4b3-4381-9b1d-25b9f63591cc> a WB:WBGene00007031,
+<http://model.geneontology.org/WB_WBGene00007031/83173e77-e924-40bf-a96c-2b331d7bc781> a GO:0045138,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007031/c4c85316-e0fe-4d4f-893d-63d4dc090cd0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007031/c638a197-15f4-4e54-8112-a26a06c9e121> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00007031  RO:0002264 GO:0045138 WB:WBPaper00006490|PMID:15030761 ECO:0000316 WB:WBGene00004048  2021-05-13 WB  id=WBOA:9035|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007031/945e53d7-babb-4767-852a-43ffc71187b4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007031/94ca8ac1-a4b3-4381-9b1d-25b9f63591cc> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007031/5f76b1d6-1ded-44ea-a9de-3b59b5186a2f> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007031  RO:0002264 GO:0045138 WB:WBPaper00006490|PMID:15030761 ECO:0000316 WB:WBGene00004048  2021-05-13 WB  id=WBOA:9035|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007031/945e53d7-babb-4767-852a-43ffc71187b4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007031/3ddea4cd-fdd4-48a2-82e0-31ce34dfec63> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007031/2befae6a-11b4-4b49-95ab-fad1b7d70063> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007031/83173e77-e924-40bf-a96c-2b331d7bc781> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007031/067008f7-7360-41ec-9e9b-c534c50636c1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00007031  RO:0002264 GO:0045138 WB:WBPaper00006490|PMID:15030761 ECO:0000316 WB:WBGene00004048  2021-05-13 WB  id=WBOA:9035|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007031/2befae6a-11b4-4b49-95ab-fad1b7d70063> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007031/32eb63a6-5b3e-4c23-9189-1ebb9a6164e6> .
 

--- a/models/WB_WBGene00007032.ttl
+++ b/models/WB_WBGene00007032.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00007032> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "erf-2 (WB:WBGene00007032)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00007032> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00007032/48d61fed-856a-4626-bc94-838c2ba76651> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00007032/1b16e248-94e7-407b-8d6f-23c12bec7f5a> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00004048" ;
+    ns1:evidence-with "WB:WBGene00004048" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:15030761" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007032/89734ad0-43b9-4c78-a3ed-40c3f6ea5367> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00007032/b67b711c-66d0-4f18-bfd4-d49229f9dedd> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00004048" ;
+    ns1:evidence-with "WB:WBGene00004048" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:15030761" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00007032/28328b96-8830-4a3e-a851-d8e3c39be9de> a GO:0045138,
+<http://model.geneontology.org/WB_WBGene00007032/7747e882-273a-4d54-b122-c3f2c94254af> a GO:0045138,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007032/49cc5dca-7a11-4cde-8bcf-eecfda3c5319> a WB:WBGene00007032,
+<http://model.geneontology.org/WB_WBGene00007032/a3125266-50fd-4236-8b5c-af110a9a1fef> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007032/c14465c6-1e09-4fb4-b0cc-8e0d34a0c106> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007032/7747e882-273a-4d54-b122-c3f2c94254af> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007032/dc8f3c6a-6c34-4832-bcbf-25b86dd00b66> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007032/c14465c6-1e09-4fb4-b0cc-8e0d34a0c106> a WB:WBGene00007032,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007032/49cc5dca-7a11-4cde-8bcf-eecfda3c5319> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00007032/28328b96-8830-4a3e-a851-d8e3c39be9de> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007032/48d61fed-856a-4626-bc94-838c2ba76651> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007032/1b16e248-94e7-407b-8d6f-23c12bec7f5a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007032  RO:0002264 GO:0045138 WB:WBPaper00006490|PMID:15030761 ECO:0000316 WB:WBGene00004048  2021-05-13 WB  id=WBOA:9036|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007032/dc8f3c6a-6c34-4832-bcbf-25b86dd00b66> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007032/49cc5dca-7a11-4cde-8bcf-eecfda3c5319> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007032/a3125266-50fd-4236-8b5c-af110a9a1fef> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007032/c14465c6-1e09-4fb4-b0cc-8e0d34a0c106> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007032/89734ad0-43b9-4c78-a3ed-40c3f6ea5367> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007032/b67b711c-66d0-4f18-bfd4-d49229f9dedd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007032  RO:0002264 GO:0045138 WB:WBPaper00006490|PMID:15030761 ECO:0000316 WB:WBGene00004048  2021-05-13 WB  id=WBOA:9036|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007032/dc8f3c6a-6c34-4832-bcbf-25b86dd00b66> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007032/28328b96-8830-4a3e-a851-d8e3c39be9de> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007032/a3125266-50fd-4236-8b5c-af110a9a1fef> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007032/7747e882-273a-4d54-b122-c3f2c94254af> .
 

--- a/models/WB_WBGene00007864.ttl
+++ b/models/WB_WBGene00007864.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00007864> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:title "irg-6 (WB:WBGene00007864)" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00007864> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00007864/c78cfcdf-4dff-4289-8afb-54824d10e25d> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00007864/72362eea-d45e-481f-96c1-e15f18d2989f> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007864/d0bb532e-7efe-4457-954d-aa2a97698c8a> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00007864/bef236dd-3cb4-4546-bf39-d177ee1095c8> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00007864/8bb783df-7bce-47fa-b600-5727161b8a32> a WB:WBGene00007864,
+<http://model.geneontology.org/WB_WBGene00007864/11f534c3-30ab-4e2f-b1f4-07f3d8b6f2c4> a GO:0010332,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007864/8f653d0f-3a6d-4abb-9edd-5c16b3ef9169> a GO:0010332,
+<http://model.geneontology.org/WB_WBGene00007864/201c20b8-aee1-4157-8ba1-07cd94cb35ca> a WB:WBGene00007864,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00007864/e9c3fe64-6be8-470b-8f75-d7d251289e84> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00007864/403920fa-0263-4f94-9617-47efc1311a44> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00007864/8f653d0f-3a6d-4abb-9edd-5c16b3ef9169> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007864/8bb783df-7bce-47fa-b600-5727161b8a32> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00007864/11f534c3-30ab-4e2f-b1f4-07f3d8b6f2c4> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00007864/201c20b8-aee1-4157-8ba1-07cd94cb35ca> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007864/d0bb532e-7efe-4457-954d-aa2a97698c8a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007864/bef236dd-3cb4-4546-bf39-d177ee1095c8> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007864  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12037|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007864/e9c3fe64-6be8-470b-8f75-d7d251289e84> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007864/8f653d0f-3a6d-4abb-9edd-5c16b3ef9169> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007864/403920fa-0263-4f94-9617-47efc1311a44> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007864/11f534c3-30ab-4e2f-b1f4-07f3d8b6f2c4> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00007864/c78cfcdf-4dff-4289-8afb-54824d10e25d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00007864/72362eea-d45e-481f-96c1-e15f18d2989f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00007864  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12037|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007864/e9c3fe64-6be8-470b-8f75-d7d251289e84> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007864/8bb783df-7bce-47fa-b600-5727161b8a32> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00007864/403920fa-0263-4f94-9617-47efc1311a44> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00007864/201c20b8-aee1-4157-8ba1-07cd94cb35ca> .
 

--- a/models/WB_WBGene00009680.ttl
+++ b/models/WB_WBGene00009680.ttl
@@ -4,14 +4,14 @@
 @prefix WBbt: <http://purl.obolibrary.org/obo/WBbt_> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -30,145 +30,149 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00009680> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:title "msd-1 (WB:WBGene00009680)" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00009680> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00009680/070173ce-51a4-4927-9b68-ea544348053f> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009680/5fc955c7-5969-4099-a848-9615b633e46a> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:15975936" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/15cee023-4a6a-48c3-b401-a99292b2db92> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009680/8679f51c-330c-43f3-9b1d-99dabfc0f859> a WB:WBGene00009680,
+        owl:NamedIndividual ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009680/01b79f68-2682-41c8-8b27-cb1e25bc7e2b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00009680/98690b39-e80f-494d-87e2-2a6810a60e53> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:15975936" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/2f1f93c3-da46-4fa0-8d53-40b680c8568f> a WB:WBGene00009680,
+<http://model.geneontology.org/WB_WBGene00009680/e6489a54-67aa-4f3a-85ff-e20a3925edb9> a WB:WBGene00009680,
         owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009680/0bd59d4a-85ab-411a-98b3-0a6490785b8b> ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009680/83f8f9a1-7f28-413b-bd66-5077cd0a611f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/6c0f2771-a2ad-44d4-984e-8e2126f8e5de> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009680/f25a9324-3f74-48eb-846e-5c3d54642983> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:15975936" ;
+    dct:created "2021-05-11" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/6d91b0d4-0d35-4688-858a-8a2d20f05eba> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009680/f33db531-0a90-4c75-911c-51630ae5e931> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dc:source "PMID:15975936" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00009680/cc09499d-8ffd-48b4-b659-fc89a1ea656f> a WB:WBGene00009680,
-        owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009680/3fb43210-13b7-42f5-b32b-59e94bf388f1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/9a4083cd-d5c4-4504-a8ea-89ec78c0278c> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00009680/7d30c866-0990-4e19-831c-0a2a9249fe8d> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/b83f845d-54e5-4c31-ab0f-40f34f59ba5b> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00009680/d74c76ae-434f-4da9-9d84-d06d0ee3c859> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0001025 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00009680/0bd59d4a-85ab-411a-98b3-0a6490785b8b> a GO:0031143,
+<http://model.geneontology.org/WB_WBGene00009680/01b79f68-2682-41c8-8b27-cb1e25bc7e2b> a GO:0031143,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009680/9a4083cd-d5c4-4504-a8ea-89ec78c0278c> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009680/d74c76ae-434f-4da9-9d84-d06d0ee3c859> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009680/3fb43210-13b7-42f5-b32b-59e94bf388f1> a GO:0044297,
+<http://model.geneontology.org/WB_WBGene00009680/83f8f9a1-7f28-413b-bd66-5077cd0a611f> a GO:0044297,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009680/b83f845d-54e5-4c31-ab0f-40f34f59ba5b> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009680/7d30c866-0990-4e19-831c-0a2a9249fe8d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009680/6c0f2771-a2ad-44d4-984e-8e2126f8e5de> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009680/5fc955c7-5969-4099-a848-9615b633e46a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00009680  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2021-05-11 WB BFO:0000050(WBbt:0006798) id=WBOA:89590|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-11|modification-date=2021-05-11" ;
-    owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/2f1f93c3-da46-4fa0-8d53-40b680c8568f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/0bd59d4a-85ab-411a-98b3-0a6490785b8b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009680/070173ce-51a4-4927-9b68-ea544348053f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-11" ;
-    dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009680  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2021-05-11 WB BFO:0000050(WBbt:0006798) id=WBOA:89591|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-11|modification-date=2021-05-11" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/3fb43210-13b7-42f5-b32b-59e94bf388f1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/b83f845d-54e5-4c31-ab0f-40f34f59ba5b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/83f8f9a1-7f28-413b-bd66-5077cd0a611f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/7d30c866-0990-4e19-831c-0a2a9249fe8d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009680/6d91b0d4-0d35-4688-858a-8a2d20f05eba> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009680/f33db531-0a90-4c75-911c-51630ae5e931> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009680  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2021-05-11 WB BFO:0000050(WBbt:0006798) id=WBOA:89590|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-11|modification-date=2021-05-11" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/0bd59d4a-85ab-411a-98b3-0a6490785b8b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/9a4083cd-d5c4-4504-a8ea-89ec78c0278c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/01b79f68-2682-41c8-8b27-cb1e25bc7e2b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/d74c76ae-434f-4da9-9d84-d06d0ee3c859> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009680/15cee023-4a6a-48c3-b401-a99292b2db92> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009680/98690b39-e80f-494d-87e2-2a6810a60e53> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-11" ;
     dct:created "2021-05-11" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00009680  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2021-05-11 WB BFO:0000050(WBbt:0006798) id=WBOA:89590|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-11|modification-date=2021-05-11" ;
+    owl:annotatedProperty obo:RO_0001025 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/8679f51c-330c-43f3-9b1d-99dabfc0f859> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/01b79f68-2682-41c8-8b27-cb1e25bc7e2b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009680/f25a9324-3f74-48eb-846e-5c3d54642983> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-11" ;
+    dct:created "2021-05-11" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009680  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2021-05-11 WB BFO:0000050(WBbt:0006798) id=WBOA:89591|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-11|modification-date=2021-05-11" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/cc09499d-8ffd-48b4-b659-fc89a1ea656f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/3fb43210-13b7-42f5-b32b-59e94bf388f1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009680/e6489a54-67aa-4f3a-85ff-e20a3925edb9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009680/83f8f9a1-7f28-413b-bd66-5077cd0a611f> .
 

--- a/models/WB_WBGene00009682.ttl
+++ b/models/WB_WBGene00009682.ttl
@@ -4,14 +4,14 @@
 @prefix WBbt: <http://purl.obolibrary.org/obo/WBbt_> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -30,145 +30,149 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00009682> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "msd-2 (WB:WBGene00009682)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00009682> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00009682/3a88f43a-13ad-42b7-bd56-40b30a45d2b3> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009682/0fc73b63-7e09-43af-be47-04582e431c60> a WB:WBGene00009682,
+        owl:NamedIndividual ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009682/70f835c8-b066-4332-b537-180f32dda72e> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00009682/68833da7-0e59-463d-ad2d-f8d3462d1b86> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/42dd3098-af86-4c3b-aaa5-1210cb374b0b> a WB:WBGene00009682,
+<http://model.geneontology.org/WB_WBGene00009682/b2982622-cdd1-4c6a-b4ca-f58869217229> a WB:WBGene00009682,
         owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009682/1455e3a8-e83a-461c-9cd0-25e390163e8b> ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009682/321edce4-1af9-4e99-81c2-216ac0741ab6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/65355024-1ca6-44be-b7f6-97fe8477ecf2> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009682/b99b6db1-d5a8-4726-8219-f46a65d3f371> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00009682/8b6108b3-f089-4a2d-9479-1f6551e1d746> a WB:WBGene00009682,
-        owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009682/89da9e05-fa38-4c03-b29a-371870ddc27b> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/92c6d8f4-82ca-4869-b74f-f22e0b88f2a8> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009682/f567d00e-75f4-4cee-9ca8-fd8bacbc384f> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/f8ae7828-6dc0-407d-83c2-a5c3b09343f2> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009682/f5a47b2f-dd74-4675-a30e-0b5eb253da6f> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/9f65fc6b-cad7-4d17-8882-c119905f5fc8> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00009682/9c8ac014-dc98-4374-92a9-f8ed8300204f> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/d44127e5-8329-4a5f-945c-e37a49a135c6> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00009682/e39c6eae-7c02-47db-b6dc-8de46821a27b> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0001025 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00009682/1455e3a8-e83a-461c-9cd0-25e390163e8b> a GO:0031143,
+<http://model.geneontology.org/WB_WBGene00009682/321edce4-1af9-4e99-81c2-216ac0741ab6> a GO:0044297,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009682/9f65fc6b-cad7-4d17-8882-c119905f5fc8> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009682/e39c6eae-7c02-47db-b6dc-8de46821a27b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009682/89da9e05-fa38-4c03-b29a-371870ddc27b> a GO:0044297,
+<http://model.geneontology.org/WB_WBGene00009682/70f835c8-b066-4332-b537-180f32dda72e> a GO:0031143,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009682/d44127e5-8329-4a5f-945c-e37a49a135c6> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009682/9c8ac014-dc98-4374-92a9-f8ed8300204f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009682/3a88f43a-13ad-42b7-bd56-40b30a45d2b3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009682/f5a47b2f-dd74-4675-a30e-0b5eb253da6f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009682  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9861|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/42dd3098-af86-4c3b-aaa5-1210cb374b0b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/1455e3a8-e83a-461c-9cd0-25e390163e8b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/0fc73b63-7e09-43af-be47-04582e431c60> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/70f835c8-b066-4332-b537-180f32dda72e> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009682/65355024-1ca6-44be-b7f6-97fe8477ecf2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009682/68833da7-0e59-463d-ad2d-f8d3462d1b86> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00009682  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9865|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/89da9e05-fa38-4c03-b29a-371870ddc27b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/d44127e5-8329-4a5f-945c-e37a49a135c6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009682/92c6d8f4-82ca-4869-b74f-f22e0b88f2a8> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00009682  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9865|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/8b6108b3-f089-4a2d-9479-1f6551e1d746> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/89da9e05-fa38-4c03-b29a-371870ddc27b> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009682/f8ae7828-6dc0-407d-83c2-a5c3b09343f2> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009682  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9861|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/1455e3a8-e83a-461c-9cd0-25e390163e8b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/9f65fc6b-cad7-4d17-8882-c119905f5fc8> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/70f835c8-b066-4332-b537-180f32dda72e> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/9c8ac014-dc98-4374-92a9-f8ed8300204f> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009682/b99b6db1-d5a8-4726-8219-f46a65d3f371> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00009682  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9865|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:RO_0001025 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/b2982622-cdd1-4c6a-b4ca-f58869217229> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/321edce4-1af9-4e99-81c2-216ac0741ab6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009682/f567d00e-75f4-4cee-9ca8-fd8bacbc384f> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00009682  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9865|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009682/321edce4-1af9-4e99-81c2-216ac0741ab6> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009682/e39c6eae-7c02-47db-b6dc-8de46821a27b> .
 

--- a/models/WB_WBGene00009684.ttl
+++ b/models/WB_WBGene00009684.ttl
@@ -4,14 +4,14 @@
 @prefix WBbt: <http://purl.obolibrary.org/obo/WBbt_> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -30,145 +30,149 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00009684> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "msd-3 (WB:WBGene00009684)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00009684> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00009684/026f0926-c8a8-4d77-ab41-b472337742e9> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009684/313d7370-85f8-408d-87ef-066e42ec95a2> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/3b3c0ae7-6153-4c04-ad34-18644ebc936d> a WB:WBGene00009684,
+<http://model.geneontology.org/WB_WBGene00009684/4fe3b99c-56da-430f-beee-b95dd81f9e1c> a WB:WBGene00009684,
         owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009684/61dcdc74-859f-487c-9ed9-eb9e0ccde591> ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009684/c3258a25-3e2d-4afd-bdba-45fb90006ce6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/777c8545-9894-4ef5-a2ea-e1f53e6544c6> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009684/87dfa416-3bbc-46a5-9aed-d79d3dd32cf4> a WB:WBGene00009684,
+        owl:NamedIndividual ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009684/c2be9031-4858-48c2-82d8-0d370b779f39> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00009684/a200c229-825a-4763-bfaa-70479b092476> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/7ea45442-ac40-48b2-895d-201a75408e32> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009684/a333acb2-9043-479e-b7e6-2858f710763d> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00009684/a1367605-86f4-4588-a6aa-9db01af7c125> a WB:WBGene00009684,
-        owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00009684/9abe36de-0703-4628-9f23-5fbe75c30829> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/d5d41066-9e24-4232-84c1-8aa0bfb7c004> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00009684/d6feaf39-4523-4a4c-a566-b3876ba09e71> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/26d09bf9-5fa8-4198-bb6c-44c72e1bbb3e> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00009684/7db77129-671a-455b-8794-acc291feec56> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/b7c7c9bd-cf1d-4c0d-b45e-b8db40a86678> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00009684/ce1d333a-277b-4e74-a92f-f820ee0fc6a5> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0001025 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00009684/61dcdc74-859f-487c-9ed9-eb9e0ccde591> a GO:0031143,
+<http://model.geneontology.org/WB_WBGene00009684/c2be9031-4858-48c2-82d8-0d370b779f39> a GO:0031143,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009684/b7c7c9bd-cf1d-4c0d-b45e-b8db40a86678> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009684/7db77129-671a-455b-8794-acc291feec56> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00009684/9abe36de-0703-4628-9f23-5fbe75c30829> a GO:0044297,
+<http://model.geneontology.org/WB_WBGene00009684/c3258a25-3e2d-4afd-bdba-45fb90006ce6> a GO:0044297,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009684/26d09bf9-5fa8-4198-bb6c-44c72e1bbb3e> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00009684/ce1d333a-277b-4e74-a92f-f820ee0fc6a5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009684/777c8545-9894-4ef5-a2ea-e1f53e6544c6> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009684/313d7370-85f8-408d-87ef-066e42ec95a2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00009684  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9866|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/9abe36de-0703-4628-9f23-5fbe75c30829> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/26d09bf9-5fa8-4198-bb6c-44c72e1bbb3e> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009684/7ea45442-ac40-48b2-895d-201a75408e32> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009684  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9862|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/3b3c0ae7-6153-4c04-ad34-18644ebc936d> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/61dcdc74-859f-487c-9ed9-eb9e0ccde591> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/87dfa416-3bbc-46a5-9aed-d79d3dd32cf4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/c2be9031-4858-48c2-82d8-0d370b779f39> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009684/d5d41066-9e24-4232-84c1-8aa0bfb7c004> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009684/a333acb2-9043-479e-b7e6-2858f710763d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009684  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9862|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/61dcdc74-859f-487c-9ed9-eb9e0ccde591> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/b7c7c9bd-cf1d-4c0d-b45e-b8db40a86678> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/c2be9031-4858-48c2-82d8-0d370b779f39> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/7db77129-671a-455b-8794-acc291feec56> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00009684/026f0926-c8a8-4d77-ab41-b472337742e9> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009684/d6feaf39-4523-4a4c-a566-b3876ba09e71> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00009684  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9866|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/a1367605-86f4-4588-a6aa-9db01af7c125> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/9abe36de-0703-4628-9f23-5fbe75c30829> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/4fe3b99c-56da-430f-beee-b95dd81f9e1c> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/c3258a25-3e2d-4afd-bdba-45fb90006ce6> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00009684/a200c229-825a-4763-bfaa-70479b092476> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00009684  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9866|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00009684/c3258a25-3e2d-4afd-bdba-45fb90006ce6> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00009684/ce1d333a-277b-4e74-a92f-f820ee0fc6a5> .
 

--- a/models/WB_WBGene00010485.ttl
+++ b/models/WB_WBGene00010485.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,51 +29,52 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00010485> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-26" ;
     dc:title "ant-1.3 (WB:WBGene00010485)" ;
     dct:created "2010-10-26" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00010485> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00010485/5c49c812-f7ba-4c72-94d8-bc304e1e1b59> a GO:0000295,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00010485/86b3d46f-42ca-47bd-8d08-37731ca5fd26> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2010-10-26" ;
-    dct:created "2010-10-26" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00010485/a73f8b49-9722-4672-b067-bbc00d2e84b4> a ECO:0000250,
+<http://model.geneontology.org/WB_WBGene00010485/58dab9f5-271c-4c3e-9e33-f2abefd4c5a8> a ECO:0000250,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-26" ;
     dc:source "PMID:18498090" ;
+    dct:created "2010-10-26" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00010485/eb60e3e4-5a55-4fda-b9bc-c267d0dbdb73> a GO:0000295,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00010485/abaabe5e-94cf-4126-b576-f164dc9f9fe6> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2010-10-26" ;
+    dct:created "2010-10-26" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00010485/86b3d46f-42ca-47bd-8d08-37731ca5fd26> a WB:WBGene00010485,
+<http://model.geneontology.org/WB_WBGene00010485/abaabe5e-94cf-4126-b576-f164dc9f9fe6> a WB:WBGene00010485,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-26" ;
     dct:created "2010-10-26" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00010485/a73f8b49-9722-4672-b067-bbc00d2e84b4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00010485/58dab9f5-271c-4c3e-9e33-f2abefd4c5a8> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2010-10-26" ;
     dct:created "2010-10-26" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00010485  RO:0002327 GO:0000295 WB:WBPaper00031899|PMID:18498090 ECO:0000250   2010-10-26 WB  id=WBOA:10532|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2010-10-26T14:08|modification-date=2010-10-26T14:08" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00010485/5c49c812-f7ba-4c72-94d8-bc304e1e1b59> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00010485/86b3d46f-42ca-47bd-8d08-37731ca5fd26> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00010485/eb60e3e4-5a55-4fda-b9bc-c267d0dbdb73> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00010485/abaabe5e-94cf-4126-b576-f164dc9f9fe6> .
 

--- a/models/WB_WBGene00011668.ttl
+++ b/models/WB_WBGene00011668.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00011668> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:title "clec-47 (WB:WBGene00011668)" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00011668> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00011668/15d1619b-186a-4509-a5ff-32dfff3d88d3> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00011668/44c1c3f1-6ab4-4e21-af81-e1b627c0cee0> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00011668/4d2e7b93-a891-4b21-bd95-46c3787695b4> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00011668/7bc3494b-784a-43e2-a30f-2230e89239ab> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00011668/1f8510e5-fb63-401c-a7a0-51fb5d1fa25b> a GO:0010332,
+<http://model.geneontology.org/WB_WBGene00011668/60b0d177-cde0-4970-b5ef-d8767196203c> a WB:WBGene00011668,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00011668/5be85688-86d4-47fb-83dd-cb2186562f65> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00011668/8eae6552-0509-4050-a5c6-26bb40289b22> a GO:0010332,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00011668/1f8510e5-fb63-401c-a7a0-51fb5d1fa25b> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00011668/91bc6ea8-f8dc-4b79-8e32-43a6aa29ab1c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00011668/91bc6ea8-f8dc-4b79-8e32-43a6aa29ab1c> a WB:WBGene00011668,
+<http://model.geneontology.org/WB_WBGene00011668/bc330fd5-1cc9-4937-af4a-0b46680278ed> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00011668/8eae6552-0509-4050-a5c6-26bb40289b22> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00011668/60b0d177-cde0-4970-b5ef-d8767196203c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00011668/4d2e7b93-a891-4b21-bd95-46c3787695b4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00011668/7bc3494b-784a-43e2-a30f-2230e89239ab> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00011668  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12038|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00011668/5be85688-86d4-47fb-83dd-cb2186562f65> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00011668/1f8510e5-fb63-401c-a7a0-51fb5d1fa25b> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00011668/bc330fd5-1cc9-4937-af4a-0b46680278ed> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00011668/8eae6552-0509-4050-a5c6-26bb40289b22> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00011668/15d1619b-186a-4509-a5ff-32dfff3d88d3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00011668/44c1c3f1-6ab4-4e21-af81-e1b627c0cee0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00011668  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12038|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00011668/5be85688-86d4-47fb-83dd-cb2186562f65> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00011668/91bc6ea8-f8dc-4b79-8e32-43a6aa29ab1c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00011668/bc330fd5-1cc9-4937-af4a-0b46680278ed> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00011668/60b0d177-cde0-4970-b5ef-d8767196203c> .
 

--- a/models/WB_WBGene00014173.ttl
+++ b/models/WB_WBGene00014173.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00014173> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:title "ZK970.7 (WB:WBGene00014173)" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00014173> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00014173/2c620cfd-1747-4283-9628-ea2e8ed5b981> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00014173/380103e7-4c44-4738-9007-7cd700c8e044> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00014173/83b36193-37b0-448d-83c4-a3cf2f84a82d> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00014173/d4f8deb7-e292-4894-84e3-a05a1db2e705> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00014173/9a4bf0ab-9ef7-4e6e-bbec-1ceac6909f63> a WB:WBGene00014173,
+<http://model.geneontology.org/WB_WBGene00014173/4bb41cf9-3e83-467f-b2c3-1028342b87be> a WB:WBGene00014173,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00014173/b64804d6-6230-4fb7-b745-5b2d75df4842> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00014173/84292efe-7577-4ad6-8ad8-35bf079d930a> a GO:0003674,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00014173/f5624554-49d4-4914-b2ca-39fcb27a3ed3> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00014173/9a4bf0ab-9ef7-4e6e-bbec-1ceac6909f63> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00014173/e9bf5753-9cf9-4e16-b8e6-02bcec6a1d74> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00014173/4bb41cf9-3e83-467f-b2c3-1028342b87be> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00014173/f5624554-49d4-4914-b2ca-39fcb27a3ed3> a GO:0010332,
+<http://model.geneontology.org/WB_WBGene00014173/e9bf5753-9cf9-4e16-b8e6-02bcec6a1d74> a GO:0010332,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00014173/83b36193-37b0-448d-83c4-a3cf2f84a82d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00014173/380103e7-4c44-4738-9007-7cd700c8e044> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00014173  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00014173/b64804d6-6230-4fb7-b745-5b2d75df4842> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00014173/f5624554-49d4-4914-b2ca-39fcb27a3ed3> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00014173/2c620cfd-1747-4283-9628-ea2e8ed5b981> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2011-08-29" ;
-    dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00014173  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00014173/b64804d6-6230-4fb7-b745-5b2d75df4842> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00014173/9a4bf0ab-9ef7-4e6e-bbec-1ceac6909f63> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00014173/84292efe-7577-4ad6-8ad8-35bf079d930a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00014173/4bb41cf9-3e83-467f-b2c3-1028342b87be> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00014173/d4f8deb7-e292-4894-84e3-a05a1db2e705> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2011-08-29" ;
+    dct:created "2011-08-29" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00014173  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12040|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00014173/84292efe-7577-4ad6-8ad8-35bf079d930a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00014173/e9bf5753-9cf9-4e16-b8e6-02bcec6a1d74> .
 

--- a/models/WB_WBGene00016447.ttl
+++ b/models/WB_WBGene00016447.ttl
@@ -4,14 +4,14 @@
 @prefix WBbt: <http://purl.obolibrary.org/obo/WBbt_> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -30,145 +30,149 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00016447> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:title "msd-4 (WB:WBGene00016447)" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00016447> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00016447/09a6d4b2-766b-41a5-8352-fc7198579a63> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00016447/1c2d5aaf-17f7-4f6d-943c-eaeb463a5901> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/0d96338b-671e-4a07-b8b4-8e2da720a7d3> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00016447/a07af842-53bc-40c2-bd78-9ce887e83cda> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/0dc95b1d-f8c0-4803-86c7-0ecd004e3f50> a WB:WBGene00016447,
+<http://model.geneontology.org/WB_WBGene00016447/afa3f2d6-3bfb-4214-8584-424ed44d9b18> a WB:WBGene00016447,
         owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00016447/74993b0e-6a9c-4ba0-b852-75cd51cbd4df> ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00016447/1f038416-acea-4aae-a5fe-0d11fbba2a78> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/28c82b2c-3339-4495-bda9-2349be63191c> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00016447/b77c29e9-16e3-46f9-b1aa-6ed166fee074> a WB:WBGene00016447,
+        owl:NamedIndividual ;
+    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00016447/1ea59595-85ab-41d4-b92d-d21285fa3d04> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00016447/bd462fbd-d0c9-4d64-93c6-4051a6c6bd68> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00016447/42fdd5e2-1c81-41c7-9bac-c2849dd519b8> a WB:WBGene00016447,
-        owl:NamedIndividual ;
-    obo:RO_0001025 <http://model.geneontology.org/WB_WBGene00016447/45f17f41-f6dd-42bb-961c-764e2a022cd1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/56350b1b-c97d-4027-9e20-c3f23043cd67> a ECO:0000314,
+<http://model.geneontology.org/WB_WBGene00016447/ff5e5096-a135-4824-bdf1-1decbd47f887> a ECO:0000314,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "PMID:15975936" ;
+    dct:created "2020-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/1b31282e-b782-41b2-83d0-5f03bc64b6b6> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00016447/3e30eb13-a3c3-43e7-b70f-9fc9974264d0> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/1e9a45d6-f388-4aad-91fe-193a2b933392> a WBbt:0006798,
+<http://model.geneontology.org/WB_WBGene00016447/f82a79a3-7586-45cc-8c9e-a18621e12ab5> a WBbt:0006798,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0001025 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00016447/45f17f41-f6dd-42bb-961c-764e2a022cd1> a GO:0031143,
+<http://model.geneontology.org/WB_WBGene00016447/1ea59595-85ab-41d4-b92d-d21285fa3d04> a GO:0031143,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00016447/1b31282e-b782-41b2-83d0-5f03bc64b6b6> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00016447/f82a79a3-7586-45cc-8c9e-a18621e12ab5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00016447/74993b0e-6a9c-4ba0-b852-75cd51cbd4df> a GO:0044297,
+<http://model.geneontology.org/WB_WBGene00016447/1f038416-acea-4aae-a5fe-0d11fbba2a78> a GO:0044297,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00016447/1e9a45d6-f388-4aad-91fe-193a2b933392> ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00016447/3e30eb13-a3c3-43e7-b70f-9fc9974264d0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00016447/28c82b2c-3339-4495-bda9-2349be63191c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00016447/bd462fbd-d0c9-4d64-93c6-4051a6c6bd68> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00016447  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9867|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/74993b0e-6a9c-4ba0-b852-75cd51cbd4df> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/1e9a45d6-f388-4aad-91fe-193a2b933392> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00016447/09a6d4b2-766b-41a5-8352-fc7198579a63> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00016447  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9867|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/0dc95b1d-f8c0-4803-86c7-0ecd004e3f50> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/74993b0e-6a9c-4ba0-b852-75cd51cbd4df> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/afa3f2d6-3bfb-4214-8584-424ed44d9b18> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/1f038416-acea-4aae-a5fe-0d11fbba2a78> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00016447/56350b1b-c97d-4027-9e20-c3f23043cd67> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00016447/1c2d5aaf-17f7-4f6d-943c-eaeb463a5901> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00016447  RO:0001025 GO:0044297 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9867|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/1f038416-acea-4aae-a5fe-0d11fbba2a78> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/3e30eb13-a3c3-43e7-b70f-9fc9974264d0> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00016447/ff5e5096-a135-4824-bdf1-1decbd47f887> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00016447  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9863|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/45f17f41-f6dd-42bb-961c-764e2a022cd1> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/1b31282e-b782-41b2-83d0-5f03bc64b6b6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/1ea59595-85ab-41d4-b92d-d21285fa3d04> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/f82a79a3-7586-45cc-8c9e-a18621e12ab5> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00016447/0d96338b-671e-4a07-b8b4-8e2da720a7d3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00016447/a07af842-53bc-40c2-bd78-9ce887e83cda> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00016447  RO:0001025 GO:0031143 WB:WBPaper00026617|PMID:15975936 ECO:0000314   2020-05-13 WB BFO:0000050(WBbt:0006798) id=WBOA:9863|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0001025 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/42fdd5e2-1c81-41c7-9bac-c2849dd519b8> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/45f17f41-f6dd-42bb-961c-764e2a022cd1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00016447/b77c29e9-16e3-46f9-b1aa-6ed166fee074> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00016447/1ea59595-85ab-41d4-b92d-d21285fa3d04> .
 

--- a/models/WB_WBGene00018646.ttl
+++ b/models/WB_WBGene00018646.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,81 +29,83 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00018646> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:title "mul-1 (WB:WBGene00018646)" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00018646> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00018646/7b9ca440-cca0-4a94-a417-13640a9f48be> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00018646/474ccae1-97df-42d2-89ae-80ff8c0eb569> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00018646/f1a378eb-751f-48d2-a4f9-7c41f3031618> a ECO:0000270,
+<http://model.geneontology.org/WB_WBGene00018646/bb882209-84ea-457a-8411-d6c58b35ac5f> a ECO:0000270,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dc:source "PMID:19104912" ;
+    dct:created "2011-08-29" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:BFO_0000050 a owl:ObjectProperty .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00018646/49e9780e-903e-4472-a827-af5ff2b8a39f> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00018646/4592cd25-007a-4de0-981d-60d251301f62> a WB:WBGene00018646,
         owl:NamedIndividual ;
-    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00018646/ad89fd47-7191-4324-afa4-4adcc6247b9d> ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00018646/dc850525-8097-4a51-a234-7725e92bcd73> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00018646/ad89fd47-7191-4324-afa4-4adcc6247b9d> a GO:0010332,
+<http://model.geneontology.org/WB_WBGene00018646/5dfb31eb-3c0b-4ce0-b866-436bf9bd0ecd> a GO:0010332,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00018646/dc850525-8097-4a51-a234-7725e92bcd73> a WB:WBGene00018646,
+<http://model.geneontology.org/WB_WBGene00018646/98a85166-730e-487f-9de0-1e9ae6890e1d> a GO:0003674,
         owl:NamedIndividual ;
+    obo:BFO_0000050 <http://model.geneontology.org/WB_WBGene00018646/5dfb31eb-3c0b-4ce0-b866-436bf9bd0ecd> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00018646/4592cd25-007a-4de0-981d-60d251301f62> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00018646/f1a378eb-751f-48d2-a4f9-7c41f3031618> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00018646/bb882209-84ea-457a-8411-d6c58b35ac5f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2011-08-29" ;
     dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00018646  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12035|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
-    owl:annotatedProperty obo:BFO_0000050 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00018646/49e9780e-903e-4472-a827-af5ff2b8a39f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00018646/ad89fd47-7191-4324-afa4-4adcc6247b9d> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00018646/7b9ca440-cca0-4a94-a417-13640a9f48be> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2011-08-29" ;
-    dct:created "2011-08-29" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00018646  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12035|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00018646/49e9780e-903e-4472-a827-af5ff2b8a39f> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00018646/dc850525-8097-4a51-a234-7725e92bcd73> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00018646/98a85166-730e-487f-9de0-1e9ae6890e1d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00018646/4592cd25-007a-4de0-981d-60d251301f62> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00018646/474ccae1-97df-42d2-89ae-80ff8c0eb569> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2011-08-29" ;
+    dct:created "2011-08-29" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00018646  RO:0002331 GO:0010332 WB:WBPaper00032454|PMID:19104912 ECO:0000270   2011-08-29 WB  id=WBOA:12035|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2011-08-29|modification-date=2011-08-29" ;
+    owl:annotatedProperty obo:BFO_0000050 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00018646/98a85166-730e-487f-9de0-1e9ae6890e1d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00018646/5dfb31eb-3c0b-4ce0-b866-436bf9bd0ecd> .
 

--- a/models/WB_WBGene00044731.ttl
+++ b/models/WB_WBGene00044731.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00044731> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "eat-1 (WB:WBGene00044731)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00044731> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00044731/c44caf95-9646-4f76-9e86-00b918202cd8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00044731/1bae7c80-35ef-4402-af67-08af18738f29> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000006" ;
+    ns1:evidence-with "WB:WBVar00000006" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:16884547" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00044731/ff17b44a-3429-49ab-829a-67e7cb52e1e3> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00044731/d3863210-cc3c-40cf-8f69-bc74e821b02c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000006" ;
+    ns1:evidence-with "WB:WBVar00000006" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:16884547" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00044731/4caa6f4f-bd0d-4f59-b72a-4b6a04ed65dc> a GO:0035264,
+<http://model.geneontology.org/WB_WBGene00044731/056a5062-d451-448a-9ac5-3522aca06eff> a WB:WBGene00044731,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00044731/d0a332b9-c4f2-4a4e-a2fb-3968ca736e8a> a WB:WBGene00044731,
+<http://model.geneontology.org/WB_WBGene00044731/24b9fc3c-3e63-48c3-98b1-90ef80d3d8ed> a GO:0035264,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00044731/f9b00f31-d652-4b41-919d-33a60bf5c141> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00044731/abfc2436-9404-4392-825f-88d8615a86a7> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00044731/d0a332b9-c4f2-4a4e-a2fb-3968ca736e8a> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00044731/4caa6f4f-bd0d-4f59-b72a-4b6a04ed65dc> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00044731/056a5062-d451-448a-9ac5-3522aca06eff> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00044731/24b9fc3c-3e63-48c3-98b1-90ef80d3d8ed> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00044731/ff17b44a-3429-49ab-829a-67e7cb52e1e3> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00044731/d3863210-cc3c-40cf-8f69-bc74e821b02c> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00044731  RO:0002264 GO:0035264 WB:WBPaper00028380|PMID:16884547 ECO:0000315 WB:WBVar00000006  2021-05-13 WB  id=WBOA:9009|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00044731/f9b00f31-d652-4b41-919d-33a60bf5c141> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00044731/4caa6f4f-bd0d-4f59-b72a-4b6a04ed65dc> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00044731/abfc2436-9404-4392-825f-88d8615a86a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00044731/24b9fc3c-3e63-48c3-98b1-90ef80d3d8ed> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00044731/c44caf95-9646-4f76-9e86-00b918202cd8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00044731/1bae7c80-35ef-4402-af67-08af18738f29> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00044731  RO:0002264 GO:0035264 WB:WBPaper00028380|PMID:16884547 ECO:0000315 WB:WBVar00000006  2021-05-13 WB  id=WBOA:9009|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00044731/f9b00f31-d652-4b41-919d-33a60bf5c141> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00044731/d0a332b9-c4f2-4a4e-a2fb-3968ca736e8a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00044731/abfc2436-9404-4392-825f-88d8615a86a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00044731/056a5062-d451-448a-9ac5-3522aca06eff> .
 

--- a/models/WB_WBGene00077700.ttl
+++ b/models/WB_WBGene00077700.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,251 +29,258 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077700> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "sex-2 (WB:WBGene00077700)" ;
     dct:created "2012-07-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077700> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077700/1659f4f5-5b95-49a3-b587-4504ff2c0e6a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077700/21a7e67d-d7e9-4d31-875d-54e0b76f3dc4> a GO:0003674,
         owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17720939" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/1cfb5a92-ae0c-4590-9888-97fc124c42d1> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00004786" ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17720939" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/1e158f46-71eb-4db6-9ccb-37101a4bb35b> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077700/171cf77b-424e-4087-bca5-956e51752724> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077700/1f6704fb-f801-4eb2-b14f-e9fcff8a88d2> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-07-13" ;
     dct:created "2012-07-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/58fb7caf-468b-4052-8939-7ca30007a92b> a WB:WBGene00077700,
+<http://model.geneontology.org/WB_WBGene00077700/3b4dfd71-7987-4fd9-a9fd-66b02df1c5e0> a ECO:0000316,
         owl:NamedIndividual ;
-    obo:RO_0002432 <http://model.geneontology.org/WB_WBGene00077700/f5e39f6c-96fe-4dd7-b573-779cb7e1d70e> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2020-05-13" ;
-    dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/87f1f44f-4d0e-411a-b54d-6c2744954fdf> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00004786" ;
+    ns1:evidence-with "WB:WBGene00004786" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17720939" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/b3973cb7-f5d6-49e3-be16-d5bf78eb7d70> a ECO:0000315,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17720939" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/b87b1686-578d-49ab-b70e-64c44caa7a81> a ECO:0000307,
+<http://model.geneontology.org/WB_WBGene00077700/6f1d58ee-f98a-44de-a007-3d3402154170> a ECO:0000307,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-07-13" ;
     dc:source "GO_REF:0000015" ;
+    dct:created "2012-07-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/d802d9c6-7c66-4aa6-9bfb-b533a137118f> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077700/77d30c07-110c-436a-b62e-389d88fb5359> a WB:WBGene00077700,
         owl:NamedIndividual ;
+    obo:RO_0002432 <http://model.geneontology.org/WB_WBGene00077700/56a3d75e-e206-463c-91a3-4d07d0ac8d81> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17720939" ;
+    dc:date "2020-05-13" ;
+    dct:created "2020-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/ee1e0ab4-4088-4991-b7cc-036ddf681507> a ECO:0000307,
+<http://model.geneontology.org/WB_WBGene00077700/7a94a1d6-2b7c-4a53-a747-0bfc990a6c72> a ECO:0000307,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dc:source "GO_REF:0000015" ;
+    dct:created "2020-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/7c6f533d-24c0-49c1-9a18-1dae355a38c1> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17720939" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/878f4148-0b27-4d70-b59f-a0fddf83f390> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00004786" ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17720939" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/bed7a5f2-5b30-4657-811b-f9615ec1fbf2> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17720939" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/c812352b-a3a0-4608-a4fe-246cb47f8e9b> a ECO:0000315,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17720939" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002233 a owl:ObjectProperty .
 
 obo:RO_0002432 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077700/171cf77b-424e-4087-bca5-956e51752724> a WB:WBGene00077700,
+<http://model.geneontology.org/WB_WBGene00077700/0e5d27d8-189c-4127-99f9-1d8bf3a13e81> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077700/4331387c-bd7e-4e62-8398-51a836913096> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077700/78180245-d41d-4c5e-8073-b3071a891097> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/1f6704fb-f801-4eb2-b14f-e9fcff8a88d2> a WB:WBGene00077700,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-07-13" ;
     dct:created "2012-07-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/17cb05cc-58c4-42fe-bd9a-5a7fc24e8313> a WB:WBGene00077700,
+<http://model.geneontology.org/WB_WBGene00077700/27d7ad19-b544-44a9-84fb-82aa776197b7> a WB:WBGene00006962,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/1c8cf741-5e67-443e-bd2e-e6cde5c1b319> a WB:WBGene00006962,
+<http://model.geneontology.org/WB_WBGene00077700/4331387c-bd7e-4e62-8398-51a836913096> a WB:WBGene00077700,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077700/3517d7fd-a79f-4b3f-9865-3fefe65ec6cb> a GO:0007538,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/90c88589-064a-4167-9cab-124f024eed5c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077700/da052e37-4807-4758-8fef-7312d9c50a2d> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077700/35fd58cb-77e3-4655-82c5-21bab1c92f2c> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/c82faa74-68fc-4ee1-a259-0cf0ea8753f4> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077700/17cb05cc-58c4-42fe-bd9a-5a7fc24e8313> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077700/3517d7fd-a79f-4b3f-9865-3fefe65ec6cb> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/da052e37-4807-4758-8fef-7312d9c50a2d> a WB:WBGene00077700,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077700/f5e39f6c-96fe-4dd7-b573-779cb7e1d70e> a GO:0005575,
+<http://model.geneontology.org/WB_WBGene00077700/56a3d75e-e206-463c-91a3-4d07d0ac8d81> a GO:0005575,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/601ad7d5-5154-4193-b7f3-c2c52de0c1ff> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077700/add5589b-fd27-4bca-b510-5dd5226aaa4d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077700/71d9ed8c-6e6d-4a03-927b-062cfbc80b5a> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/71d9ed8c-6e6d-4a03-927b-062cfbc80b5a> a GO:0007538,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077700/add5589b-fd27-4bca-b510-5dd5226aaa4d> a WB:WBGene00077700,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077700/35fd58cb-77e3-4655-82c5-21bab1c92f2c> a GO:0006366,
+<http://model.geneontology.org/WB_WBGene00077700/78180245-d41d-4c5e-8073-b3071a891097> a GO:0006366,
         owl:NamedIndividual ;
-    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00077700/1c8cf741-5e67-443e-bd2e-e6cde5c1b319> ;
+    obo:RO_0002233 <http://model.geneontology.org/WB_WBGene00077700/27d7ad19-b544-44a9-84fb-82aa776197b7> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/d802d9c6-7c66-4aa6-9bfb-b533a137118f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/3b4dfd71-7987-4fd9-a9fd-66b02df1c5e0> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0006366 WB:WBPaper00030931|PMID:17720939 ECO:0000315   2021-05-13 WB RO:0002233(WB:WBGene00006962) id=WBOA:13209|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/90c88589-064a-4167-9cab-124f024eed5c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/da052e37-4807-4758-8fef-7312d9c50a2d> .
+    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0007538 WB:WBPaper00030931|PMID:17720939 ECO:0000316 WB:WBGene00004786  2021-05-13 WB  id=WBOA:13203|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/601ad7d5-5154-4193-b7f3-c2c52de0c1ff> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/71d9ed8c-6e6d-4a03-927b-062cfbc80b5a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/b87b1686-578d-49ab-b70e-64c44caa7a81> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/6f1d58ee-f98a-44de-a007-3d3402154170> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2012-07-13" ;
     dct:created "2012-07-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077700  RO:0002327 GO:0003674 GO_REF:0000015 ECO:0000307   2012-07-13 WB  id=WBOA:13202|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2012-07-13T7:36|modification-date=2012-07-13T7:36" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/1e158f46-71eb-4db6-9ccb-37101a4bb35b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/171cf77b-424e-4087-bca5-956e51752724> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/21a7e67d-d7e9-4d31-875d-54e0b76f3dc4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/1f6704fb-f801-4eb2-b14f-e9fcff8a88d2> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/b3973cb7-f5d6-49e3-be16-d5bf78eb7d70> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0006366 WB:WBPaper00030931|PMID:17720939 ECO:0000315   2021-05-13 WB RO:0002233(WB:WBGene00006962) id=WBOA:13209|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/90c88589-064a-4167-9cab-124f024eed5c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/35fd58cb-77e3-4655-82c5-21bab1c92f2c> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/87f1f44f-4d0e-411a-b54d-6c2744954fdf> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0007538 WB:WBPaper00030931|PMID:17720939 ECO:0000316 WB:WBGene00004786  2021-05-13 WB  id=WBOA:13203|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/c82faa74-68fc-4ee1-a259-0cf0ea8753f4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/17cb05cc-58c4-42fe-bd9a-5a7fc24e8313> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/1659f4f5-5b95-49a3-b587-4504ff2c0e6a> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0006366 WB:WBPaper00030931|PMID:17720939 ECO:0000315   2021-05-13 WB RO:0002233(WB:WBGene00006962) id=WBOA:13209|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002233 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/35fd58cb-77e3-4655-82c5-21bab1c92f2c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/1c8cf741-5e67-443e-bd2e-e6cde5c1b319> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/1cfb5a92-ae0c-4590-9888-97fc124c42d1> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0007538 WB:WBPaper00030931|PMID:17720939 ECO:0000316 WB:WBGene00004786  2021-05-13 WB  id=WBOA:13203|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/c82faa74-68fc-4ee1-a259-0cf0ea8753f4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/3517d7fd-a79f-4b3f-9865-3fefe65ec6cb> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077700/ee1e0ab4-4088-4991-b7cc-036ddf681507> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/7a94a1d6-2b7c-4a53-a747-0bfc990a6c72> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2020-05-13" ;
     dct:created "2020-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077700  RO:0002432 GO:0005575 GO_REF:0000015 ECO:0000307   2020-05-13 WB  id=WBOA:13201|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2020-05-13|modification-date=2020-05-13" ;
     owl:annotatedProperty obo:RO_0002432 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/58fb7caf-468b-4052-8939-7ca30007a92b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/f5e39f6c-96fe-4dd7-b573-779cb7e1d70e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/77d30c07-110c-436a-b62e-389d88fb5359> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/56a3d75e-e206-463c-91a3-4d07d0ac8d81> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/878f4148-0b27-4d70-b59f-a0fddf83f390> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0007538 WB:WBPaper00030931|PMID:17720939 ECO:0000316 WB:WBGene00004786  2021-05-13 WB  id=WBOA:13203|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/601ad7d5-5154-4193-b7f3-c2c52de0c1ff> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/add5589b-fd27-4bca-b510-5dd5226aaa4d> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/bed7a5f2-5b30-4657-811b-f9615ec1fbf2> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0006366 WB:WBPaper00030931|PMID:17720939 ECO:0000315   2021-05-13 WB RO:0002233(WB:WBGene00006962) id=WBOA:13209|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/0e5d27d8-189c-4127-99f9-1d8bf3a13e81> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/78180245-d41d-4c5e-8073-b3071a891097> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/7c6f533d-24c0-49c1-9a18-1dae355a38c1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0006366 WB:WBPaper00030931|PMID:17720939 ECO:0000315   2021-05-13 WB RO:0002233(WB:WBGene00006962) id=WBOA:13209|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002233 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/78180245-d41d-4c5e-8073-b3071a891097> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/27d7ad19-b544-44a9-84fb-82aa776197b7> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077700/c812352b-a3a0-4608-a4fe-246cb47f8e9b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077700  RO:0002264 GO:0006366 WB:WBPaper00030931|PMID:17720939 ECO:0000315   2021-05-13 WB RO:0002233(WB:WBGene00006962) id=WBOA:13209|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077700/0e5d27d8-189c-4127-99f9-1d8bf3a13e81> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077700/4331387c-bd7e-4e62-8398-51a836913096> .
 

--- a/models/WB_WBGene00077729.ttl
+++ b/models/WB_WBGene00077729.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,266 +29,278 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077729> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-1 (WB:WBGene00077729)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077729> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077729/073145ab-5519-4c20-a3e3-0cb15a833280> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/0dfc16ca-470f-454b-909f-2595d72ce20a> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/0db1c484-71da-49ca-bd88-9d12fbe93c5c> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/2dc504c4-4348-4f51-bf2e-729939415baf> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/28868ee2-8d58-4928-aade-8437b2ff86e2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/3a2e234d-08da-4240-84c6-64b73fce3b81> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/398cd9d3-3477-4e6f-8cc9-b3a736041a5e> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077729/64afa6bc-5c1c-4ba3-819c-6f1578670948> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/5e6349f3-c7c7-4dc7-931c-45334bdf3acd> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/a478b157-c6f1-40ad-b46e-2b4cff493987> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/751aab22-a692-40e3-b6bc-761f1ef07a67> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/a79e89b5-dac9-4918-8c1d-b3b97d770fca> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/7a9fa70d-1c84-4701-8dc6-711de47db2cd> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/ba8809e4-86da-4713-8e0b-deb839aad8af> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/961e94e1-2414-448e-8afc-31ce8763a7f7> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077729/bbfd4543-21f9-466d-be00-dd73b390abe1> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/a0307916-5c07-4891-a20e-49c6dc75859a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/d36ca9ef-f7c5-4790-b62b-3f66abba580d> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/a5573225-b33f-46c9-8d04-226918f7fba2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/de24752f-d74e-4c80-ba93-223c2e7bdfdb> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/a8a85023-72ca-4a28-a4c8-fdf40be6e285> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/e8d02990-9659-4d55-bfd3-94d482da7f7c> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/e0acf585-ab05-4f20-94e4-a76b3f3b00f2> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077729/f021033d-19a5-4bdf-b22c-a1c3d0d851f5> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278468" ;
+    ns1:evidence-with "WB:WBVar00278468" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077729/0c2f3be9-04e8-4251-8b99-2f22ca257422> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/a626cff6-0355-46b5-8af5-e91ac09971f0> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/c81bb26a-34b6-47dc-922d-24a24ba49f5a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/19d40de9-e10e-42d2-8bac-bb83828042c2> a GO:0007098,
+<http://model.geneontology.org/WB_WBGene00077729/1967afad-9449-4f97-a37e-d44f6280cbc2> a GO:0007098,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/204a4d99-37bb-41a0-aa18-5e0d63c32fdf> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/e10dbb7a-90c2-44e6-a4bf-376c31921a82> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/2738555a-45a2-4072-882c-47c048cc88b5> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077729/2738555a-45a2-4072-882c-47c048cc88b5> a GO:0051301,
+<http://model.geneontology.org/WB_WBGene00077729/1db8c40e-5a13-4f48-ada1-c091dda1c398> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/397680a2-df82-43c4-8cb5-ba4f62c15e95> a GO:0002119,
+<http://model.geneontology.org/WB_WBGene00077729/2900e5bf-968d-4ec9-8b7d-7ab232f6ba34> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/3c877210-5043-42e5-be39-117ee884c7c9> a WB:WBGene00077729,
+<http://model.geneontology.org/WB_WBGene00077729/2d7d38f8-a30a-420e-bf2a-38b4839e03ec> a WB:WBGene00077729,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/451cc24e-6e2d-4622-963c-37a0e509db90> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00077729/5a48936f-947f-44b4-91b1-7c6409703283> a WB:WBGene00077729,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/637a58bf-c405-4a5e-87c9-8280c1752441> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/3c877210-5043-42e5-be39-117ee884c7c9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/c35de04c-5b36-4914-bed9-4841bd576155> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077729/715c628e-3fc1-47e3-8ae5-a623a7946142> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/b8324e3e-2451-4fca-9628-654fe824867e> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/451cc24e-6e2d-4622-963c-37a0e509db90> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077729/a14f9e57-e9c0-4891-9df9-24d96913a9ce> a WB:WBGene00077729,
+<http://model.geneontology.org/WB_WBGene00077729/5a6a3e37-9976-48a4-b374-ec0af5874051> a WB:WBGene00077729,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/a3b73bcc-dc3e-40d0-afb8-715ffaf2155a> a WB:WBGene00077729,
+<http://model.geneontology.org/WB_WBGene00077729/63740883-3675-41ed-bec1-6b791ee1f15d> a WB:WBGene00077729,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/a626cff6-0355-46b5-8af5-e91ac09971f0> a WB:WBGene00077729,
+<http://model.geneontology.org/WB_WBGene00077729/690d8d30-3daa-4490-8998-26baa4c29b3d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/2d7d38f8-a30a-420e-bf2a-38b4839e03ec> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/2900e5bf-968d-4ec9-8b7d-7ab232f6ba34> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077729/6e9acd54-b53c-4557-97cc-12f680ad592b> a GO:0045132,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/b8324e3e-2451-4fca-9628-654fe824867e> a WB:WBGene00077729,
+<http://model.geneontology.org/WB_WBGene00077729/75dcdfcc-d66c-4281-9f14-8528e236b38a> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/63740883-3675-41ed-bec1-6b791ee1f15d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/1db8c40e-5a13-4f48-ada1-c091dda1c398> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077729/937dd081-134b-4539-a453-1ca16f824f83> a WB:WBGene00077729,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/c35de04c-5b36-4914-bed9-4841bd576155> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077729/a300cc94-1f0a-4723-a505-eab4286ef4e5> a GO:0002119,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/c81bb26a-34b6-47dc-922d-24a24ba49f5a> a GO:0045132,
+<http://model.geneontology.org/WB_WBGene00077729/af2525d0-b3b1-4140-826c-fe56c3195247> a WB:WBGene00077729,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/cbd069d1-e743-4321-a30e-1e504bbb956a> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077729/b3f977fd-963e-4671-91e2-35012126a475> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/a14f9e57-e9c0-4891-9df9-24d96913a9ce> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/397680a2-df82-43c4-8cb5-ba4f62c15e95> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/937dd081-134b-4539-a453-1ca16f824f83> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/6e9acd54-b53c-4557-97cc-12f680ad592b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/dcf4eb9a-4eda-4fec-8a3b-48e1567b3e51> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077729/bb5a045b-4daa-4a54-b135-aaab218cb887> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/a3b73bcc-dc3e-40d0-afb8-715ffaf2155a> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/19d40de9-e10e-42d2-8bac-bb83828042c2> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/af2525d0-b3b1-4140-826c-fe56c3195247> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/1967afad-9449-4f97-a37e-d44f6280cbc2> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077729/e10dbb7a-90c2-44e6-a4bf-376c31921a82> a WB:WBGene00077729,
+<http://model.geneontology.org/WB_WBGene00077729/bc4b350c-2126-43a6-956e-ba28c5f733fc> a GO:0051301,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077729/cfdb5c16-98b9-4102-bf2d-5f3d9618f3f4> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/5a6a3e37-9976-48a4-b374-ec0af5874051> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/a300cc94-1f0a-4723-a505-eab4286ef4e5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077729/d7321356-5d51-4080-adc0-4e7f9001b91b> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077729/5a48936f-947f-44b4-91b1-7c6409703283> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077729/bc4b350c-2126-43a6-956e-ba28c5f733fc> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -296,146 +308,146 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/7a9fa70d-1c84-4701-8dc6-711de47db2cd> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/3a2e234d-08da-4240-84c6-64b73fce3b81> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0002119 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7874|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/cbd069d1-e743-4321-a30e-1e504bbb956a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/a14f9e57-e9c0-4891-9df9-24d96913a9ce> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/a0307916-5c07-4891-a20e-49c6dc75859a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0051301 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7914|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/204a4d99-37bb-41a0-aa18-5e0d63c32fdf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/e10dbb7a-90c2-44e6-a4bf-376c31921a82> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/d7321356-5d51-4080-adc0-4e7f9001b91b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/5a48936f-947f-44b4-91b1-7c6409703283> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/398cd9d3-3477-4e6f-8cc9-b3a736041a5e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/0dfc16ca-470f-454b-909f-2595d72ce20a> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7871|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0002119 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7874|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/637a58bf-c405-4a5e-87c9-8280c1752441> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/3c877210-5043-42e5-be39-117ee884c7c9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/cfdb5c16-98b9-4102-bf2d-5f3d9618f3f4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/5a6a3e37-9976-48a4-b374-ec0af5874051> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/a5573225-b33f-46c9-8d04-226918f7fba2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/f021033d-19a5-4bdf-b22c-a1c3d0d851f5> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7873|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/b3f977fd-963e-4671-91e2-35012126a475> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/6e9acd54-b53c-4557-97cc-12f680ad592b> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/ba8809e4-86da-4713-8e0b-deb839aad8af> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7873|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/0c2f3be9-04e8-4251-8b99-2f22ca257422> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/a626cff6-0355-46b5-8af5-e91ac09971f0> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/b3f977fd-963e-4671-91e2-35012126a475> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/937dd081-134b-4539-a453-1ca16f824f83> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/751aab22-a692-40e3-b6bc-761f1ef07a67> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/a79e89b5-dac9-4918-8c1d-b3b97d770fca> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0007098 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:89551|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/dcf4eb9a-4eda-4fec-8a3b-48e1567b3e51> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/19d40de9-e10e-42d2-8bac-bb83828042c2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/a8a85023-72ca-4a28-a4c8-fdf40be6e285> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7872|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/715c628e-3fc1-47e3-8ae5-a623a7946142> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/b8324e3e-2451-4fca-9628-654fe824867e> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/75dcdfcc-d66c-4281-9f14-8528e236b38a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/63740883-3675-41ed-bec1-6b791ee1f15d> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/e0acf585-ab05-4f20-94e4-a76b3f3b00f2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/2dc504c4-4348-4f51-bf2e-729939415baf> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7873|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7872|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/0c2f3be9-04e8-4251-8b99-2f22ca257422> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/c81bb26a-34b6-47dc-922d-24a24ba49f5a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/75dcdfcc-d66c-4281-9f14-8528e236b38a> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/1db8c40e-5a13-4f48-ada1-c091dda1c398> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/28868ee2-8d58-4928-aade-8437b2ff86e2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/64afa6bc-5c1c-4ba3-819c-6f1578670948> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0051301 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7914|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/204a4d99-37bb-41a0-aa18-5e0d63c32fdf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/2738555a-45a2-4072-882c-47c048cc88b5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/d7321356-5d51-4080-adc0-4e7f9001b91b> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/bc4b350c-2126-43a6-956e-ba28c5f733fc> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/961e94e1-2414-448e-8afc-31ce8763a7f7> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/a478b157-c6f1-40ad-b46e-2b4cff493987> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7871|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/637a58bf-c405-4a5e-87c9-8280c1752441> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/c35de04c-5b36-4914-bed9-4841bd576155> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/073145ab-5519-4c20-a3e3-0cb15a833280> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0007098 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:89551|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/dcf4eb9a-4eda-4fec-8a3b-48e1567b3e51> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/a3b73bcc-dc3e-40d0-afb8-715ffaf2155a> .
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/bb5a045b-4daa-4a54-b135-aaab218cb887> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/1967afad-9449-4f97-a37e-d44f6280cbc2> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/0db1c484-71da-49ca-bd88-9d12fbe93c5c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/de24752f-d74e-4c80-ba93-223c2e7bdfdb> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7871|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/690d8d30-3daa-4490-8998-26baa4c29b3d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/2d7d38f8-a30a-420e-bf2a-38b4839e03ec> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/d36ca9ef-f7c5-4790-b62b-3f66abba580d> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0002119 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7874|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/cbd069d1-e743-4321-a30e-1e504bbb956a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/397680a2-df82-43c4-8cb5-ba4f62c15e95> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/cfdb5c16-98b9-4102-bf2d-5f3d9618f3f4> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/a300cc94-1f0a-4723-a505-eab4286ef4e5> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077729/5e6349f3-c7c7-4dc7-931c-45334bdf3acd> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/e8d02990-9659-4d55-bfd3-94d482da7f7c> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:7872|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0007098 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278468  2021-05-13 WB  id=WBOA:89551|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/bb5a045b-4daa-4a54-b135-aaab218cb887> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/af2525d0-b3b1-4140-826c-fe56c3195247> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077729/bbfd4543-21f9-466d-be00-dd73b390abe1> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077729  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7871|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/715c628e-3fc1-47e3-8ae5-a623a7946142> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/451cc24e-6e2d-4622-963c-37a0e509db90> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077729/690d8d30-3daa-4490-8998-26baa4c29b3d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077729/2900e5bf-968d-4ec9-8b7d-7ab232f6ba34> .
 

--- a/models/WB_WBGene00077731.ttl
+++ b/models/WB_WBGene00077731.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077731> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "szy-3 (WB:WBGene00077731)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077731> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077731/b9fa704f-f937-4e65-9c1c-1d2dfb87a21e> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077731/d8f15d44-82a2-402e-bc80-18e379c21927> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077731/e7ca97bb-7b7f-4ed0-941e-aae9ca807960> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077731/f515eafc-2d8a-4f17-9531-5f53422b16d5> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077731/25c206a9-75a6-4830-b30b-98da90ae900d> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077731/17c9a206-b0a0-491f-861a-84d41c0e492a> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077731/25f72603-d64a-4668-a426-98b9a6ebe574> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077731/504d54eb-1157-484c-bfc1-712f43872eb0> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077731/5a897bd8-bf81-4a16-8262-09ddc3c918e1> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077731/25c206a9-75a6-4830-b30b-98da90ae900d> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077731/a55c506f-59a8-40bd-8dcf-8838ea6ceb48> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077731/17c9a206-b0a0-491f-861a-84d41c0e492a> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077731/5a897bd8-bf81-4a16-8262-09ddc3c918e1> a WB:WBGene00077731,
+<http://model.geneontology.org/WB_WBGene00077731/a55c506f-59a8-40bd-8dcf-8838ea6ceb48> a WB:WBGene00077731,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077731/b9fa704f-f937-4e65-9c1c-1d2dfb87a21e> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077731/d8f15d44-82a2-402e-bc80-18e379c21927> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077731  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7853|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077731/25f72603-d64a-4668-a426-98b9a6ebe574> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077731/25c206a9-75a6-4830-b30b-98da90ae900d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077731/504d54eb-1157-484c-bfc1-712f43872eb0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077731/17c9a206-b0a0-491f-861a-84d41c0e492a> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077731/e7ca97bb-7b7f-4ed0-941e-aae9ca807960> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077731/f515eafc-2d8a-4f17-9531-5f53422b16d5> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077731  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7853|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077731/25f72603-d64a-4668-a426-98b9a6ebe574> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077731/5a897bd8-bf81-4a16-8262-09ddc3c918e1> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077731/504d54eb-1157-484c-bfc1-712f43872eb0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077731/a55c506f-59a8-40bd-8dcf-8838ea6ceb48> .
 

--- a/models/WB_WBGene00077735.ttl
+++ b/models/WB_WBGene00077735.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077735> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "szy-7 (WB:WBGene00077735)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077735> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077735/0ca263f0-4fc8-4a3a-b1d4-6c3f40421bbe> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077735/3edef2ed-0501-43a0-b017-99fe3e744a5e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077735/78f4e04c-7577-4c30-bd07-b02ca3bcd1f0> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077735/ec105ffc-2a06-4142-942c-2ab62b1d249d> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077735/7c273e4f-9a68-435f-b922-db2fae179a91> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077735/11fa12e3-e468-49ba-ba65-4b4842534137> a WB:WBGene00077735,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077735/c274a4c4-054b-4d2c-ba8a-59f52202dd99> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077735/84c6b062-77f5-45d7-b378-99d623b414fe> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077735/84c6b062-77f5-45d7-b378-99d623b414fe> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077735/20c096cf-ab0b-4849-aa0b-d1995cbe9902> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077735/11fa12e3-e468-49ba-ba65-4b4842534137> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077735/f39056bb-d5d9-410f-8747-aca7db266163> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077735/c274a4c4-054b-4d2c-ba8a-59f52202dd99> a WB:WBGene00077735,
+<http://model.geneontology.org/WB_WBGene00077735/f39056bb-d5d9-410f-8747-aca7db266163> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077735/0ca263f0-4fc8-4a3a-b1d4-6c3f40421bbe> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077735/3edef2ed-0501-43a0-b017-99fe3e744a5e> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077735  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7857|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077735/7c273e4f-9a68-435f-b922-db2fae179a91> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077735/84c6b062-77f5-45d7-b378-99d623b414fe> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077735/20c096cf-ab0b-4849-aa0b-d1995cbe9902> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077735/f39056bb-d5d9-410f-8747-aca7db266163> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077735/78f4e04c-7577-4c30-bd07-b02ca3bcd1f0> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077735/ec105ffc-2a06-4142-942c-2ab62b1d249d> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077735  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7857|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077735/7c273e4f-9a68-435f-b922-db2fae179a91> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077735/c274a4c4-054b-4d2c-ba8a-59f52202dd99> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077735/20c096cf-ab0b-4849-aa0b-d1995cbe9902> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077735/11fa12e3-e468-49ba-ba65-4b4842534137> .
 

--- a/models/WB_WBGene00077736.ttl
+++ b/models/WB_WBGene00077736.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,99 +29,103 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077736> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "szy-8 (WB:WBGene00077736)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077736> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077736/25c97275-8b9d-461e-9656-1e5f98aff237> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077736/0be7920d-43e2-4936-8334-e7e8e4c8a13b> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278470" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077736/549a72b8-4d2a-4f99-bf4e-7d647ed6ec0c> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278470" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077736/75693b03-7bcc-4bda-b715-b918b5c8676b> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077736/79273385-2fa1-416a-9353-054f09a5517f> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077736/0eb7675e-6bcd-4803-ac5f-176f4fa2cb19> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00278470" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077736/dbab4219-5813-433e-b775-bd7323addc20> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00278470" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077736/f2a2ce5c-65af-40d3-809e-349ed5eae6e1> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077736/0c6c549c-6701-4db4-a0ab-cf2dd4974597> a WB:WBGene00077736,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077736/21ecc58b-e71b-4b19-aa76-f3bfddb6233d> a GO:0009792,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077736/b32b3589-4afd-4bbd-ad8c-e9b87a384aa5> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077736/31e54819-40fc-43e0-8c33-cf0745a96a63> a WB:WBGene00077736,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077736/d1615996-c43e-4df5-b9e2-504922f5ec5b> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077736/3f2d171f-b301-49d2-88b8-bc14a0b3780f> a GO:0051298,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077736/0c6c549c-6701-4db4-a0ab-cf2dd4974597> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077736/21ecc58b-e71b-4b19-aa76-f3bfddb6233d> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077736/961abefe-f0f7-47c8-b2b2-2aef6f3e7c55> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077736/edc65fda-befc-462e-b490-2697afbbdc22> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077736/e8cacc6c-4d6b-47ae-a749-ac5854350b09> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077736/d59f6245-851f-4197-9389-68d9cd48eb52> a WB:WBGene00077736,
+<http://model.geneontology.org/WB_WBGene00077736/c6610523-89fc-459b-810e-9b383622ceaa> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077736/31e54819-40fc-43e0-8c33-cf0745a96a63> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077736/3f2d171f-b301-49d2-88b8-bc14a0b3780f> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077736/e2858cc5-6cb1-4120-9847-a7ea61f14f71> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077736/e8cacc6c-4d6b-47ae-a749-ac5854350b09> a GO:0009792,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077736/d59f6245-851f-4197-9389-68d9cd48eb52> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077736/b32b3589-4afd-4bbd-ad8c-e9b87a384aa5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077736/edc65fda-befc-462e-b490-2697afbbdc22> a WB:WBGene00077736,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -129,50 +133,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077736/549a72b8-4d2a-4f99-bf4e-7d647ed6ec0c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077736/dbab4219-5813-433e-b775-bd7323addc20> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077736  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278470  2021-05-13 WB  id=WBOA:7898|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/d1615996-c43e-4df5-b9e2-504922f5ec5b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/21ecc58b-e71b-4b19-aa76-f3bfddb6233d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/961abefe-f0f7-47c8-b2b2-2aef6f3e7c55> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/e8cacc6c-4d6b-47ae-a749-ac5854350b09> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077736/25c97275-8b9d-461e-9656-1e5f98aff237> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077736/0eb7675e-6bcd-4803-ac5f-176f4fa2cb19> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077736  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278470  2021-05-13 WB  id=WBOA:7898|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/d1615996-c43e-4df5-b9e2-504922f5ec5b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/0c6c549c-6701-4db4-a0ab-cf2dd4974597> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/961abefe-f0f7-47c8-b2b2-2aef6f3e7c55> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/edc65fda-befc-462e-b490-2697afbbdc22> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077736/79273385-2fa1-416a-9353-054f09a5517f> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077736/f2a2ce5c-65af-40d3-809e-349ed5eae6e1> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077736  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7858|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/e2858cc5-6cb1-4120-9847-a7ea61f14f71> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/d59f6245-851f-4197-9389-68d9cd48eb52> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/c6610523-89fc-459b-810e-9b383622ceaa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/31e54819-40fc-43e0-8c33-cf0745a96a63> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077736/75693b03-7bcc-4bda-b715-b918b5c8676b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077736/0be7920d-43e2-4936-8334-e7e8e4c8a13b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077736  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7858|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/e2858cc5-6cb1-4120-9847-a7ea61f14f71> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/b32b3589-4afd-4bbd-ad8c-e9b87a384aa5> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077736/c6610523-89fc-459b-810e-9b383622ceaa> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077736/3f2d171f-b301-49d2-88b8-bc14a0b3780f> .
 

--- a/models/WB_WBGene00077737.ttl
+++ b/models/WB_WBGene00077737.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077737> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "szy-9 (WB:WBGene00077737)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077737> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077737/1e74ccd2-1949-4c17-9082-be30cdb70fc5> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077737/4db2ee70-2c00-4a89-b607-f93205d89270> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077737/77cda4c0-35e8-45b0-8085-8d7fdc5cb4fb> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077737/80ed07f9-f76f-44c4-b45d-beacbbf57589> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077737/0b1eeb11-edcd-4bf5-ae38-93f65cc493f6> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077737/2770c64c-b506-4353-a800-7a7f980afaa0> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077737/d23bf4ea-997a-40d4-b783-cca44230fba7> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077737/6d438804-97a6-4299-bd2d-a18a8235f1c9> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077737/0c420494-4a72-419a-b76d-3c81d61e831c> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077737/6d438804-97a6-4299-bd2d-a18a8235f1c9> a GO:0051298,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077737/66bbc73d-cd60-4f53-832a-a7cb0ae8b1c1> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077737/0b1eeb11-edcd-4bf5-ae38-93f65cc493f6> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077737/66bbc73d-cd60-4f53-832a-a7cb0ae8b1c1> a WB:WBGene00077737,
+<http://model.geneontology.org/WB_WBGene00077737/d23bf4ea-997a-40d4-b783-cca44230fba7> a WB:WBGene00077737,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077737/77cda4c0-35e8-45b0-8085-8d7fdc5cb4fb> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077737/4db2ee70-2c00-4a89-b607-f93205d89270> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077737  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7859|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077737/0c420494-4a72-419a-b76d-3c81d61e831c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077737/66bbc73d-cd60-4f53-832a-a7cb0ae8b1c1> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077737/1e74ccd2-1949-4c17-9082-be30cdb70fc5> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077737  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7859|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077737/0c420494-4a72-419a-b76d-3c81d61e831c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077737/0b1eeb11-edcd-4bf5-ae38-93f65cc493f6> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077737/2770c64c-b506-4353-a800-7a7f980afaa0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077737/6d438804-97a6-4299-bd2d-a18a8235f1c9> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077737/80ed07f9-f76f-44c4-b45d-beacbbf57589> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077737  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7859|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077737/2770c64c-b506-4353-a800-7a7f980afaa0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077737/d23bf4ea-997a-40d4-b783-cca44230fba7> .
 

--- a/models/WB_WBGene00077739.ttl
+++ b/models/WB_WBGene00077739.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,99 +29,103 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077739> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671",
         "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "szy-11 (WB:WBGene00077739)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077739> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077739/2901adb3-4e45-4029-951b-8f1c723bd5ea> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077739/2f8d2c55-a5a2-4995-844c-94324266321b> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000551" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077739/3676d511-33f8-4397-ac40-737af734d5f4> a ECO:0000315,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00000551" ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077739/90667b59-2104-4cc8-9fbd-a5d2ae100fd4> a ECO:0000316,
-        owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077739/bf83974e-1c87-4662-be77-1f3b09dfae6c> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077739/92a10d66-ea25-4691-99cb-66e0c611c9df> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00000551" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077739/9f234538-5a37-42a8-95f1-99cf6106608b> a ECO:0000315,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBVar00000551" ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077739/adc2bb67-15a9-4fa8-8e62-fce887b6a2f7> a ECO:0000316,
+        owl:NamedIndividual ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077739/13865289-dade-4d1e-9e87-3e88f28abfb2> a WB:WBGene00077739,
+<http://model.geneontology.org/WB_WBGene00077739/372b21a0-ea24-4917-b497-52e41e9ca398> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077739/5ccd55f0-fe8d-490b-9f53-84be094a5161> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077739/3aab1663-3fdc-4a1f-bf88-3336e2a7246b> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077739/3aab1663-3fdc-4a1f-bf88-3336e2a7246b> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077739/30d86925-5827-461d-9625-81a28ef83aa5> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077739/40efddba-80d4-453e-9d13-e697fc435ce9> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077739/13865289-dade-4d1e-9e87-3e88f28abfb2> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077739/c7402a56-f592-434f-bcc0-51a60e76281f> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077739/5484b535-5c3b-4cb3-beb2-3db8568c982c> a GO:0045132,
-        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077739/d356b200-9349-4a17-96e3-4cf9b928773e> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077739/ca496c19-d783-49de-8a0c-999a454035fd> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077739/b193fc82-a1c1-4941-9a74-058a1efdd4a6> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077739/f24025d1-6bad-441f-be60-e72c9c2f8787> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077739/5484b535-5c3b-4cb3-beb2-3db8568c982c> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077739/c7402a56-f592-434f-bcc0-51a60e76281f> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077739/5ccd55f0-fe8d-490b-9f53-84be094a5161> a WB:WBGene00077739,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077739/f24025d1-6bad-441f-be60-e72c9c2f8787> a WB:WBGene00077739,
+<http://model.geneontology.org/WB_WBGene00077739/ca496c19-d783-49de-8a0c-999a454035fd> a GO:0045132,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077739/d356b200-9349-4a17-96e3-4cf9b928773e> a WB:WBGene00077739,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -129,50 +133,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077739/90667b59-2104-4cc8-9fbd-a5d2ae100fd4> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077739  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7861|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/30d86925-5827-461d-9625-81a28ef83aa5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/13865289-dade-4d1e-9e87-3e88f28abfb2> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077739/3676d511-33f8-4397-ac40-737af734d5f4> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077739/92a10d66-ea25-4691-99cb-66e0c611c9df> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077739  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00000551  2021-05-13 WB  id=WBOA:7903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/b193fc82-a1c1-4941-9a74-058a1efdd4a6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/5484b535-5c3b-4cb3-beb2-3db8568c982c> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/40efddba-80d4-453e-9d13-e697fc435ce9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/ca496c19-d783-49de-8a0c-999a454035fd> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077739/2901adb3-4e45-4029-951b-8f1c723bd5ea> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077739  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00000551  2021-05-13 WB  id=WBOA:7903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/b193fc82-a1c1-4941-9a74-058a1efdd4a6> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/f24025d1-6bad-441f-be60-e72c9c2f8787> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077739/bf83974e-1c87-4662-be77-1f3b09dfae6c> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077739/2f8d2c55-a5a2-4995-844c-94324266321b> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077739  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7861|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/372b21a0-ea24-4917-b497-52e41e9ca398> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/5ccd55f0-fe8d-490b-9f53-84be094a5161> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077739/9f234538-5a37-42a8-95f1-99cf6106608b> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077739  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00000551  2021-05-13 WB  id=WBOA:7903|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/40efddba-80d4-453e-9d13-e697fc435ce9> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/d356b200-9349-4a17-96e3-4cf9b928773e> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077739/adc2bb67-15a9-4fa8-8e62-fce887b6a2f7> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077739  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7861|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/30d86925-5827-461d-9625-81a28ef83aa5> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/c7402a56-f592-434f-bcc0-51a60e76281f> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077739/372b21a0-ea24-4917-b497-52e41e9ca398> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077739/3aab1663-3fdc-4a1f-bf88-3336e2a7246b> .
 

--- a/models/WB_WBGene00077740.ttl
+++ b/models/WB_WBGene00077740.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077740> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:title "szy-12 (WB:WBGene00077740)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077740> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077740/19c4a58a-059b-4f85-a2cc-e11937c2b298> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077740/ba9b011b-b2ba-4d3d-bdc9-e30a21839509> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077740/25ec570b-7852-496e-8050-00408a93980d> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077740/f501c1af-a315-443d-8e4c-0bb9919639f1> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077740/08317fa2-92c8-4a03-8788-41e3549e1596> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077740/0360c27d-0a37-4d55-b593-f04a0d677856> a WB:WBGene00077740,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077740/0be0beec-2828-486f-9255-f66edb9a4b5b> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077740/20646cd8-9fcb-4ef4-b4f4-29edcf5b6637> a GO:0051298,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077740/8db712eb-4099-476d-94da-763e709680d6> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077740/08317fa2-92c8-4a03-8788-41e3549e1596> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077740/8db712eb-4099-476d-94da-763e709680d6> a WB:WBGene00077740,
+<http://model.geneontology.org/WB_WBGene00077740/bc6209c9-f306-4096-b203-3d22ddbe38f5> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077740/0360c27d-0a37-4d55-b593-f04a0d677856> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077740/20646cd8-9fcb-4ef4-b4f4-29edcf5b6637> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077740/25ec570b-7852-496e-8050-00408a93980d> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077740/ba9b011b-b2ba-4d3d-bdc9-e30a21839509> ;
     dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077740  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7862|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077740/0be0beec-2828-486f-9255-f66edb9a4b5b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077740/8db712eb-4099-476d-94da-763e709680d6> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077740/19c4a58a-059b-4f85-a2cc-e11937c2b298> ;
-    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077740  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7862|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077740/0be0beec-2828-486f-9255-f66edb9a4b5b> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077740/08317fa2-92c8-4a03-8788-41e3549e1596> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077740/bc6209c9-f306-4096-b203-3d22ddbe38f5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077740/20646cd8-9fcb-4ef4-b4f4-29edcf5b6637> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077740/f501c1af-a315-443d-8e4c-0bb9919639f1> ;
+    dc:contributor "https://orcid.org/0000-0002-1706-4196" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077740  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7862|contributor-id=https://orcid.org/0000-0002-1706-4196|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077740/bc6209c9-f306-4096-b203-3d22ddbe38f5> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077740/0360c27d-0a37-4d55-b593-f04a0d677856> .
 

--- a/models/WB_WBGene00077742.ttl
+++ b/models/WB_WBGene00077742.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077742> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-14 (WB:WBGene00077742)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077742> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077742/1069126d-09bb-4f7e-85f3-679b353dc8d2> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077742/02ca3e26-4c53-4cc2-bc69-efda5bf972c1> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077742/8fefed3a-1af2-4e00-9f54-e3747b1b5354> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077742/0e0f775d-ae68-4028-9f7e-e09b59a89b2f> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077742/310da5c1-8067-4bae-b188-f97c37ee9bbf> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077742/6450f368-fd22-4146-9156-73d11d794470> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077742/441a77a4-65a3-4478-af8c-5fc37c9afa51> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077742/d23c9c63-8ca7-4dad-9d83-19aed64b2a13> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077742/8447cfb3-88db-4690-bdff-126f1a74439b> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077742/a1b36da2-824d-4a48-9d07-d157f6fbc47b> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077742/441a77a4-65a3-4478-af8c-5fc37c9afa51> a WB:WBGene00077742,
+<http://model.geneontology.org/WB_WBGene00077742/8447cfb3-88db-4690-bdff-126f1a74439b> a WB:WBGene00077742,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077742/d23c9c63-8ca7-4dad-9d83-19aed64b2a13> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077742/a1b36da2-824d-4a48-9d07-d157f6fbc47b> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077742/1069126d-09bb-4f7e-85f3-679b353dc8d2> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077742/0e0f775d-ae68-4028-9f7e-e09b59a89b2f> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077742  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7864|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077742/310da5c1-8067-4bae-b188-f97c37ee9bbf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077742/d23c9c63-8ca7-4dad-9d83-19aed64b2a13> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077742/6450f368-fd22-4146-9156-73d11d794470> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077742/a1b36da2-824d-4a48-9d07-d157f6fbc47b> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077742/8fefed3a-1af2-4e00-9f54-e3747b1b5354> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077742/02ca3e26-4c53-4cc2-bc69-efda5bf972c1> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077742  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7864|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077742/310da5c1-8067-4bae-b188-f97c37ee9bbf> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077742/441a77a4-65a3-4478-af8c-5fc37c9afa51> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077742/6450f368-fd22-4146-9156-73d11d794470> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077742/8447cfb3-88db-4690-bdff-126f1a74439b> .
 

--- a/models/WB_WBGene00077743.ttl
+++ b/models/WB_WBGene00077743.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077743> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-15 (WB:WBGene00077743)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077743> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077743/67f5e728-e74b-4745-8ede-cb0ea90193e7> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077743/169439e8-3446-44cd-baf8-1d0d2ebb3c40> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00278473" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/a8af9912-a229-4e41-b172-944bd01e417b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077743/76c46999-1ca4-4b97-9af6-ba0359121d89> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278473" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/b0bc23a1-30e7-4340-9bd1-75713f15ba9b> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077743/885b895b-7d10-4753-ad9e-3885e351b2b7> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278473" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/ff93aecd-686d-4954-9d3a-52215d270aff> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077743/c76ba248-8bee-4812-b308-557912091242> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00278473" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077743/14cdb467-55be-449d-9bf5-6d06315489f4> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077743/3cac72ab-5426-4032-aa8d-e977e33d3dcf> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077743/66b7e2b8-86d1-4e0c-beb1-995e0fcd2e9a> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/3cac72ab-5426-4032-aa8d-e977e33d3dcf> a WB:WBGene00077743,
+<http://model.geneontology.org/WB_WBGene00077743/0cf824cc-061f-449b-835e-c4ff47ad8696> a GO:0009792,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/45b24dc5-6394-4edd-b8c9-93e28ff4d421> a GO:0009792,
+<http://model.geneontology.org/WB_WBGene00077743/158faf8c-8e0d-432c-ac9c-2d37aed0d405> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077743/995f57cb-5379-4130-bd4f-30236228b6d2> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077743/76cfc349-b6bc-4ce3-b28e-9196fadc6aa2> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077743/76cfc349-b6bc-4ce3-b28e-9196fadc6aa2> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/4cc4ad9d-785c-40dc-8ffa-0ddd2496694c> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077743/66096d53-9b2d-48a6-b782-77679e7350e4> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077743/45b24dc5-6394-4edd-b8c9-93e28ff4d421> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077743/66096d53-9b2d-48a6-b782-77679e7350e4> a WB:WBGene00077743,
+<http://model.geneontology.org/WB_WBGene00077743/995f57cb-5379-4130-bd4f-30236228b6d2> a WB:WBGene00077743,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077743/66b7e2b8-86d1-4e0c-beb1-995e0fcd2e9a> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077743/9a626e15-02d4-4d8c-a5fa-e39551f96b8d> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077743/e8dd0896-8103-4f31-807a-1b65e2e133c2> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077743/0cf824cc-061f-449b-835e-c4ff47ad8696> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077743/e8dd0896-8103-4f31-807a-1b65e2e133c2> a WB:WBGene00077743,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077743/ff93aecd-686d-4954-9d3a-52215d270aff> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077743/885b895b-7d10-4753-ad9e-3885e351b2b7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077743  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7865|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/14cdb467-55be-449d-9bf5-6d06315489f4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/3cac72ab-5426-4032-aa8d-e977e33d3dcf> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077743/67f5e728-e74b-4745-8ede-cb0ea90193e7> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077743  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7865|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/14cdb467-55be-449d-9bf5-6d06315489f4> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/66b7e2b8-86d1-4e0c-beb1-995e0fcd2e9a> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/158faf8c-8e0d-432c-ac9c-2d37aed0d405> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/76cfc349-b6bc-4ce3-b28e-9196fadc6aa2> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077743/b0bc23a1-30e7-4340-9bd1-75713f15ba9b> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077743/c76ba248-8bee-4812-b308-557912091242> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077743  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278473  2021-05-13 WB  id=WBOA:7900|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/4cc4ad9d-785c-40dc-8ffa-0ddd2496694c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/66096d53-9b2d-48a6-b782-77679e7350e4> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077743/a8af9912-a229-4e41-b172-944bd01e417b> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077743  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278473  2021-05-13 WB  id=WBOA:7900|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/4cc4ad9d-785c-40dc-8ffa-0ddd2496694c> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/45b24dc5-6394-4edd-b8c9-93e28ff4d421> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/9a626e15-02d4-4d8c-a5fa-e39551f96b8d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/0cf824cc-061f-449b-835e-c4ff47ad8696> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077743/169439e8-3446-44cd-baf8-1d0d2ebb3c40> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077743  RO:0002264 GO:0009792 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278473  2021-05-13 WB  id=WBOA:7900|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/9a626e15-02d4-4d8c-a5fa-e39551f96b8d> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/e8dd0896-8103-4f31-807a-1b65e2e133c2> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077743/76c46999-1ca4-4b97-9af6-ba0359121d89> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077743  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7865|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077743/158faf8c-8e0d-432c-ac9c-2d37aed0d405> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077743/995f57cb-5379-4130-bd4f-30236228b6d2> .
 

--- a/models/WB_WBGene00077744.ttl
+++ b/models/WB_WBGene00077744.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077744> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-16 (WB:WBGene00077744)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077744> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077744/ee3c42c6-1121-4ebd-b1f8-02e7d708ec07> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077744/6f106868-32d6-460b-ac8f-759b5f65e574> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077744/eedf4826-df34-4b04-a456-f1b8b38831bb> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077744/d2c6d560-dfb8-48f6-824c-610dd80b3f97> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077744/00f2af4b-1c4a-41e2-95ac-4b9bb5463d96> a WB:WBGene00077744,
+<http://model.geneontology.org/WB_WBGene00077744/405af5df-b2e4-4dd9-bc1b-1e86433b4c26> a GO:0003674,
         owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077744/9450782d-ce92-4eb1-9a26-79e05201dc9d> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077744/8548ac9a-4a31-4c76-a5bc-95104f33abeb> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077744/30334d06-7f61-4bfc-8b0d-adb48417513a> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077744/8548ac9a-4a31-4c76-a5bc-95104f33abeb> a GO:0051298,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077744/00f2af4b-1c4a-41e2-95ac-4b9bb5463d96> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077744/d385dc5f-17b8-409a-93b8-03aac5d67f40> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077744/d385dc5f-17b8-409a-93b8-03aac5d67f40> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077744/9450782d-ce92-4eb1-9a26-79e05201dc9d> a WB:WBGene00077744,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077744/ee3c42c6-1121-4ebd-b1f8-02e7d708ec07> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077744/d2c6d560-dfb8-48f6-824c-610dd80b3f97> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077744  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7866|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077744/30334d06-7f61-4bfc-8b0d-adb48417513a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077744/00f2af4b-1c4a-41e2-95ac-4b9bb5463d96> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077744/eedf4826-df34-4b04-a456-f1b8b38831bb> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077744  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7866|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077744/30334d06-7f61-4bfc-8b0d-adb48417513a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077744/d385dc5f-17b8-409a-93b8-03aac5d67f40> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077744/405af5df-b2e4-4dd9-bc1b-1e86433b4c26> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077744/8548ac9a-4a31-4c76-a5bc-95104f33abeb> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077744/6f106868-32d6-460b-ac8f-759b5f65e574> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077744  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7866|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077744/405af5df-b2e4-4dd9-bc1b-1e86433b4c26> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077744/9450782d-ce92-4eb1-9a26-79e05201dc9d> .
 

--- a/models/WB_WBGene00077745.ttl
+++ b/models/WB_WBGene00077745.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,98 +29,102 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077745> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-17 (WB:WBGene00077745)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077745> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077745/130ecfdc-757a-4ac0-a5a4-e32da60dc47c> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077745/23faea41-7cbd-418e-b274-3b9424761d0b> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00278474" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/68a8bb19-fbba-4ef6-b78d-ce514fae3c19> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077745/4b6c66e4-81fe-4088-885f-59fa1dd203db> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278474" ;
+    ns1:evidence-with "WB:WBVar00278474" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/6d0f34d8-a5a6-4dbf-9554-0e91ab391848> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077745/b0e9e9af-fe9d-48ab-802a-5d9c84080d25> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/6d3abeac-7a3c-451e-9f9d-479678f1272e> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077745/dab0fe4a-0b6e-4394-8128-4561aa1cd7c6> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278474" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/059cbe48-7520-46a4-a79b-a0cee80e080e> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077745/03896f91-51a0-4ec2-bff3-832764e082dc> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077745/de5710f2-de0b-4c88-830d-284b71d62eff> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077745/d9accd94-41b1-4258-98cd-992b257a50bf> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077745/b4915c6c-bda5-4a60-972b-597cfffad090> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077745/8af35aeb-df5c-4db1-a154-88e78f3b7acb> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/33530491-d22a-4a2a-bfdc-2021cf7132e5> a WB:WBGene00077745,
-        owl:NamedIndividual ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077745/72c9dfdd-5fe2-4b7a-bd76-f8a9bc476113> a GO:0045132,
+<http://model.geneontology.org/WB_WBGene00077745/6d5e9b44-8318-4333-b6d3-d976c3870246> a WB:WBGene00077745,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/b0a9bad4-abf8-4a1e-ac7d-74461b99e39a> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077745/33530491-d22a-4a2a-bfdc-2021cf7132e5> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077745/72c9dfdd-5fe2-4b7a-bd76-f8a9bc476113> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077745/d9accd94-41b1-4258-98cd-992b257a50bf> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077745/8af35aeb-df5c-4db1-a154-88e78f3b7acb> a GO:0045132,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077745/de5710f2-de0b-4c88-830d-284b71d62eff> a WB:WBGene00077745,
+<http://model.geneontology.org/WB_WBGene00077745/b4915c6c-bda5-4a60-972b-597cfffad090> a WB:WBGene00077745,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077745/c2f3912d-2b88-4cc1-9d6f-ccde9b951b10> a GO:0051298,
+        owl:NamedIndividual ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077745/e1291978-6793-4e8a-870d-36cd864409a7> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077745/6d5e9b44-8318-4333-b6d3-d976c3870246> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077745/c2f3912d-2b88-4cc1-9d6f-ccde9b951b10> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -128,50 +132,50 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077745/68a8bb19-fbba-4ef6-b78d-ce514fae3c19> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077745/b0e9e9af-fe9d-48ab-802a-5d9c84080d25> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077745  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278474  2021-05-13 WB  id=WBOA:7904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/b0a9bad4-abf8-4a1e-ac7d-74461b99e39a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/72c9dfdd-5fe2-4b7a-bd76-f8a9bc476113> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077745/6d3abeac-7a3c-451e-9f9d-479678f1272e> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077745  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278474  2021-05-13 WB  id=WBOA:7904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/b0a9bad4-abf8-4a1e-ac7d-74461b99e39a> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/33530491-d22a-4a2a-bfdc-2021cf7132e5> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077745/130ecfdc-757a-4ac0-a5a4-e32da60dc47c> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077745  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7867|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/059cbe48-7520-46a4-a79b-a0cee80e080e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/de5710f2-de0b-4c88-830d-284b71d62eff> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/e1291978-6793-4e8a-870d-36cd864409a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/6d5e9b44-8318-4333-b6d3-d976c3870246> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077745/6d0f34d8-a5a6-4dbf-9554-0e91ab391848> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077745/dab0fe4a-0b6e-4394-8128-4561aa1cd7c6> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077745  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7867|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/059cbe48-7520-46a4-a79b-a0cee80e080e> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/d9accd94-41b1-4258-98cd-992b257a50bf> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/e1291978-6793-4e8a-870d-36cd864409a7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/c2f3912d-2b88-4cc1-9d6f-ccde9b951b10> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077745/23faea41-7cbd-418e-b274-3b9424761d0b> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077745  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278474  2021-05-13 WB  id=WBOA:7904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/03896f91-51a0-4ec2-bff3-832764e082dc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/b4915c6c-bda5-4a60-972b-597cfffad090> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077745/4b6c66e4-81fe-4088-885f-59fa1dd203db> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077745  RO:0002264 GO:0045132 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278474  2021-05-13 WB  id=WBOA:7904|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077745/03896f91-51a0-4ec2-bff3-832764e082dc> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077745/8af35aeb-df5c-4db1-a154-88e78f3b7acb> .
 

--- a/models/WB_WBGene00077746.ttl
+++ b/models/WB_WBGene00077746.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,140 +29,146 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077746> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-18 (WB:WBGene00077746)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077746> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077746/32e64f27-1139-42a6-ae54-e87e1d9672c8> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077746/5f2e1b4a-08a9-4b4a-a492-dd197cd71b2e> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278475" ;
+    ns1:evidence-with "WB:WBVar00278475" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/34001203-b67a-43d8-89a8-9d39f420bf21> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077746/606a251e-ffa7-4967-b9be-624a12979057> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBVar00278475" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/63900e22-57b5-45de-bb34-9a8fcacba4c8> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077746/a0c7c634-6986-405b-9721-9ff548a467f4> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/ba8fa864-4f79-4263-91c7-6dfa94467955> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077746/a5d8dc3c-192a-4de1-af4e-3a5c3892175e> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278475" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/c521bc24-af2e-402b-8fd6-3456f3f04c90> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077746/d8e1ecd1-65e8-4fa4-a2c5-e1f170be9ec6> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278475" ;
+    ns1:evidence-with "WB:WBVar00278475" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/fafc8313-3f7a-4e7b-a786-93d3c15be04a> a ECO:0000315,
+<http://model.geneontology.org/WB_WBGene00077746/dc40d3e0-60ee-489f-aefd-8d5219f67598> a ECO:0000315,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBVar00278475" ;
+    ns1:evidence-with "WB:WBVar00278475" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/4fe57388-7d76-4571-8503-bcf97d9c8393> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077746/0502601f-493f-4c25-aa47-5d088461c25f> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077746/327b77b2-363d-4e2c-80e5-6038b7e81484> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077746/4be83db1-a1e2-4fac-ab9c-eea0d8cf1d87> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077746/1e346812-e916-42b7-8eb0-6ac26682ee93> a GO:0051301,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/5d9d4e4c-0cc7-4270-82ac-fbaa7f44fd42> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077746/d25059bc-f9d1-4019-acf6-b9a6880ecdf0> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077746/b16af89c-ff3e-4cdb-9f65-7bd8920e663d> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077746/7e8a1787-e238-476b-aa25-5080d8e4ca33> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077746/be49866d-3973-4668-ac27-0e8a2915691a> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077746/4fe57388-7d76-4571-8503-bcf97d9c8393> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077746/8b6088cc-476c-4bf0-beba-e6f46def0bda> a GO:0003674,
-        owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077746/a59032c2-7a89-4336-9a9d-3782ba777cbe> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077746/a6065e54-686a-42d2-863d-50c623683858> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" .
-
-<http://model.geneontology.org/WB_WBGene00077746/a59032c2-7a89-4336-9a9d-3782ba777cbe> a WB:WBGene00077746,
+<http://model.geneontology.org/WB_WBGene00077746/31993e8d-1890-4c41-925c-0998721a7fbd> a WB:WBGene00077746,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/a6065e54-686a-42d2-863d-50c623683858> a GO:0051301,
+<http://model.geneontology.org/WB_WBGene00077746/327b77b2-363d-4e2c-80e5-6038b7e81484> a WB:WBGene00077746,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/b16af89c-ff3e-4cdb-9f65-7bd8920e663d> a GO:0007098,
+<http://model.geneontology.org/WB_WBGene00077746/33899a39-eaa3-4a7d-9274-8dc2765b3ce3> a GO:0007098,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/be49866d-3973-4668-ac27-0e8a2915691a> a WB:WBGene00077746,
+<http://model.geneontology.org/WB_WBGene00077746/4be83db1-a1e2-4fac-ab9c-eea0d8cf1d87> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077746/d25059bc-f9d1-4019-acf6-b9a6880ecdf0> a WB:WBGene00077746,
+<http://model.geneontology.org/WB_WBGene00077746/c3668d57-4f05-4c02-be8b-08307f23d197> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077746/cce8e3e1-a128-4833-9585-bd9dd1c19736> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077746/1e346812-e916-42b7-8eb0-6ac26682ee93> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077746/cce8e3e1-a128-4833-9585-bd9dd1c19736> a WB:WBGene00077746,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" .
+
+<http://model.geneontology.org/WB_WBGene00077746/f15f1eb9-f505-4b9f-83c7-2cb3cd598fe0> a GO:0003674,
+        owl:NamedIndividual ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077746/31993e8d-1890-4c41-925c-0998721a7fbd> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077746/33899a39-eaa3-4a7d-9274-8dc2765b3ce3> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
@@ -170,74 +176,74 @@ obo:RO_0002333 a owl:ObjectProperty .
 obo:RO_0002418 a owl:ObjectProperty .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077746/fafc8313-3f7a-4e7b-a786-93d3c15be04a> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077746/606a251e-ffa7-4967-b9be-624a12979057> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051301 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278475  2021-05-13 WB  id=WBOA:7916|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/8b6088cc-476c-4bf0-beba-e6f46def0bda> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/a6065e54-686a-42d2-863d-50c623683858> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077746/ba8fa864-4f79-4263-91c7-6dfa94467955> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0007098 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278475  2021-05-13 WB  id=WBOA:89552|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/5d9d4e4c-0cc7-4270-82ac-fbaa7f44fd42> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/d25059bc-f9d1-4019-acf6-b9a6880ecdf0> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/f15f1eb9-f505-4b9f-83c7-2cb3cd598fe0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/31993e8d-1890-4c41-925c-0998721a7fbd> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077746/c521bc24-af2e-402b-8fd6-3456f3f04c90> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077746/dc40d3e0-60ee-489f-aefd-8d5219f67598> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0007098 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278475  2021-05-13 WB  id=WBOA:89552|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/5d9d4e4c-0cc7-4270-82ac-fbaa7f44fd42> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/b16af89c-ff3e-4cdb-9f65-7bd8920e663d> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/f15f1eb9-f505-4b9f-83c7-2cb3cd598fe0> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/33899a39-eaa3-4a7d-9274-8dc2765b3ce3> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077746/63900e22-57b5-45de-bb34-9a8fcacba4c8> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077746/5f2e1b4a-08a9-4b4a-a492-dd197cd71b2e> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7868|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051301 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278475  2021-05-13 WB  id=WBOA:7916|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/7e8a1787-e238-476b-aa25-5080d8e4ca33> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/4fe57388-7d76-4571-8503-bcf97d9c8393> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/c3668d57-4f05-4c02-be8b-08307f23d197> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/1e346812-e916-42b7-8eb0-6ac26682ee93> .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077746/34001203-b67a-43d8-89a8-9d39f420bf21> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077746/d8e1ecd1-65e8-4fa4-a2c5-e1f170be9ec6> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7868|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/7e8a1787-e238-476b-aa25-5080d8e4ca33> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/be49866d-3973-4668-ac27-0e8a2915691a> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077746/32e64f27-1139-42a6-ae54-e87e1d9672c8> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051301 WB:WBPaper00029303|PMID:17446307 ECO:0000315 WB:WBVar00278475  2021-05-13 WB  id=WBOA:7916|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/8b6088cc-476c-4bf0-beba-e6f46def0bda> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/a59032c2-7a89-4336-9a9d-3782ba777cbe> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/c3668d57-4f05-4c02-be8b-08307f23d197> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/cce8e3e1-a128-4833-9585-bd9dd1c19736> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077746/a0c7c634-6986-405b-9721-9ff548a467f4> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7868|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002333 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/0502601f-493f-4c25-aa47-5d088461c25f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/327b77b2-363d-4e2c-80e5-6038b7e81484> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077746/a5d8dc3c-192a-4de1-af4e-3a5c3892175e> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077746  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7868|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077746/0502601f-493f-4c25-aa47-5d088461c25f> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077746/4be83db1-a1e2-4fac-ab9c-eea0d8cf1d87> .
 

--- a/models/WB_WBGene00077747.ttl
+++ b/models/WB_WBGene00077747.ttl
@@ -3,14 +3,14 @@
 @prefix WB: <http://identifiers.org/wormbase/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix ns1: <https://w3id.org/biolink/vocab/> .
+@prefix ns1: <http://geneontology.org/lego/> .
 @prefix ns2: <http://purl.org/pav/> .
-@prefix ns3: <http://geneontology.org/lego/> .
+@prefix ns3: <https://w3id.org/biolink/vocab/> .
 @prefix obo: <http://purl.obolibrary.org/obo/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
-ns3:evidence a owl:AnnotationProperty .
+ns1:evidence a owl:AnnotationProperty .
 
 <http://geneontology.org/lego/hint/layout/x> a owl:AnnotationProperty .
 
@@ -29,83 +29,85 @@ dct:dateAccepted a owl:AnnotationProperty .
 ns2:providedBy a owl:AnnotationProperty .
 
 <http://model.geneontology.org/WB_WBGene00077747> a owl:Ontology ;
-    ns3:modelstate "production" ;
+    ns1:modelstate "production" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:title "szy-19 (WB:WBGene00077747)" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     owl:versionIRI <http://model.geneontology.org/WB_WBGene00077747> ;
-    ns1:in_taxon obo:NCBITaxon_6239 .
+    ns3:in_taxon obo:NCBITaxon_6239 .
 
-<http://model.geneontology.org/WB_WBGene00077747/12fc0e16-7d6d-41c5-a452-0014f624ec64> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077747/8aedfb55-8215-4ec9-b2f9-1c6fa57a22c5> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077747/293ba7f6-c1c1-478c-b365-280995ce8dd4> a ECO:0000316,
+<http://model.geneontology.org/WB_WBGene00077747/c12cbc3e-4249-4b29-9f66-ac22ea3733d3> a ECO:0000316,
         owl:NamedIndividual ;
-    ns3:evidence-with "WB:WBGene00006988" ;
+    ns1:evidence-with "WB:WBGene00006988" ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dc:source "PMID:17446307" ;
+    dct:created "2021-05-13" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 obo:RO_0002333 a owl:ObjectProperty .
 
 obo:RO_0002418 a owl:ObjectProperty .
 
-<http://model.geneontology.org/WB_WBGene00077747/233b61a4-23e9-4294-a416-26b2c7f59de0> a GO:0003674,
+<http://model.geneontology.org/WB_WBGene00077747/7504bdfa-3fbe-4dac-906a-dc16dd7b21b7> a GO:0003674,
         owl:NamedIndividual ;
-    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077747/b333f597-ccd9-48be-a902-e8f551790be9> ;
-    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077747/751eae3a-a4c8-4336-80ba-dc7d72cf4915> ;
+    obo:RO_0002333 <http://model.geneontology.org/WB_WBGene00077747/7ebe3fbb-5946-41a7-9860-24ebb022d8f3> ;
+    obo:RO_0002418 <http://model.geneontology.org/WB_WBGene00077747/8714008f-82b9-4bc4-b2c2-22c59a8622c7> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077747/751eae3a-a4c8-4336-80ba-dc7d72cf4915> a GO:0051298,
+<http://model.geneontology.org/WB_WBGene00077747/7ebe3fbb-5946-41a7-9860-24ebb022d8f3> a WB:WBGene00077747,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
-<http://model.geneontology.org/WB_WBGene00077747/b333f597-ccd9-48be-a902-e8f551790be9> a WB:WBGene00077747,
+<http://model.geneontology.org/WB_WBGene00077747/8714008f-82b9-4bc4-b2c2-22c59a8622c7> a GO:0051298,
         owl:NamedIndividual ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" .
 
 [] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077747/12fc0e16-7d6d-41c5-a452-0014f624ec64> ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077747/c12cbc3e-4249-4b29-9f66-ac22ea3733d3> ;
     dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
     dc:date "2021-05-13" ;
     dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
-    ns2:providedBy "http://www.wormbase.org" ;
-    rdfs:comment "WB:WBGene00077747  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7869|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
-    owl:annotatedProperty obo:RO_0002418 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077747/233b61a4-23e9-4294-a416-26b2c7f59de0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077747/751eae3a-a4c8-4336-80ba-dc7d72cf4915> .
-
-[] a owl:Axiom ;
-    ns3:evidence <http://model.geneontology.org/WB_WBGene00077747/293ba7f6-c1c1-478c-b365-280995ce8dd4> ;
-    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
-    dc:date "2021-05-13" ;
-    dct:created "2021-05-13" ;
-    dct:dateAccepted "2021-08-09" ;
+    dct:dateAccepted "2021-11-17" ;
     ns2:providedBy "http://www.wormbase.org" ;
     rdfs:comment "WB:WBGene00077747  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7869|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
     owl:annotatedProperty obo:RO_0002333 ;
-    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077747/233b61a4-23e9-4294-a416-26b2c7f59de0> ;
-    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077747/b333f597-ccd9-48be-a902-e8f551790be9> .
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077747/7504bdfa-3fbe-4dac-906a-dc16dd7b21b7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077747/7ebe3fbb-5946-41a7-9860-24ebb022d8f3> .
+
+[] a owl:Axiom ;
+    ns1:evidence <http://model.geneontology.org/WB_WBGene00077747/8aedfb55-8215-4ec9-b2f9-1c6fa57a22c5> ;
+    dc:contributor "https://orcid.org/0000-0002-1478-7671" ;
+    dc:date "2021-05-13" ;
+    dct:created "2021-05-13" ;
+    dct:dateAccepted "2021-11-17" ;
+    ns2:providedBy "http://www.wormbase.org" ;
+    rdfs:comment "WB:WBGene00077747  RO:0002264 GO:0051298 WB:WBPaper00029303|PMID:17446307 ECO:0000316 WB:WBGene00006988  2021-05-13 WB  id=WBOA:7869|contributor-id=https://orcid.org/0000-0002-1478-7671|creation-date=2021-05-13|modification-date=2021-05-13" ;
+    owl:annotatedProperty obo:RO_0002418 ;
+    owl:annotatedSource <http://model.geneontology.org/WB_WBGene00077747/7504bdfa-3fbe-4dac-906a-dc16dd7b21b7> ;
+    owl:annotatedTarget <http://model.geneontology.org/WB_WBGene00077747/8714008f-82b9-4bc4-b2c2-22c59a8622c7> .
 

--- a/products/wb_oa_4.report.md
+++ b/products/wb_oa_4.report.md
@@ -2,7 +2,7 @@
 
 ## SUMMARY
 
-This report generated on 2021-07-16
+This report generated on 2021-11-17
 
   * Associations: 360
   * Lines in file (incl headers): 363

--- a/source/wb.gpi
+++ b/source/wb.gpi
@@ -1,0 +1,13721 @@
+!gpi-version: 1.2
+WB	WBGene00000001	aap-1		Y110A7A.10	gene	taxon:6239			
+WB	WBGene00000002	aat-1		F27C8.1	gene	taxon:6239			
+WB	WBGene00000003	aat-2		F07C3.7	gene	taxon:6239			
+WB	WBGene00000004	aat-3		F52H2.2	gene	taxon:6239			
+WB	WBGene00000005	aat-4		T13A10.10	gene	taxon:6239			
+WB	WBGene00000006	aat-5		C55C2.5	gene	taxon:6239			
+WB	WBGene00000007	aat-6		T11F9.4	gene	taxon:6239			
+WB	WBGene00000008	aat-7		F54D12.3|F54D12.f	gene	taxon:6239			
+WB	WBGene00000009	aat-8		F28F9.4	gene	taxon:6239			
+WB	WBGene00000010	aat-9		Y53H1C.1	gene	taxon:6239			
+WB	WBGene00000011	abc-1			gene	taxon:6239			
+WB	WBGene00000012	abf-1		C50F2.9	gene	taxon:6239			
+WB	WBGene00000013	abf-2		C50F2.10|C50F2.e	gene	taxon:6239			
+WB	WBGene00000014	abf-3		F54B8.5	gene	taxon:6239			
+WB	WBGene00000018	abl-1		M79.1	gene	taxon:6239			
+WB	WBGene00000019	abt-1		C24F3.5	gene	taxon:6239			
+WB	WBGene00000020	abt-2		F12B6.1|Y39G10AL.b	gene	taxon:6239			
+WB	WBGene00000022	abt-4		Y39D8C.1	gene	taxon:6239			
+WB	WBGene00000023	abt-5		Y53C10A.9	gene	taxon:6239			
+WB	WBGene00000024	abu-1		AC3.3|pqn-1	gene	taxon:6239			
+WB	WBGene00000025	abu-2		F19G12.7|pqn-30	gene	taxon:6239			
+WB	WBGene00000027	abu-4		Y5H2A.3|Y5H2A.a|Y5H2A.c	gene	taxon:6239			
+WB	WBGene00000028	abu-5		Y105C5A.4|pqn-77	gene	taxon:6239			
+WB	WBGene00000029	abu-6		C03A7.7|pqn-6	gene	taxon:6239			
+WB	WBGene00000030	abu-7		C03A7.8|pqn-7	gene	taxon:6239			
+WB	WBGene00000031	abu-8		C03A7.14|pqn-4	gene	taxon:6239			
+WB	WBGene00000032	abu-9		R09F10.2|pqn-56	gene	taxon:6239			
+WB	WBGene00000033	abu-10		F35A5.3|pqn-33	gene	taxon:6239			
+WB	WBGene00000034	abu-11		T01D1.6|pqn-61	gene	taxon:6239			
+WB	WBGene00000035	ace-1		W09B12.1|ACE1|cest-23	gene	taxon:6239			
+WB	WBGene00000036	ace-2		Y44E3A.2|cest-20	gene	taxon:6239			
+WB	WBGene00000037	ace-3		Y48B6A.8|cest-21	gene	taxon:6239			
+WB	WBGene00000038	ace-4		Y48B6A.7|cest-22	gene	taxon:6239			
+WB	WBGene00000039	acn-1		C42D8.5	gene	taxon:6239			
+WB	WBGene00000040	aco-1		ZK455.1|gei-22	gene	taxon:6239			
+WB	WBGene00000041	aco-2		F54H12.1	gene	taxon:6239			
+WB	WBGene00000042	acr-2		K11G12.2	gene	taxon:6239			
+WB	WBGene00000043	acr-3		K11G12.7	gene	taxon:6239			
+WB	WBGene00000044	acr-5		K03F8.2	gene	taxon:6239			
+WB	WBGene00000045	acr-6		ZK973.5	gene	taxon:6239			
+WB	WBGene00000046	acr-7		T09A5.3	gene	taxon:6239			
+WB	WBGene00000047	acr-8		ZC504.2	gene	taxon:6239			
+WB	WBGene00000048	acr-9		C40C9.2	gene	taxon:6239			
+WB	WBGene00000049	acr-10		R02E12.8	gene	taxon:6239			
+WB	WBGene00000050	acr-11		D2092.3	gene	taxon:6239			
+WB	WBGene00000051	acr-12		R01E6.4	gene	taxon:6239			
+WB	WBGene00000053	acr-14		T05C12.2	gene	taxon:6239			
+WB	WBGene00000054	acr-15		F25G6.4	gene	taxon:6239			
+WB	WBGene00000055	acr-16		F25G6.3|Ce21	gene	taxon:6239			
+WB	WBGene00000056	acr-17		F53E10.2	gene	taxon:6239			
+WB	WBGene00000057	acr-18		F28F8.1	gene	taxon:6239			
+WB	WBGene00000058	acr-19		C31H5.3	gene	taxon:6239			
+WB	WBGene00000059	acr-20		R06A4.10	gene	taxon:6239			
+WB	WBGene00000060	acr-21		F27B3.2	gene	taxon:6239			
+WB	WBGene00000061	lgc-11		F48E3.7|acr-22	gene	taxon:6239			
+WB	WBGene00000062	acr-23		F59B1.9	gene	taxon:6239			
+WB	WBGene00000063	act-1		T04C12.6	gene	taxon:6239			
+WB	WBGene00000064	act-2		T04C12.5|act2	gene	taxon:6239			
+WB	WBGene00000066	act-4		M03F4.2|act4	gene	taxon:6239			
+WB	WBGene00000067	act-5		T25C8.2	gene	taxon:6239			
+WB	WBGene00000068	acy-1		F17C8.1|sgs-1	gene	taxon:6239			
+WB	WBGene00000069	acy-2		C10F3.3	gene	taxon:6239			
+WB	WBGene00000070	acy-3		C44F1.5	gene	taxon:6239			
+WB	WBGene00000071	acy-4		T01C2.1	gene	taxon:6239			
+WB	WBGene00000072	add-1		F39C12.2	gene	taxon:6239			
+WB	WBGene00000073	add-2		F57F5.4	gene	taxon:6239			
+WB	WBGene00000074	adm-2		C04A11.4	gene	taxon:6239			
+WB	WBGene00000075	adm-4		ZK154.7	gene	taxon:6239			
+WB	WBGene00000078	adp-1			gene	taxon:6239			
+WB	WBGene00000079	adr-1		H15N14.1|adr-1c|adr-1d|adr-1e|adr-1f|adr-1g	gene	taxon:6239			
+WB	WBGene00000080	adr-2		T20H4.4	gene	taxon:6239			
+WB	WBGene00000081	ads-1		Y50D7A.7|ADHAPS|Y50D7A.b|Y50D7A.j|Y50D7A.k	gene	taxon:6239			
+WB	WBGene00000082	adt-1		C02B4.1	gene	taxon:6239			
+WB	WBGene00000083	adt-2		F08C6.1|sma-21	gene	taxon:6239			
+WB	WBGene00000084	aex-1		D2030.10	gene	taxon:6239			
+WB	WBGene00000085	aex-2		T14B1.2	gene	taxon:6239			
+WB	WBGene00000086	aex-3		C02H7.3	gene	taxon:6239			
+WB	WBGene00000088	aex-5		F32A7.6|kpc-3|kpc-5	gene	taxon:6239			
+WB	WBGene00000089	aex-6		Y87G2A.4|rab-27|rab27	gene	taxon:6239			
+WB	WBGene00000090	age-1		B0334.8|daf-23	gene	taxon:6239			
+WB	WBGene00000092	ags-3		F32A6.4|ags-3.1	gene	taxon:6239			
+WB	WBGene00000093	agt-1		Y62E10A.5|cAGT-1	gene	taxon:6239			
+WB	WBGene00000094	agt-2		F09E5.13|cAGT-2|F09E5.b	gene	taxon:6239			
+WB	WBGene00000095	aha-1		C25A1.11	gene	taxon:6239			
+WB	WBGene00000096	ahr-1		C41G7.5	gene	taxon:6239			
+WB	WBGene00000097	aip-1		F58E10.4	gene	taxon:6239			
+WB	WBGene00000098	air-1		K07C11.2|let-412	gene	taxon:6239			
+WB	WBGene00000099	air-2		B0207.4|cyk-6|let-603|stu-7	gene	taxon:6239			
+WB	WBGene00000100	ajm-1		C25A11.4|H08J11.a|H08J11.b|H08J11.c|jam-1	gene	taxon:6239			
+WB	WBGene00000101	aka-1		D1022.7|kap-1	gene	taxon:6239			
+WB	WBGene00000102	akt-1		C12D8.10|akt-1a|akt-1b	gene	taxon:6239			
+WB	WBGene00000103	akt-2		F28H6.1	gene	taxon:6239			
+WB	WBGene00000105	alg-1		F48F7.1	gene	taxon:6239			
+WB	WBGene00000106	alg-2		T07D3.7|T07D3	gene	taxon:6239			
+WB	WBGene00000107	alh-1		F54D8.3	gene	taxon:6239			
+WB	WBGene00000108	alh-2		K04F1.15	gene	taxon:6239			
+WB	WBGene00000109	alh-3		F36H1.6	gene	taxon:6239			
+WB	WBGene00000110	alh-4		T05H4.13	gene	taxon:6239			
+WB	WBGene00000111	alh-5		T08B1.3	gene	taxon:6239			
+WB	WBGene00000112	alh-6		F56D12.1|xrep-2	gene	taxon:6239			
+WB	WBGene00000113	alh-7		F45H10.1	gene	taxon:6239			
+WB	WBGene00000114	alh-8		F13D12.4	gene	taxon:6239			
+WB	WBGene00000115	alh-9		F01F1.6|M80125	gene	taxon:6239			
+WB	WBGene00000116	alh-10		C54D1.4	gene	taxon:6239			
+WB	WBGene00000117	alh-11		F42G9.5	gene	taxon:6239			
+WB	WBGene00000118	alh-12		Y69F12A.2	gene	taxon:6239			
+WB	WBGene00000120	aly-1		C01F6.5|ref-1	gene	taxon:6239			
+WB	WBGene00000121	aly-2		F23B2.6|ref-2	gene	taxon:6239			
+WB	WBGene00000122	aly-3		M18.7	gene	taxon:6239			
+WB	WBGene00000123	ama-1		F36A4.7|rpb-1	gene	taxon:6239			
+WB	WBGene00000133	amt-1		C05E11.4	gene	taxon:6239			
+WB	WBGene00000134	amt-2		F49E11.3	gene	taxon:6239			
+WB	WBGene00000135	amt-3		M195.3	gene	taxon:6239			
+WB	WBGene00000136	amt-4		C05E11.5	gene	taxon:6239			
+WB	WBGene00000137	amx-1		R13G10.2	gene	taxon:6239			
+WB	WBGene00000138	amx-2		B0019.1	gene	taxon:6239			
+WB	WBGene00000139	amx-3		F25C8.2	gene	taxon:6239			
+WB	WBGene00000140	anc-1		ZK973.6|T03A1.a|T03A1.c	gene	taxon:6239			
+WB	WBGene00000142	aos-1		C08B6.9	gene	taxon:6239			
+WB	WBGene00000143	apc-2		K06H7.6	gene	taxon:6239			
+WB	WBGene00000144	apc-10		F15H10.3	gene	taxon:6239			
+WB	WBGene00000145	apc-11		F35G12.9	gene	taxon:6239			
+WB	WBGene00000146	ape-1		F46F3.4	gene	taxon:6239			
+WB	WBGene00000147	aph-1		VF36H2L.1|pen-1	gene	taxon:6239			
+WB	WBGene00000148	aph-2		ZC434.6	gene	taxon:6239			
+WB	WBGene00000149	apl-1		C42D8.8|uvt-4	gene	taxon:6239			
+WB	WBGene00000150	apm-1		F55A12.7|let-612	gene	taxon:6239			
+WB	WBGene00000151	apn-1		T05H10.2|CeAPN1	gene	taxon:6239			
+WB	WBGene00000155	app-1		W03G9.4	gene	taxon:6239			
+WB	WBGene00000156	apr-1		K04G2.8|APC	gene	taxon:6239			
+WB	WBGene00000157	aps-2		F02E8.3	gene	taxon:6239			
+WB	WBGene00000158	apg-1		Y105E8A.9|apt-1|Y105E8E.j|Y105E8E.k	gene	taxon:6239			
+WB	WBGene00000159	aps-1		F29G9.3|apt-2	gene	taxon:6239			
+WB	WBGene00000160	apb-1		Y71H2B.10|apt-3|Y71H2B.a|Y71H2_389.E	gene	taxon:6239			
+WB	WBGene00000161	apa-2		T20B5.1|apt-4	gene	taxon:6239			
+WB	WBGene00000162	apd-3		W09G10.4|apt-5	gene	taxon:6239			
+WB	WBGene00000163	apb-3		R11A5.1|apt-6	gene	taxon:6239			
+WB	WBGene00000164	apm-3		F53H8.1|apt-7	gene	taxon:6239			
+WB	WBGene00000165	aps-3		Y48G8AL.14|apt-8	gene	taxon:6239			
+WB	WBGene00000166	apt-9		W04G3.4	gene	taxon:6239			
+WB	WBGene00000168	apx-1		K08D9.3	gene	taxon:6239			
+WB	WBGene00000169	aqp-1		F32A5.5|dod-4	gene	taxon:6239			
+WB	WBGene00000170	aqp-2		C01G6.1	gene	taxon:6239			
+WB	WBGene00000171	aqp-3		Y69E1A.7	gene	taxon:6239			
+WB	WBGene00000172	aqp-4		F40F9.9	gene	taxon:6239			
+WB	WBGene00000173	aqp-5		C35A5.1	gene	taxon:6239			
+WB	WBGene00000174	aqp-6		C32C4.2	gene	taxon:6239			
+WB	WBGene00000175	aqp-7		M02F4.8	gene	taxon:6239			
+WB	WBGene00000176	aqp-8		K02G10.7	gene	taxon:6239			
+WB	WBGene00000177	aqp-9		K07A1.16	gene	taxon:6239			
+WB	WBGene00000178	aqp-10		ZK1321.3	gene	taxon:6239			
+WB	WBGene00000179	aqp-11		ZK525.2	gene	taxon:6239			
+WB	WBGene00000180	arc-1		ZK1320.6|arl-4	gene	taxon:6239			
+WB	WBGene00000181	ard-1		F01G4.2	gene	taxon:6239			
+WB	WBGene00000182	arf-1		B0336.2|arf-1.2|ARF\/1	gene	taxon:6239			
+WB	WBGene00000183	arf-5		F57H12.1|arf-3	gene	taxon:6239			
+WB	WBGene00000184	arf-6		Y116A8C.12	gene	taxon:6239			
+WB	WBGene00000185	arg-1		F31A9.3	gene	taxon:6239			
+WB	WBGene00000186	ark-1		C01C7.1|rok-1	gene	taxon:6239			
+WB	WBGene00000187	arl-1		F54C9.10	gene	taxon:6239			
+WB	WBGene00000188	arl-3		F19H8.3	gene	taxon:6239			
+WB	WBGene00000189	arl-5		ZK632.8|arl-2	gene	taxon:6239			
+WB	WBGene00000190	warf-1		F45E4.1|arf-1.1|arl-6	gene	taxon:6239			
+WB	WBGene00000192	arl-8		Y57G11C.13	gene	taxon:6239			
+WB	WBGene00000193	arl-6		C38D4.8|arl-query|bbs-3	gene	taxon:6239			
+WB	WBGene00000195	arr-1		F53H8.2	gene	taxon:6239			
+WB	WBGene00000196	aars-1		W02B12.6|alas|ars-1	gene	taxon:6239			
+WB	WBGene00000197	aars-2		F28H1.3|ars-2|let-366	gene	taxon:6239			
+WB	WBGene00000198	art-1		C15F1.6	gene	taxon:6239			
+WB	WBGene00000199	arx-1		Y71F9AL.16	gene	taxon:6239			
+WB	WBGene00000200	arx-2		K07C5.1|arp-2	gene	taxon:6239			
+WB	WBGene00000201	arx-3		Y79H2A.6	gene	taxon:6239			
+WB	WBGene00000203	arx-5		Y37D8A.1	gene	taxon:6239			
+WB	WBGene00000204	arx-6		C35D10.16	gene	taxon:6239			
+WB	WBGene00000205	arx-7		M01B12.3|M01B12.d	gene	taxon:6239			
+WB	WBGene00000206	asb-1		F35G12.10	gene	taxon:6239			
+WB	WBGene00000207	asb-2		F02E8.1	gene	taxon:6239			
+WB	WBGene00000208	trip-4		Y53F4B.15|asc-1	gene	taxon:6239			
+WB	WBGene00000209	asg-1		K07A12.3	gene	taxon:6239			
+WB	WBGene00000210	asg-2		C53B7.4	gene	taxon:6239			
+WB	WBGene00000211	asm-1		B0252.2	gene	taxon:6239			
+WB	WBGene00000212	asm-2		ZK455.4	gene	taxon:6239			
+WB	WBGene00000213	asm-3		W03G1.7	gene	taxon:6239			
+WB	WBGene00000214	asp-1		Y39B6A.20|Y39B6B.g	gene	taxon:6239			
+WB	WBGene00000215	asp-2		T18H9.2	gene	taxon:6239			
+WB	WBGene00000216	asp-3		H22K11.1	gene	taxon:6239			
+WB	WBGene00000217	asp-4		R12H7.2	gene	taxon:6239			
+WB	WBGene00000218	asp-5		F21F8.3	gene	taxon:6239			
+WB	WBGene00000219	asp-6		F21F8.7	gene	taxon:6239			
+WB	WBGene00000220	atf-2		K08F8.2	gene	taxon:6239			
+WB	WBGene00000221	atf-4		T04C10.4|atf-5	gene	taxon:6239			
+WB	WBGene00000222	atf-6		F45E6.2	gene	taxon:6239			
+WB	WBGene00000223	atf-7		C07G2.2	gene	taxon:6239			
+WB	WBGene00000224	atgp-1		F26D10.9|atg-1|tag-95	gene	taxon:6239			
+WB	WBGene00000225	atgp-2		C38C6.2|atg-2	gene	taxon:6239			
+WB	WBGene00000226	atl-1		T06E4.3|Ce-atl1	gene	taxon:6239			
+WB	WBGene00000227	atm-1		Y48G1BL.2|Y48G1BL.f	gene	taxon:6239			
+WB	WBGene00000228	atn-1		W04D2.1	gene	taxon:6239			
+WB	WBGene00000229	atp-2		C34E10.6	gene	taxon:6239			
+WB	WBGene00000230	atp-3		F27C1.7	gene	taxon:6239			
+WB	WBGene00000231	atx-2		D2045.1	gene	taxon:6239			
+WB	WBGene00000232	avr-14		B0207.12|gbr-2|Q17369	gene	taxon:6239			
+WB	WBGene00000233	avr-15		R11G10.1	gene	taxon:6239			
+WB	WBGene00000235	baf-1		B0464.7|3J557|pna-1	gene	taxon:6239			
+WB	WBGene00000236	bag-1		F57B10.11	gene	taxon:6239			
+WB	WBGene00000237	bam-2		Y71F9AR.1|Y71F9AR.c	gene	taxon:6239			
+WB	WBGene00000238	bar-1		C54D1.6|pvl-1|spy-1	gene	taxon:6239			
+WB	WBGene00000239	bas-1		C05D2.4	gene	taxon:6239			
+WB	WBGene00000240	pah-1		K08F8.4|AAH\/1|bas-2	gene	taxon:6239			
+WB	WBGene00000241	bbs-1		Y105E8A.5|Y105E8E.c	gene	taxon:6239			
+WB	WBGene00000242	bbs-2		F20D12.3	gene	taxon:6239			
+WB	WBGene00000244	bbs-8		T25F10.5|olrn-2	gene	taxon:6239			
+WB	WBGene00000245	bca-1		T13C5.5	gene	taxon:6239			
+WB	WBGene00000246	bcc-1		M7.3	gene	taxon:6239			
+WB	WBGene00000247	bec-1		T19E7.3|atg-6	gene	taxon:6239			
+WB	WBGene00000248	ben-1		C54C6.2|tbb-5	gene	taxon:6239			
+WB	WBGene00000249	bir-1		T27F2.3	gene	taxon:6239			
+WB	WBGene00000250	bir-2		C50B8.2	gene	taxon:6239			
+WB	WBGene00000251	bli-1		C09G5.6	gene	taxon:6239			
+WB	WBGene00000252	bli-2		F59E12.12	gene	taxon:6239			
+WB	WBGene00000253	bli-3		F56C11.1|duox-1|tag-31	gene	taxon:6239			
+WB	WBGene00000254	bli-4		K04F10.4|kpc-4|let-77	gene	taxon:6239			
+WB	WBGene00000255	bli-5		F45G2.5	gene	taxon:6239			
+WB	WBGene00000256	bli-6		Y73B6BL.34|col-112	gene	taxon:6239			
+WB	WBGene00000257	bmk-1		F23B12.8|klp-14	gene	taxon:6239			
+WB	WBGene00000259	bpl-1		F13H8.10	gene	taxon:6239			
+WB	WBGene00000262	bra-1		F54B11.6	gene	taxon:6239			
+WB	WBGene00000263	F23H11.5			gene	taxon:6239			
+WB	WBGene00000264	brc-1		C36A4.8	gene	taxon:6239			
+WB	WBGene00000265	brd-1		K04C2.4|K04C2.a|K04C2.b	gene	taxon:6239			
+WB	WBGene00000266	bre-1		C53B4.7|gmd-1	gene	taxon:6239			
+WB	WBGene00000267	bre-2		Y39E4B.9	gene	taxon:6239			
+WB	WBGene00000268	bre-3		B0464.4	gene	taxon:6239			
+WB	WBGene00000269	bre-4		Y73E7A.7	gene	taxon:6239			
+WB	WBGene00000270	bre-5		T12G3.8	gene	taxon:6239			
+WB	WBGene00000271	brf-1		F45E12.2	gene	taxon:6239			
+WB	WBGene00000272	bro-1		F56A3.5	gene	taxon:6239			
+WB	WBGene00000273	brp-1		Y79H2A.1|pqn-93	gene	taxon:6239			
+WB	WBGene00000274	btf-1		F15D4.1	gene	taxon:6239			
+WB	WBGene00000275	bub-1		R06C7.8	gene	taxon:6239			
+WB	WBGene00000277	cab-1		C23H4.1	gene	taxon:6239			
+WB	WBGene00000278	cad-1			gene	taxon:6239			
+WB	WBGene00000279	cah-1		F54D8.4	gene	taxon:6239			
+WB	WBGene00000280	cah-2		D1022.8	gene	taxon:6239			
+WB	WBGene00000281	cah-3		K05G3.3	gene	taxon:6239			
+WB	WBGene00000282	cah-4		R01E6.3	gene	taxon:6239			
+WB	WBGene00000283	cah-5		R173.1	gene	taxon:6239			
+WB	WBGene00000284	cah-6		T28F2.3	gene	taxon:6239			
+WB	WBGene00000285	cal-1		C13C12.1	gene	taxon:6239			
+WB	WBGene00000286	cal-2		C18E9.1	gene	taxon:6239			
+WB	WBGene00000287	cal-3		M02B7.6	gene	taxon:6239			
+WB	WBGene00000288	cal-4		T07G12.1	gene	taxon:6239			
+WB	WBGene00000289	cam-1		C01G6.8|kin-8	gene	taxon:6239			
+WB	WBGene00000292	cap-1		D2024.6|CAPZ\/A	gene	taxon:6239			
+WB	WBGene00000293	cap-2		M106.5|CAPZ\/B	gene	taxon:6239			
+WB	WBGene00000294	cas-1		F41G4.2|cah-1	gene	taxon:6239			
+WB	WBGene00000295	cat-1		W01C8.6	gene	taxon:6239			
+WB	WBGene00000296	cat-2		B0432.5	gene	taxon:6239			
+WB	WBGene00000298	cat-4		F32G8.6|gtpch-1	gene	taxon:6239			
+WB	WBGene00000300	cat-6			gene	taxon:6239			
+WB	WBGene00000301	cav-1		T13F2.8	gene	taxon:6239			
+WB	WBGene00000302	cav-2		C56A3.7	gene	taxon:6239			
+WB	WBGene00000366	cbp-1		R10E11.1|CBD|cep-1	gene	taxon:6239			
+WB	WBGene00000367	cca-1		C54D2.5	gene	taxon:6239			
+WB	WBGene00000368	ccb-1		T28F2.5|let-152	gene	taxon:6239			
+WB	WBGene00000369	ccf-1		Y56A3A.20	gene	taxon:6239			
+WB	WBGene00000371	cox-5B		F26E4.9|cco-1|lpd-4	gene	taxon:6239			
+WB	WBGene00000372	cyp-13A7		T10B9.10|ccp-13A7	gene	taxon:6239			
+WB	WBGene00000373	cyp-14A5		F08F3.7|ccp-14A5	gene	taxon:6239			
+WB	WBGene00000375	cyp-44A1		ZK177.5|ccp-44|cyp-44	gene	taxon:6239			
+WB	WBGene00000376	ccr-4		ZC518.3	gene	taxon:6239			
+WB	WBGene00000377	cct-1		T05C12.7|tcp-1	gene	taxon:6239			
+WB	WBGene00000378	cct-2		T21B10.7	gene	taxon:6239			
+WB	WBGene00000379	cct-4		K01C8.10	gene	taxon:6239			
+WB	WBGene00000380	cct-5		C07G2.3	gene	taxon:6239			
+WB	WBGene00000381	cct-6		F01F1.8	gene	taxon:6239			
+WB	WBGene00000382	cdc-6		C43E11.10	gene	taxon:6239			
+WB	WBGene00000383	cdc-14		C17G10.4|cdc14	gene	taxon:6239			
+WB	WBGene00000386	cdc-25.1		K06A5.7|lin-60	gene	taxon:6239			
+WB	WBGene00000387	cdc-25.2		F16B4.8|emb-29	gene	taxon:6239			
+WB	WBGene00000388	cdc-25.3		ZK637.11	gene	taxon:6239			
+WB	WBGene00000389	cdc-25.4		R05H5.2	gene	taxon:6239			
+WB	WBGene00000390	cdc-42		R07G3.1|CDC42Ce	gene	taxon:6239			
+WB	WBGene00000391	cdd-1		C47D2.2|tag-17	gene	taxon:6239			
+WB	WBGene00000392	cdd-2		F49E8.4	gene	taxon:6239			
+WB	WBGene00000393	cdf-1		C15B12.7	gene	taxon:6239			
+WB	WBGene00000395	cdh-3		ZK112.7	gene	taxon:6239			
+WB	WBGene00000396	cdh-4		F25F2.2	gene	taxon:6239			
+WB	WBGene00000397	cdh-5		F08B4.2	gene	taxon:6239			
+WB	WBGene00000399	cdh-7		R05H10.6	gene	taxon:6239			
+WB	WBGene00000401	cdh-9		F59C12.1	gene	taxon:6239			
+WB	WBGene00000402	cdh-10		C45G7.5	gene	taxon:6239			
+WB	WBGene00000403	casy-1		B0034.3|cdh-11	gene	taxon:6239			
+WB	WBGene00000405	cdk-1		T05G5.3|ncc-1	gene	taxon:6239			
+WB	WBGene00000406	cdk-4		F18H3.5	gene	taxon:6239			
+WB	WBGene00000407	cdk-5		T27E9.3	gene	taxon:6239			
+WB	WBGene00000408	cdk-7		Y39G10AL.3	gene	taxon:6239			
+WB	WBGene00000409	cdk-8		F39H11.3	gene	taxon:6239			
+WB	WBGene00000410	cdk-9		H25P06.2	gene	taxon:6239			
+WB	WBGene00000411	cdl-1		R06F6.1|hbp	gene	taxon:6239			
+WB	WBGene00000412	cdr-1		F35E8.11	gene	taxon:6239			
+WB	WBGene00000413	cdt-1		Y54E10A.15	gene	taxon:6239			
+WB	WBGene00000414	cec-1		ZK1236.2	gene	taxon:6239			
+WB	WBGene00000415	ced-1		Y47H9C.4	gene	taxon:6239			
+WB	WBGene00000416	ced-2		Y41D4B.13	gene	taxon:6239			
+WB	WBGene00000417	ced-3		C48D1.2	gene	taxon:6239			
+WB	WBGene00000418	ced-4		C35D10.9	gene	taxon:6239			
+WB	WBGene00000419	ced-5		C02F4.1	gene	taxon:6239			
+WB	WBGene00000420	ced-6		F56D2.7	gene	taxon:6239			
+WB	WBGene00000421	ced-7		C48B4.4	gene	taxon:6239			
+WB	WBGene00000422	ced-8		F08F1.5	gene	taxon:6239			
+WB	WBGene00000423	ced-9		T07C4.8	gene	taxon:6239			
+WB	WBGene00000424	ced-10		C09G12.8|C09G12.8B|CErac1|rac1	gene	taxon:6239			
+WB	WBGene00000425	ced-11		ZK512.3	gene	taxon:6239			
+WB	WBGene00000426	ced-12		Y106G6E.5|mig-16	gene	taxon:6239			
+WB	WBGene00000427	ced-13		R09F10.9|cip-1	gene	taxon:6239			
+WB	WBGene00000428	ceh-1		F16H11.4	gene	taxon:6239			
+WB	WBGene00000429	ceh-2		C27A12.5	gene	taxon:6239			
+WB	WBGene00000430	ceh-5		C16C2.1	gene	taxon:6239			
+WB	WBGene00000431	ceh-6		K02B12.1	gene	taxon:6239			
+WB	WBGene00000432	ceh-7		C34C6.8	gene	taxon:6239			
+WB	WBGene00000433	ceh-8		ZK265.4	gene	taxon:6239			
+WB	WBGene00000434	ceh-9		Y65B4BR.9	gene	taxon:6239			
+WB	WBGene00000435	ceh-10		W03A3.1|mig-11	gene	taxon:6239			
+WB	WBGene00000436	ceh-12		F33D11.4	gene	taxon:6239			
+WB	WBGene00000437	ceh-13		R13A5.5	gene	taxon:6239			
+WB	WBGene00000438	ceh-14		F46C8.5	gene	taxon:6239			
+WB	WBGene00000439	ceh-16		C13G5.1	gene	taxon:6239			
+WB	WBGene00000440	ceh-17		D1007.1|ceh-42	gene	taxon:6239			
+WB	WBGene00000441	ceh-18		ZC64.3	gene	taxon:6239			
+WB	WBGene00000442	ceh-19		F20D12.6	gene	taxon:6239			
+WB	WBGene00000443	ceh-20		F31E3.1	gene	taxon:6239			
+WB	WBGene00000444	ceh-21		T26C11.6	gene	taxon:6239			
+WB	WBGene00000445	ceh-22		F29F11.5|sys-3	gene	taxon:6239			
+WB	WBGene00000446	ceh-23		ZK652.5	gene	taxon:6239			
+WB	WBGene00000447	ceh-24		F55B12.1	gene	taxon:6239			
+WB	WBGene00000448	pros-1		K12H4.1|ceh-26|rdy-3	gene	taxon:6239			
+WB	WBGene00000449	ceh-27		F46F3.1	gene	taxon:6239			
+WB	WBGene00000450	ceh-28		K03A11.3	gene	taxon:6239			
+WB	WBGene00000451	ceh-30		C33D12.7	gene	taxon:6239			
+WB	WBGene00000452	ceh-31		C33D12.1	gene	taxon:6239			
+WB	WBGene00000453	ceh-32		W05E10.3	gene	taxon:6239			
+WB	WBGene00000454	ceh-33		C10G8.7	gene	taxon:6239			
+WB	WBGene00000455	ceh-34		C10G8.6	gene	taxon:6239			
+WB	WBGene00000457	ceh-36		C37E2.4	gene	taxon:6239			
+WB	WBGene00000458	ceh-37		C37E2.5	gene	taxon:6239			
+WB	WBGene00000459	ceh-38		F22D3.1	gene	taxon:6239			
+WB	WBGene00000460	ceh-39		T26C11.7	gene	taxon:6239			
+WB	WBGene00000461	ceh-40		F17A2.5	gene	taxon:6239			
+WB	WBGene00000462	ceh-41		T26C11.5	gene	taxon:6239			
+WB	WBGene00000463	ceh-43		C28A5.4|dopy-2	gene	taxon:6239			
+WB	WBGene00000464	ceh-44		Y54F10AM.4	gene	taxon:6239			
+WB	WBGene00000465	cpg-1		C07G2.1|cej-1	gene	taxon:6239			
+WB	WBGene00000466	cel-1		C03D6.3	gene	taxon:6239			
+WB	WBGene00000467	cep-1		F52B5.5	gene	taxon:6239			
+WB	WBGene00000468	ces-1		F43G9.11	gene	taxon:6239			
+WB	WBGene00000469	ces-2		ZK909.4	gene	taxon:6239			
+WB	WBGene00000472	cey-1		F33A8.3	gene	taxon:6239			
+WB	WBGene00000473	cey-2		F46F11.2	gene	taxon:6239			
+WB	WBGene00000474	cey-3		M01E11.5	gene	taxon:6239			
+WB	WBGene00000475	cey-4		Y39A1C.3	gene	taxon:6239			
+WB	WBGene00000476	cfi-1		T23D8.8	gene	taxon:6239			
+WB	WBGene00000477	cft-1		C18C4.2|C18C4.e	gene	taxon:6239			
+WB	WBGene00000478	cfz-2		F27E11.3	gene	taxon:6239			
+WB	WBGene00000479	cgh-1		C07H6.5	gene	taxon:6239			
+WB	WBGene00000480	cgp-1		Y38C9A.2	gene	taxon:6239			
+WB	WBGene00000481	cha-1		ZC416.8	gene	taxon:6239			
+WB	WBGene00000482	chd-3		T14G8.1	gene	taxon:6239			
+WB	WBGene00000483	che-1		C55B7.12|tax-1|tax-5	gene	taxon:6239			
+WB	WBGene00000484	che-2		F38G1.1	gene	taxon:6239			
+WB	WBGene00000485	che-3		F18C12.1|avr-1|caf-2|che-8|dhc-2|osm-2	gene	taxon:6239			
+WB	WBGene00000487	che-6		C23H5.7|cng-4	gene	taxon:6239			
+WB	WBGene00000488	che-7		F26D11.10|inx-4	gene	taxon:6239			
+WB	WBGene00000490	che-11		C27A7.4|ift-140|mev-4	gene	taxon:6239			
+WB	WBGene00000491	che-12		B0024.8	gene	taxon:6239			
+WB	WBGene00000492	che-13		F59C6.7|che-9	gene	taxon:6239			
+WB	WBGene00000493	che-14		F56H1.1|ptd-1	gene	taxon:6239			
+WB	WBGene00000496	chs-1		T25G3.2|chi-1|chs-2	gene	taxon:6239			
+WB	WBGene00000497	chs-2		F48A11.1|chi-2|chs-1	gene	taxon:6239			
+WB	WBGene00000498	chk-1		Y39H10A.7|Y39H10A.a	gene	taxon:6239			
+WB	WBGene00000499	chk-2		Y60A3A.12|cds-1|Ce-cds-1|Ce-chk-2	gene	taxon:6239			
+WB	WBGene00000500	chn-1		T09B4.10|1G758|tag-69	gene	taxon:6239			
+WB	WBGene00000501	cho-1		C48D1.3	gene	taxon:6239			
+WB	WBGene00000502	chp-1		Y110A7A.13|chp	gene	taxon:6239			
+WB	WBGene00000503	cht-1		C04F6.3|CHT1	gene	taxon:6239			
+WB	WBGene00000504	cib-1			gene	taxon:6239			
+WB	WBGene00000506	cic-1		H14E04.5	gene	taxon:6239			
+WB	WBGene00000507	cit-1.1		F44B9.4	gene	taxon:6239			
+WB	WBGene00000508	cit-1.2		F44B9.3	gene	taxon:6239			
+WB	WBGene00000509	cka-1		C28D4.2	gene	taxon:6239			
+WB	WBGene00000510	cka-2		C52B9.1	gene	taxon:6239			
+WB	WBGene00000511	ckb-1		B0285.8	gene	taxon:6239			
+WB	WBGene00000512	ckb-2		B0285.9	gene	taxon:6239			
+WB	WBGene00000513	ckb-3		B0285.10	gene	taxon:6239			
+WB	WBGene00000514	ckb-4		F22F7.5	gene	taxon:6239			
+WB	WBGene00000515	ckc-1		T27A10.3	gene	taxon:6239			
+WB	WBGene00000516	cki-1		T05A6.1	gene	taxon:6239			
+WB	WBGene00000517	cki-2		T05A6.2	gene	taxon:6239			
+WB	WBGene00000518	ckk-1		C05H8.1	gene	taxon:6239			
+WB	WBGene00000519	cku-70		Y47D3A.4|Y47D3A.g	gene	taxon:6239			
+WB	WBGene00000520	cku-80		R07E5.8	gene	taxon:6239			
+WB	WBGene00000521	cky-1		C15C8.2|cNXFL	gene	taxon:6239			
+WB	WBGene00000522	clc-1		C09F12.1	gene	taxon:6239			
+WB	WBGene00000523	clc-2		C01C10.1	gene	taxon:6239			
+WB	WBGene00000524	clc-3		ZK563.4	gene	taxon:6239			
+WB	WBGene00000525	clc-4		T05A10.2	gene	taxon:6239			
+WB	WBGene00000526	clc-5		C01C10.4	gene	taxon:6239			
+WB	WBGene00000527	cle-1		C36B1.1|cpg-10	gene	taxon:6239			
+WB	WBGene00000528	clh-1		T27D12.2	gene	taxon:6239			
+WB	WBGene00000529	clh-2		B0491.8|ceclc-2|clc-2	gene	taxon:6239			
+WB	WBGene00000530	clh-3		E04F6.11|ceclc-3	gene	taxon:6239			
+WB	WBGene00000531	clh-4		T06F4.2|T06F4.a|T06F4.b	gene	taxon:6239			
+WB	WBGene00000532	clh-5		C07H4.2	gene	taxon:6239			
+WB	WBGene00000533	clh-6		R07B7.1|cup-12	gene	taxon:6239			
+WB	WBGene00000534	cpi-2		R01B10.1|cli-1	gene	taxon:6239			
+WB	WBGene00000535	cpi-1		K08B4.6|cli-2	gene	taxon:6239			
+WB	WBGene00000536	clk-1		ZC395.2|coq-1|coq-7	gene	taxon:6239			
+WB	WBGene00000537	clk-2		C07H6.6|rad-5	gene	taxon:6239			
+WB	WBGene00000538	clk-3			gene	taxon:6239			
+WB	WBGene00000539	cln-3.1		F07B10.1	gene	taxon:6239			
+WB	WBGene00000540	cln-3.2		C01G8.2	gene	taxon:6239			
+WB	WBGene00000541	cln-3.3		ZC190.1	gene	taxon:6239			
+WB	WBGene00000542	clp-1		C06G4.2	gene	taxon:6239			
+WB	WBGene00000543	clp-2		T04A8.16	gene	taxon:6239			
+WB	WBGene00000544	clp-3		Y47H10A.1	gene	taxon:6239			
+WB	WBGene00000545	clp-4		Y39A3CL.5	gene	taxon:6239			
+WB	WBGene00000546	clp-6		Y77E11A.10	gene	taxon:6239			
+WB	WBGene00000547	clp-7		Y77E11A.11	gene	taxon:6239			
+WB	WBGene00000548	clr-1		F56D1.4|F56D1.g	gene	taxon:6239			
+WB	WBGene00000549	cls-2		R107.6	gene	taxon:6239			
+WB	WBGene00000550	clu-1		F55H2.6	gene	taxon:6239			
+WB	WBGene00000551	clx-1		C50F7.2|col-4	gene	taxon:6239			
+WB	WBGene00000552	cmd-1		T21H3.3	gene	taxon:6239			
+WB	WBGene00000553	cmk-1		K07A9.2|Ce-CaM-KI	gene	taxon:6239			
+WB	WBGene00000554	cnb-1		F55C10.1	gene	taxon:6239			
+WB	WBGene00000555	cnc-1		R09B5.2	gene	taxon:6239			
+WB	WBGene00000556	cnc-2		R09B5.3	gene	taxon:6239			
+WB	WBGene00000558	cnc-4		R09B5.9	gene	taxon:6239			
+WB	WBGene00000559	cnc-5		R09B5.10	gene	taxon:6239			
+WB	WBGene00000560	cnc-6		Y46E12A.1|Y46E12A.d	gene	taxon:6239			
+WB	WBGene00000561	cnd-1		C34E10.7|C34E10|C34E10.d|CeND|hlh-5	gene	taxon:6239			
+WB	WBGene00000562	cng-1		F14H8.6	gene	taxon:6239			
+WB	WBGene00000563	cng-3		F38E11.12	gene	taxon:6239			
+WB	WBGene00000564	cnk-1		R01H10.8	gene	taxon:6239			
+WB	WBGene00000565	cnt-1		Y17G7B.15|cnt-1A|cnt-1B|cps-2	gene	taxon:6239			
+WB	WBGene00000566	cnt-2		Y39A1A.15|cnt-2a|cnt-2b	gene	taxon:6239			
+WB	WBGene00000567	cnx-1		ZK632.6	gene	taxon:6239			
+WB	WBGene00000583	cof-2		C48E7.5|col-57|ofm-2	gene	taxon:6239			
+WB	WBGene00000584	cog-1		R03C1.3	gene	taxon:6239			
+WB	WBGene00000585	cogc-2		C06G3.10|cgo-2|cog2	gene	taxon:6239			
+WB	WBGene00000591	coh-1		K08A8.3|rad-21.2	gene	taxon:6239			
+WB	WBGene00000592	coh-3		F08H9.1	gene	taxon:6239			
+WB	WBGene00000593	col-2		W01B6.7	gene	taxon:6239			
+WB	WBGene00000594	col-3		T28C6.6|col-117	gene	taxon:6239			
+WB	WBGene00000596	col-7		C15A11.5|col7	gene	taxon:6239			
+WB	WBGene00000597	col-8		F11H8.3|col8	gene	taxon:6239			
+WB	WBGene00000598	col-9		F54B11.1	gene	taxon:6239			
+WB	WBGene00000599	col-10		B0222.8	gene	taxon:6239			
+WB	WBGene00000601	col-12		F15H10.1	gene	taxon:6239			
+WB	WBGene00000602	col-13		F15H10.2	gene	taxon:6239			
+WB	WBGene00000603	col-14		C46A5.3|col14	gene	taxon:6239			
+WB	WBGene00000606	col-17		F11G11.10	gene	taxon:6239			
+WB	WBGene00000608	col-19		ZK1193.1|col19	gene	taxon:6239			
+WB	WBGene00000609	col-20		F11G11.11	gene	taxon:6239			
+WB	WBGene00000610	col-33		F36A4.6	gene	taxon:6239			
+WB	WBGene00000611	col-34		F36A4.10|alpha-collagen|ram-4	gene	taxon:6239			
+WB	WBGene00000612	col-35		C15A11.1	gene	taxon:6239			
+WB	WBGene00000613	col-36		C27H5.5	gene	taxon:6239			
+WB	WBGene00000614	col-37		ZK863.2	gene	taxon:6239			
+WB	WBGene00000615	col-38		F54C9.4	gene	taxon:6239			
+WB	WBGene00000616	col-39		C09G5.4	gene	taxon:6239			
+WB	WBGene00000617	col-40		T13B5.4	gene	taxon:6239			
+WB	WBGene00000618	col-41		T10B10.1	gene	taxon:6239			
+WB	WBGene00000620	col-43		ZC513.8	gene	taxon:6239			
+WB	WBGene00000621	col-44		F54B11.2	gene	taxon:6239			
+WB	WBGene00000622	col-45		F53G12.7	gene	taxon:6239			
+WB	WBGene00000623	col-46		Y18H1A.13	gene	taxon:6239			
+WB	WBGene00000624	col-47		Y18H1A.12	gene	taxon:6239			
+WB	WBGene00000625	col-48		Y54E10BL.2	gene	taxon:6239			
+WB	WBGene00000626	col-49		K09H9.3	gene	taxon:6239			
+WB	WBGene00000627	col-50		T28F2.6	gene	taxon:6239			
+WB	WBGene00000628	col-51		T28F2.8	gene	taxon:6239			
+WB	WBGene00000629	col-52		D1007.2	gene	taxon:6239			
+WB	WBGene00000630	col-53		M01A12.1	gene	taxon:6239			
+WB	WBGene00000631	col-54		F33D11.3	gene	taxon:6239			
+WB	WBGene00000632	col-55		T05E7.2	gene	taxon:6239			
+WB	WBGene00000633	col-56		T08B2.2	gene	taxon:6239			
+WB	WBGene00000634	col-58		F26B1.4	gene	taxon:6239			
+WB	WBGene00000636	col-60		F22D6.10	gene	taxon:6239			
+WB	WBGene00000637	col-61		C01H6.1	gene	taxon:6239			
+WB	WBGene00000638	col-62		C15A11.6	gene	taxon:6239			
+WB	WBGene00000639	col-63		ZK265.2	gene	taxon:6239			
+WB	WBGene00000640	col-64		F52F12.2	gene	taxon:6239			
+WB	WBGene00000641	col-65		K08C9.4	gene	taxon:6239			
+WB	WBGene00000644	col-68		C50D2.4	gene	taxon:6239			
+WB	WBGene00000645	col-69		K01A2.7	gene	taxon:6239			
+WB	WBGene00000647	col-71		Y49F6B.10|Y49F6B.p	gene	taxon:6239			
+WB	WBGene00000648	col-72		W09G10.1	gene	taxon:6239			
+WB	WBGene00000649	col-73		F11G11.12	gene	taxon:6239			
+WB	WBGene00000650	col-74		ZK1248.2	gene	taxon:6239			
+WB	WBGene00000651	col-75		K03H9.2	gene	taxon:6239			
+WB	WBGene00000652	col-76		M110.1	gene	taxon:6239			
+WB	WBGene00000653	col-77		M195.1	gene	taxon:6239			
+WB	WBGene00000654	col-78		W07A12.5	gene	taxon:6239			
+WB	WBGene00000655	col-79		C09G5.3	gene	taxon:6239			
+WB	WBGene00000656	col-80		C09G5.5	gene	taxon:6239			
+WB	WBGene00000657	col-81		F38A3.1	gene	taxon:6239			
+WB	WBGene00000658	col-83		F33A8.9	gene	taxon:6239			
+WB	WBGene00000659	col-84		K12D12.3	gene	taxon:6239			
+WB	WBGene00000660	col-85		T21B4.2	gene	taxon:6239			
+WB	WBGene00000661	col-86		Y81G3A.5	gene	taxon:6239			
+WB	WBGene00000662	col-87		Y39G8C.4	gene	taxon:6239			
+WB	WBGene00000663	col-88		W05G11.3	gene	taxon:6239			
+WB	WBGene00000664	col-89		F17C8.2	gene	taxon:6239			
+WB	WBGene00000665	col-90		C29E4.1	gene	taxon:6239			
+WB	WBGene00000666	col-91		F09G8.6	gene	taxon:6239			
+WB	WBGene00000667	col-92		W05B2.6	gene	taxon:6239			
+WB	WBGene00000668	col-93		W05B2.5	gene	taxon:6239			
+WB	WBGene00000669	col-94		W05B2.1	gene	taxon:6239			
+WB	WBGene00000670	col-95		Y41C4A.16	gene	taxon:6239			
+WB	WBGene00000671	col-96		Y41C4A.19	gene	taxon:6239			
+WB	WBGene00000672	col-97		ZK1010.7	gene	taxon:6239			
+WB	WBGene00000673	col-98		F14F7.1	gene	taxon:6239			
+WB	WBGene00000674	col-99		F29C4.8|Y38C1AA.c	gene	taxon:6239			
+WB	WBGene00000675	col-101		K02D7.3	gene	taxon:6239			
+WB	WBGene00000676	col-102		C18H7.3	gene	taxon:6239			
+WB	WBGene00000677	col-103		F56B3.1	gene	taxon:6239			
+WB	WBGene00000678	col-104		F58F6.1	gene	taxon:6239			
+WB	WBGene00000679	col-105		F58F6.2	gene	taxon:6239			
+WB	WBGene00000680	col-106		Y77E11A.15	gene	taxon:6239			
+WB	WBGene00000681	col-107		C34H4.4	gene	taxon:6239			
+WB	WBGene00000682	col-108		Y41D4A.2	gene	taxon:6239			
+WB	WBGene00000683	col-109		Y38C1BA.3	gene	taxon:6239			
+WB	WBGene00000684	col-110		F19C7.7	gene	taxon:6239			
+WB	WBGene00000685	col-111		F29B9.9	gene	taxon:6239			
+WB	WBGene00000687	col-113		C34D4.15	gene	taxon:6239			
+WB	WBGene00000688	col-114		D2024.8	gene	taxon:6239			
+WB	WBGene00000689	col-115		Y42H9B.1|Y42H9B.c	gene	taxon:6239			
+WB	WBGene00000690	col-116		F17E9.1	gene	taxon:6239			
+WB	WBGene00000691	col-117		T28C6.4|col-3	gene	taxon:6239			
+WB	WBGene00000692	col-118		T11B7.3	gene	taxon:6239			
+WB	WBGene00000693	col-119		C53B4.5	gene	taxon:6239			
+WB	WBGene00000694	col-120		Y11D7A.11	gene	taxon:6239			
+WB	WBGene00000695	col-121		F56D5.1|bis-1	gene	taxon:6239			
+WB	WBGene00000696	col-122		T05A1.2	gene	taxon:6239			
+WB	WBGene00000697	col-123		W08D2.6	gene	taxon:6239			
+WB	WBGene00000698	col-124		C24F3.6	gene	taxon:6239			
+WB	WBGene00000699	col-125		C29F4.1	gene	taxon:6239			
+WB	WBGene00000700	col-126		F54D1.2	gene	taxon:6239			
+WB	WBGene00000701	col-127		F54D1.3	gene	taxon:6239			
+WB	WBGene00000702	col-128		F12F6.9	gene	taxon:6239			
+WB	WBGene00000703	col-129		M18.1	gene	taxon:6239			
+WB	WBGene00000704	col-130		F08G5.4	gene	taxon:6239			
+WB	WBGene00000705	col-131		C39E9.3	gene	taxon:6239			
+WB	WBGene00000706	col-132		C39E9.9	gene	taxon:6239			
+WB	WBGene00000707	col-133		F52B11.4	gene	taxon:6239			
+WB	WBGene00000708	col-135		M199.5	gene	taxon:6239			
+WB	WBGene00000710	col-137		Y51H4A.9	gene	taxon:6239			
+WB	WBGene00000711	col-138		C52D10.13	gene	taxon:6239			
+WB	WBGene00000712	col-139		F41F3.4	gene	taxon:6239			
+WB	WBGene00000713	col-140		F26F12.1	gene	taxon:6239			
+WB	WBGene00000714	col-141		T15B7.5	gene	taxon:6239			
+WB	WBGene00000715	col-142		T15B7.4	gene	taxon:6239			
+WB	WBGene00000716	col-143		T15B7.3	gene	taxon:6239			
+WB	WBGene00000717	col-144		B0222.6	gene	taxon:6239			
+WB	WBGene00000718	col-145		B0222.7	gene	taxon:6239			
+WB	WBGene00000719	col-146		T06E4.6	gene	taxon:6239			
+WB	WBGene00000720	col-147		T06E4.4	gene	taxon:6239			
+WB	WBGene00000721	col-148		C12D8.8	gene	taxon:6239			
+WB	WBGene00000722	col-149		B0024.1	gene	taxon:6239			
+WB	WBGene00000723	col-150		B0024.2	gene	taxon:6239			
+WB	WBGene00000724	col-151		AC3.6	gene	taxon:6239			
+WB	WBGene00000725	col-152		F32G8.5	gene	taxon:6239			
+WB	WBGene00000726	col-153		F17C11.3	gene	taxon:6239			
+WB	WBGene00000727	col-154		F55C10.2	gene	taxon:6239			
+WB	WBGene00000728	col-155		F55C10.3	gene	taxon:6239			
+WB	WBGene00000729	col-156		F57B7.3	gene	taxon:6239			
+WB	WBGene00000730	col-157		T11F9.9	gene	taxon:6239			
+WB	WBGene00000731	col-158		D2023.7	gene	taxon:6239			
+WB	WBGene00000732	col-159		F57B1.3	gene	taxon:6239			
+WB	WBGene00000733	col-160		F57B1.4	gene	taxon:6239			
+WB	WBGene00000734	col-161		C50B6.4	gene	taxon:6239			
+WB	WBGene00000735	col-162		Y2H9A.3	gene	taxon:6239			
+WB	WBGene00000736	col-163		F46B3.17	gene	taxon:6239			
+WB	WBGene00000737	col-164		T21D9.1|cpg-11	gene	taxon:6239			
+WB	WBGene00000738	col-165		F14H12.1	gene	taxon:6239			
+WB	WBGene00000739	col-166		T07H6.3	gene	taxon:6239			
+WB	WBGene00000740	col-167		T10E10.2|T10E10.d	gene	taxon:6239			
+WB	WBGene00000741	col-168		T10E10.1	gene	taxon:6239			
+WB	WBGene00000742	col-169		T10E10.5|T10E10.f	gene	taxon:6239			
+WB	WBGene00000743	col-170		T10E10.6|T10E10.e	gene	taxon:6239			
+WB	WBGene00000744	col-171		T10E10.7|T10E10.a|T10E10.h	gene	taxon:6239			
+WB	WBGene00000745	col-172		F38B6.5	gene	taxon:6239			
+WB	WBGene00000746	col-173		F41C6.5	gene	taxon:6239			
+WB	WBGene00000747	col-174		F46C8.2	gene	taxon:6239			
+WB	WBGene00000748	col-175		C35B8.1	gene	taxon:6239			
+WB	WBGene00000749	col-176		ZC373.7	gene	taxon:6239			
+WB	WBGene00000750	col-177		F59F3.2	gene	taxon:6239			
+WB	WBGene00000751	col-178		C34F6.2	gene	taxon:6239			
+WB	WBGene00000752	col-179		C34F6.3	gene	taxon:6239			
+WB	WBGene00000753	col-180		C44C10.1	gene	taxon:6239			
+WB	WBGene00000754	col-181		W03G11.1	gene	taxon:6239			
+WB	WBGene00000756	col-183		F02D10.1	gene	taxon:6239			
+WB	WBGene00000757	col-184		F15A2.1	gene	taxon:6239			
+WB	WBGene00000758	col-185		H06A10.2	gene	taxon:6239			
+WB	WBGene00000759	col-186		E03G2.4	gene	taxon:6239			
+WB	WBGene00000760	col-187		C30F2.1	gene	taxon:6239			
+WB	WBGene00000761	coq-1		C24A11.9|let-370|tag-134	gene	taxon:6239			
+WB	WBGene00000762	coq-2		F57B9.4	gene	taxon:6239			
+WB	WBGene00000763	coq-3		Y57G11C.11	gene	taxon:6239			
+WB	WBGene00000764	coq-4		T03F1.2	gene	taxon:6239			
+WB	WBGene00000765	coq-5		ZK652.9	gene	taxon:6239			
+WB	WBGene00000766	coq-6		K07B1.2	gene	taxon:6239			
+WB	WBGene00000767	coq-8		C35D10.4	gene	taxon:6239			
+WB	WBGene00000768	cor-1		R01H10.3	gene	taxon:6239			
+WB	WBGene00000770	cpb-1		C40H1.1	gene	taxon:6239			
+WB	WBGene00000771	cpb-2		C30B5.3	gene	taxon:6239			
+WB	WBGene00000772	cpb-3		B0414.5	gene	taxon:6239			
+WB	WBGene00000773	cpf-1		F28C6.3	gene	taxon:6239			
+WB	WBGene00000774	cpf-2		F56A8.6	gene	taxon:6239			
+WB	WBGene00000775	cpin-1		F38E11.3|cpi-1	gene	taxon:6239			
+WB	WBGene00000776	cpl-1		T03E6.7	gene	taxon:6239			
+WB	WBGene00000779	cpn-3		F28H1.2	gene	taxon:6239			
+WB	WBGene00000781	cpr-1		C52E4.1|CPROT\/1|gcp-1	gene	taxon:6239			
+WB	WBGene00000782	cpr-2		F36D3.9|CPROT\/2	gene	taxon:6239			
+WB	WBGene00000783	cpr-3		T10H4.12	gene	taxon:6239			
+WB	WBGene00000784	cpr-4		F44C4.3	gene	taxon:6239			
+WB	WBGene00000785	cpr-5		W07B8.5	gene	taxon:6239			
+WB	WBGene00000786	cpr-6		C25B8.3	gene	taxon:6239			
+WB	WBGene00000787	cps-6		C41D11.8	gene	taxon:6239			
+WB	WBGene00000788	cpz-1		F32B5.8	gene	taxon:6239			
+WB	WBGene00000789	cpz-2		M04G12.2	gene	taxon:6239			
+WB	WBGene00000792	crb-1		F11C7.4	gene	taxon:6239			
+WB	WBGene00000793	crh-1		Y41C4A.4	gene	taxon:6239			
+WB	WBGene00000794	crn-1		Y47G6A.8|fen-1	gene	taxon:6239			
+WB	WBGene00000795	crn-2		CD4.2	gene	taxon:6239			
+WB	WBGene00000796	crn-3		C14A4.4|exos-10	gene	taxon:6239			
+WB	WBGene00000797	crn-4		AH9.2	gene	taxon:6239			
+WB	WBGene00000798	crn-5		C14A4.5|exos-5	gene	taxon:6239			
+WB	WBGene00000799	crn-6		K04H4.6	gene	taxon:6239			
+WB	WBGene00000800	cars-1		Y23H5A.7|crs-1	gene	taxon:6239			
+WB	WBGene00000802	crt-1		Y38A10A.5	gene	taxon:6239			
+WB	WBGene00000803	csb-1		F53H4.1|Cecsb	gene	taxon:6239			
+WB	WBGene00000804	csc-1		Y48E1B.12	gene	taxon:6239			
+WB	WBGene00000812	csk-1		Y48G1C.2	gene	taxon:6239			
+WB	WBGene00000813	csn-1		Y59A8A.1|Y59A8A.c	gene	taxon:6239			
+WB	WBGene00000814	csn-2		B0025.2	gene	taxon:6239			
+WB	WBGene00000815	csn-3		Y38C1AA.2	gene	taxon:6239			
+WB	WBGene00000816	csn-4		Y55F3AM.15	gene	taxon:6239			
+WB	WBGene00000817	csn-5		B0547.1	gene	taxon:6239			
+WB	WBGene00000818	csn-6		Y67H2A.6	gene	taxon:6239			
+WB	WBGene00000819	csp-1		Y48E1B.13	gene	taxon:6239			
+WB	WBGene00000820	csp-2		Y73B6BL.7	gene	taxon:6239			
+WB	WBGene00000821	csp-3		Y47H9C.6	gene	taxon:6239			
+WB	WBGene00000822	csq-1		F40E10.3	gene	taxon:6239			
+WB	WBGene00000829	ctb-1		MTCE.21|CYTB	gene	taxon:6239			
+WB	WBGene00000830	ctl-1		Y54G11A.6|cat2	gene	taxon:6239			
+WB	WBGene00000831	ctl-2		Y54G11A.5|CAT|cat1	gene	taxon:6239			
+WB	WBGene00000832	ctn-1		Y23H5A.5|Y23H5A.c	gene	taxon:6239			
+WB	WBGene00000833	cts-1		T20G5.2	gene	taxon:6239			
+WB	WBGene00000834	cua-1		Y76A2A.2|tag-21	gene	taxon:6239			
+WB	WBGene00000835	cuc-1		ZK652.11	gene	taxon:6239			
+WB	WBGene00000836	cul-1		D2045.6|lin-19	gene	taxon:6239			
+WB	WBGene00000837	cul-2		ZK520.4|ccd-3|div-3	gene	taxon:6239			
+WB	WBGene00000838	cul-3		Y108G3AL.1	gene	taxon:6239			
+WB	WBGene00000839	cul-4		F45E12.3	gene	taxon:6239			
+WB	WBGene00000840	cul-5		ZK856.1	gene	taxon:6239			
+WB	WBGene00000841	cul-6		K08E7.7	gene	taxon:6239			
+WB	WBGene00000842	cup-1			gene	taxon:6239			
+WB	WBGene00000843	cup-2		F25D7.1|der-1|tag-352	gene	taxon:6239			
+WB	WBGene00000844	cup-3			gene	taxon:6239			
+WB	WBGene00000845	cup-4		C02C2.3	gene	taxon:6239			
+WB	WBGene00000846	cup-5		R13A5.1|muc-1	gene	taxon:6239			
+WB	WBGene00000848	cup-8			gene	taxon:6239			
+WB	WBGene00000849	cup-9			gene	taxon:6239			
+WB	WBGene00000850	cup-11			gene	taxon:6239			
+WB	WBGene00000851	cut-1		C47G2.1|vmp-1	gene	taxon:6239			
+WB	WBGene00000853	cut-6		M142.2	gene	taxon:6239			
+WB	WBGene00000857	cwn-1		K10B4.6|Wnt-1	gene	taxon:6239			
+WB	WBGene00000858	cwn-2		W01B6.1|Wnt-2	gene	taxon:6239			
+WB	WBGene00000863	cya-1		ZK507.6	gene	taxon:6239			
+WB	WBGene00000865	cyb-1		ZC168.4	gene	taxon:6239			
+WB	WBGene00000866	cyb-2.1		Y43E12A.1	gene	taxon:6239			
+WB	WBGene00000867	cyb-2.2		H31G24.4	gene	taxon:6239			
+WB	WBGene00000868	cyb-3		T06E6.2|cyb-2	gene	taxon:6239			
+WB	WBGene00000869	cyc-1		C54G4.8	gene	taxon:6239			
+WB	WBGene00000870	cyd-1		Y38F1A.5	gene	taxon:6239			
+WB	WBGene00000871	cye-1		C37A2.4|evl-10|let-605	gene	taxon:6239			
+WB	WBGene00000872	cyk-1		F11H8.4	gene	taxon:6239			
+WB	WBGene00000873	cyk-2			gene	taxon:6239			
+WB	WBGene00000874	cyk-3		ZK328.1|uch-1	gene	taxon:6239			
+WB	WBGene00000875	cyk-4		K08E3.6	gene	taxon:6239			
+WB	WBGene00000876	cyl-1		C52E4.6	gene	taxon:6239			
+WB	WBGene00000877	cyn-1		Y49A3A.5|cyp-1	gene	taxon:6239			
+WB	WBGene00000878	cyn-2		ZK520.5|cyp-2	gene	taxon:6239			
+WB	WBGene00000879	cyn-3		Y75B12B.5|cyp-3	gene	taxon:6239			
+WB	WBGene00000880	cyn-4		F59E10.2|cyp-4|mog-6	gene	taxon:6239			
+WB	WBGene00000881	cyn-5		F31C3.1|cyp-5	gene	taxon:6239			
+WB	WBGene00000882	cyn-6		F42G9.2|cyp-6	gene	taxon:6239			
+WB	WBGene00000883	cyn-7		Y75B12B.2|cyp-7	gene	taxon:6239			
+WB	WBGene00000884	cyn-8		D1009.2|cyp-8	gene	taxon:6239			
+WB	WBGene00000885	cyn-9		T27D1.1|cyp-9	gene	taxon:6239			
+WB	WBGene00000886	cyn-10		B0252.4|cyp-10	gene	taxon:6239			
+WB	WBGene00000887	cyn-11		T01B7.4|cyp-11	gene	taxon:6239			
+WB	WBGene00000888	cyn-12		C34D4.12|cyp-12	gene	taxon:6239			
+WB	WBGene00000889	cyn-13		Y116A8C.34|cyp-13	gene	taxon:6239			
+WB	WBGene00000890	sig-7		F39H2.2|cyn-14|cyp-14	gene	taxon:6239			
+WB	WBGene00000891	cyn-15		Y87G2A.6|cyp-15	gene	taxon:6239			
+WB	WBGene00000892	cyn-16		Y17G7B.9|cyp-16	gene	taxon:6239			
+WB	WBGene00000894	dab-1		M110.5	gene	taxon:6239			
+WB	WBGene00000895	dac-1		B0412.1|ski-1	gene	taxon:6239			
+WB	WBGene00000896	dad-1		F57B10.10	gene	taxon:6239			
+WB	WBGene00000897	daf-1		F29C4.1	gene	taxon:6239			
+WB	WBGene00000898	daf-2		Y55D5A.5	gene	taxon:6239			
+WB	WBGene00000899	daf-3		F25E2.5	gene	taxon:6239			
+WB	WBGene00000900	daf-4		C05D2.1	gene	taxon:6239			
+WB	WBGene00000901	daf-5		W01G7.1	gene	taxon:6239			
+WB	WBGene00000902	daf-6		F31F6.5|ptr-7	gene	taxon:6239			
+WB	WBGene00000903	daf-7		B0412.2	gene	taxon:6239			
+WB	WBGene00000904	daf-8		R05D11.1|smad-1	gene	taxon:6239			
+WB	WBGene00000905	daf-9		T13C5.1|cyp-22A1|mig-8	gene	taxon:6239			
+WB	WBGene00000906	daf-10		F23B2.4|osm-4	gene	taxon:6239			
+WB	WBGene00000907	daf-11		B0240.3	gene	taxon:6239			
+WB	WBGene00000908	daf-12		F11A1.3|daf-20|mig-7|XL285	gene	taxon:6239			
+WB	WBGene00000910	daf-14		F01G10.8	gene	taxon:6239			
+WB	WBGene00000911	daf-15		C10C5.6	gene	taxon:6239			
+WB	WBGene00000912	daf-16		R13H8.1|daf-17	gene	taxon:6239			
+WB	WBGene00000913	daf-18		T07A9.6	gene	taxon:6239			
+WB	WBGene00000914	daf-19		F33H1.1|daf-24	gene	taxon:6239			
+WB	WBGene00000915	hsp-90		C47E8.5|daf-21|Hsp90|tax-3	gene	taxon:6239			
+WB	WBGene00000917	daf-25		Y48G1A.3|chb-3|Y48G1A.f	gene	taxon:6239			
+WB	WBGene00000920	daf-28		Y116F11B.1|Y116F11B.b	gene	taxon:6239			
+WB	WBGene00000923	daf-31		K07H8.3	gene	taxon:6239			
+WB	WBGene00000929	dao-3		K07E3.3	gene	taxon:6239			
+WB	WBGene00000931	dao-5		C25A1.10	gene	taxon:6239			
+WB	WBGene00000933	dap-3		C14A4.2|mrps-29	gene	taxon:6239			
+WB	WBGene00000934	dat-1		T23G5.5	gene	taxon:6239			
+WB	WBGene00000935	daz-1		F56D1.7	gene	taxon:6239			
+WB	WBGene00000936	dbl-1		T25F10.2|cet-1	gene	taxon:6239			
+WB	WBGene00000937	dbr-1		C55B7.8|Ce-dbr1|let-386	gene	taxon:6239			
+WB	WBGene00000938	dcp-66		C26C6.5	gene	taxon:6239			
+WB	WBGene00000939	dcr-1		K12H4.8|eri-4|let-740	gene	taxon:6239			
+WB	WBGene00000940	dcs-1		Y113G7A.9|DcpS|hsl-1	gene	taxon:6239			
+WB	WBGene00000941	ddp-1		Y39A3CR.4|tim-8|tin-8	gene	taxon:6239			
+WB	WBGene00000942	deb-1		ZC477.9|pat-8	gene	taxon:6239			
+WB	WBGene00000950	deg-1		C47C12.6	gene	taxon:6239			
+WB	WBGene00000951	deg-3		K03B8.9	gene	taxon:6239			
+WB	WBGene00000952	del-1		E02H4.1	gene	taxon:6239			
+WB	WBGene00000955	des-2		T26H10.1|acr-4	gene	taxon:6239			
+WB	WBGene00000958	dgk-1		C09E10.2|sag-1	gene	taxon:6239			
+WB	WBGene00000959	dgk-2		F46H6.2	gene	taxon:6239			
+WB	WBGene00000960	dgk-3		F54G8.2	gene	taxon:6239			
+WB	WBGene00000961	dgn-1		T21B6.1	gene	taxon:6239			
+WB	WBGene00000962	dhc-1		T21E12.4|let-354|spd-4	gene	taxon:6239			
+WB	WBGene00000963	dhp-1		R06C7.3|CeCRMP\/DHP-1	gene	taxon:6239			
+WB	WBGene00000964	dhp-2		C47E12.8|CeCRMP\/DHP-2	gene	taxon:6239			
+WB	WBGene00000965	dhs-1		C01G8.3	gene	taxon:6239			
+WB	WBGene00000966	dhs-2		F55A12.4	gene	taxon:6239			
+WB	WBGene00000967	dhs-3		T02E1.5	gene	taxon:6239			
+WB	WBGene00000968	dhs-4		T05F1.10	gene	taxon:6239			
+WB	WBGene00000969	dhs-5		F56D1.5|F56D1.e	gene	taxon:6239			
+WB	WBGene00000970	dhs-6		C17G10.8	gene	taxon:6239			
+WB	WBGene00000971	dhs-7		E04F6.7	gene	taxon:6239			
+WB	WBGene00000972	dhs-8		K10H10.3	gene	taxon:6239			
+WB	WBGene00000973	dhs-9		Y32H12A.3	gene	taxon:6239			
+WB	WBGene00000974	dhs-11		Y39A1A.11	gene	taxon:6239			
+WB	WBGene00000975	dhs-12		K08F4.9	gene	taxon:6239			
+WB	WBGene00000976	dhs-13		F36H9.3|NCBI: NP_503501|O16619	gene	taxon:6239			
+WB	WBGene00000977	dhs-14		R05D8.8	gene	taxon:6239			
+WB	WBGene00000978	dhs-15		R05D8.10	gene	taxon:6239			
+WB	WBGene00000979	dhs-16		C10F3.2	gene	taxon:6239			
+WB	WBGene00000980	dhs-17		F29G9.6	gene	taxon:6239			
+WB	WBGene00000981	dhs-18		C45B11.3	gene	taxon:6239			
+WB	WBGene00000982	dhs-19		T11F9.11	gene	taxon:6239			
+WB	WBGene00000983	dhs-20		F35B12.2	gene	taxon:6239			
+WB	WBGene00000984	dhs-21		R11D1.11|Q21929	gene	taxon:6239			
+WB	WBGene00000985	dhs-22		C15H11.4	gene	taxon:6239			
+WB	WBGene00000986	dhs-23		R08H2.1	gene	taxon:6239			
+WB	WBGene00000987	dhs-24		Y60A3A.10	gene	taxon:6239			
+WB	WBGene00000988	dhs-25		F09E10.3	gene	taxon:6239			
+WB	WBGene00000989	dhs-26		ZK816.5	gene	taxon:6239			
+WB	WBGene00000990	dhs-27		C04F6.5	gene	taxon:6239			
+WB	WBGene00000991	dhs-28		M03A8.1	gene	taxon:6239			
+WB	WBGene00000992	dhs-29		F27D9.6	gene	taxon:6239			
+WB	WBGene00000993	dhs-30		T25G12.7	gene	taxon:6239			
+WB	WBGene00000995	die-1		C18D1.1	gene	taxon:6239			
+WB	WBGene00000996	dif-1		F49E8.5|slc-25A20	gene	taxon:6239			
+WB	WBGene00000998	dig-1		K07E12.1|sax-8	gene	taxon:6239			
+WB	WBGene00001000	dim-1		C18A11.7	gene	taxon:6239			
+WB	WBGene00001001	dis-3		C04G2.6|tag-128	gene	taxon:6239			
+WB	WBGene00001002	div-1		R01H10.1|ccd-1|emb-16	gene	taxon:6239			
+WB	WBGene00001005	dlc-1		T26A5.9	gene	taxon:6239			
+WB	WBGene00001006	dlg-1		C25F6.2	gene	taxon:6239			
+WB	WBGene00001007	dli-1		C39E9.14	gene	taxon:6239			
+WB	WBGene00001008	dlk-1		F33E2.2	gene	taxon:6239			
+WB	WBGene00001016	dna-2		F43G6.1	gene	taxon:6239			
+WB	WBGene00001017	dnc-1		ZK593.5	gene	taxon:6239			
+WB	WBGene00001018	dnc-2		C28H8.12	gene	taxon:6239			
+WB	WBGene00001019	dnj-1		B0035.14	gene	taxon:6239			
+WB	WBGene00001020	dnj-2		B0035.2	gene	taxon:6239			
+WB	WBGene00001021	dnj-3		C01G10.12	gene	taxon:6239			
+WB	WBGene00001022	dnj-4		C01G8.4	gene	taxon:6239			
+WB	WBGene00001023	dnj-5		C04A2.7	gene	taxon:6239			
+WB	WBGene00001025	dnj-7		C55B6.2	gene	taxon:6239			
+WB	WBGene00001026	dnj-8		C56C10.13	gene	taxon:6239			
+WB	WBGene00001027	dnj-9		F11G11.7	gene	taxon:6239			
+WB	WBGene00001028	dnj-10		F22B7.5	gene	taxon:6239			
+WB	WBGene00001029	dnj-11		F38A5.13	gene	taxon:6239			
+WB	WBGene00001030	dnj-12		F39B2.10|F39B10.2	gene	taxon:6239			
+WB	WBGene00001031	dnj-13		F54D5.8	gene	taxon:6239			
+WB	WBGene00001032	dnj-14		K02G10.8	gene	taxon:6239			
+WB	WBGene00001033	dnj-15		K08D10.2	gene	taxon:6239			
+WB	WBGene00001035	dnj-17		T03F6.2	gene	taxon:6239			
+WB	WBGene00001036	dnj-18		T04A8.9	gene	taxon:6239			
+WB	WBGene00001037	dnj-19		T05C3.5|dnj-6	gene	taxon:6239			
+WB	WBGene00001038	dnj-20		T15H9.7	gene	taxon:6239			
+WB	WBGene00001039	dnj-21		T19B4.4|let-378	gene	taxon:6239			
+WB	WBGene00001042	dnj-24		W03A5.7	gene	taxon:6239			
+WB	WBGene00001043	dnj-25		W07A8.3|Ce-auxilin	gene	taxon:6239			
+WB	WBGene00001044	dnj-26		Y39C12A.8	gene	taxon:6239			
+WB	WBGene00001045	dnj-27		Y47H9C.5	gene	taxon:6239			
+WB	WBGene00001046	dnj-28		Y54E10BL.4	gene	taxon:6239			
+WB	WBGene00001047	dnj-29		Y63D3A.6	gene	taxon:6239			
+WB	WBGene00001049	dog-1		F33H2.1	gene	taxon:6239			
+WB	WBGene00001050	dom-3		F54C1.2	gene	taxon:6239			
+WB	WBGene00001051	cks-1		C09G4.3|dom-6	gene	taxon:6239			
+WB	WBGene00001052	dop-1		F15A8.5	gene	taxon:6239			
+WB	WBGene00001053	dop-2		K09G1.4|dop-2L	gene	taxon:6239			
+WB	WBGene00001054	dpf-1		T23F1.7	gene	taxon:6239			
+WB	WBGene00001055	dpf-2		C27C12.7	gene	taxon:6239			
+WB	WBGene00001056	dpf-3		K02F2.1|K02F2.a|K02F2.i	gene	taxon:6239			
+WB	WBGene00001057	dpf-4		F01F1.5	gene	taxon:6239			
+WB	WBGene00001058	dpf-5		R11E3.8	gene	taxon:6239			
+WB	WBGene00001059	dpf-6		F44B9.1	gene	taxon:6239			
+WB	WBGene00001060	dpf-7		R11E3.7	gene	taxon:6239			
+WB	WBGene00001061	dpl-1		T23G7.1|mex-4|szy-10	gene	taxon:6239			
+WB	WBGene00001062	dpr-1		R10D12.2|end-2	gene	taxon:6239			
+WB	WBGene00001063	dpy-1		M01E10.2	gene	taxon:6239			
+WB	WBGene00001064	dpy-2		T14B4.6|rol-2	gene	taxon:6239			
+WB	WBGene00001065	dpy-3		EGAP7.1|dpy-12	gene	taxon:6239			
+WB	WBGene00001066	dpy-4		Y41E3.2|col-134	gene	taxon:6239			
+WB	WBGene00001067	dpy-5		F27C1.8	gene	taxon:6239			
+WB	WBGene00001068	dpy-6		F16F9.2	gene	taxon:6239			
+WB	WBGene00001069	dpy-7		F46C8.6	gene	taxon:6239			
+WB	WBGene00001070	dpy-8		C31H2.2	gene	taxon:6239			
+WB	WBGene00001071	dpy-9		T21D12.2|col-100	gene	taxon:6239			
+WB	WBGene00001072	dpy-10		T14B4.7|rol-7	gene	taxon:6239			
+WB	WBGene00001073	dpy-11		F46E10.9	gene	taxon:6239			
+WB	WBGene00001074	dpy-13		F30B5.1|dpy-16	gene	taxon:6239			
+WB	WBGene00001075	dpy-14		H27M09.4|col-59	gene	taxon:6239			
+WB	WBGene00001076	dpy-17		F54D8.1	gene	taxon:6239			
+WB	WBGene00001077	dpy-18		Y47D3B.10|phy-1|T28D6.1	gene	taxon:6239			
+WB	WBGene00001078	dpy-19		F22B7.10	gene	taxon:6239			
+WB	WBGene00001079	dpy-20		T22B3.1	gene	taxon:6239			
+WB	WBGene00001080	dpy-21		Y59A8B.1|Y59A8B.c	gene	taxon:6239			
+WB	WBGene00001081	dpy-22		F47A4.2|mdt-12|psa-6|sop-1	gene	taxon:6239			
+WB	WBGene00001082	dpy-23		R160.1|apm-2|CEAP50	gene	taxon:6239			
+WB	WBGene00001085	dpy-26		C25G4.5	gene	taxon:6239			
+WB	WBGene00001086	dpy-27		R13G10.1	gene	taxon:6239			
+WB	WBGene00001087	dpy-28		Y39A1B.3	gene	taxon:6239			
+WB	WBGene00001088	dpy-30		ZK863.6	gene	taxon:6239			
+WB	WBGene00001089	dre-1		K04A8.6|F46E10.a	gene	taxon:6239			
+WB	WBGene00001090	drh-1		F15B10.2	gene	taxon:6239			
+WB	WBGene00001092	dro-1		F53A2.5	gene	taxon:6239			
+WB	WBGene00001093	drp-1		T12E12.4	gene	taxon:6239			
+WB	WBGene00001094	dars-1		B0464.1|drs-1	gene	taxon:6239			
+WB	WBGene00001095	dars-2		F10C2.6|drs-2	gene	taxon:6239			
+WB	WBGene00001096	dsc-1		C18B12.3	gene	taxon:6239			
+WB	WBGene00001099	dsc-4		K02D7.4	gene	taxon:6239			
+WB	WBGene00001101	dsh-1		C34F11.9|nde-3	gene	taxon:6239			
+WB	WBGene00001102	dsh-2		C27A2.6	gene	taxon:6239			
+WB	WBGene00001103	dsl-1		W09G12.4	gene	taxon:6239			
+WB	WBGene00001104	dsl-2		W09G12.1	gene	taxon:6239			
+WB	WBGene00001105	dsl-3		Y41D4B.10	gene	taxon:6239			
+WB	WBGene00001106	dsl-4		F16B12.2	gene	taxon:6239			
+WB	WBGene00001107	dsl-5		F58B3.8	gene	taxon:6239			
+WB	WBGene00001108	dsl-6		H02I12.4	gene	taxon:6239			
+WB	WBGene00001109	dsl-7		F15B9.9	gene	taxon:6239			
+WB	WBGene00001110	duo-1		F38B7.5|usp-1	gene	taxon:6239			
+WB	WBGene00001112	duo-3		Y106G6H.12	gene	taxon:6239			
+WB	WBGene00001115	dyb-1		F47G6.1	gene	taxon:6239			
+WB	WBGene00001116	dyc-1		C33G3.1	gene	taxon:6239			
+WB	WBGene00001117	dyf-1		F54C1.5	gene	taxon:6239			
+WB	WBGene00001118	dyf-2		ZK520.3	gene	taxon:6239			
+WB	WBGene00001119	dyf-3		C04C3.5	gene	taxon:6239			
+WB	WBGene00001121	dyf-5		M04C9.5	gene	taxon:6239			
+WB	WBGene00001122	dyf-6		F46F6.4	gene	taxon:6239			
+WB	WBGene00001123	dyf-7		C43C3.3|dyf-8	gene	taxon:6239			
+WB	WBGene00001127	dyf-11		C02H7.1	gene	taxon:6239			
+WB	WBGene00001129	dyf-13		C27H5.7	gene	taxon:6239			
+WB	WBGene00001130	dyn-1		C02C6.1|dyn1	gene	taxon:6239			
+WB	WBGene00001131	dys-1		F15D3.1	gene	taxon:6239			
+WB	WBGene00001132	alp-1		T11B7.4	gene	taxon:6239			
+WB	WBGene00001133	eat-2		Y48B6A.4|Y51H7C.p	gene	taxon:6239			
+WB	WBGene00001134	eat-3		D2013.5|mgm-1	gene	taxon:6239			
+WB	WBGene00001135	eat-4		ZK512.6|not-1|vglu-1	gene	taxon:6239			
+WB	WBGene00001136	eat-5		F13G3.8	gene	taxon:6239			
+WB	WBGene00001137	eat-6		B0365.3|NaK\/1|spa-1	gene	taxon:6239			
+WB	WBGene00001141	eat-10			gene	taxon:6239			
+WB	WBGene00001145	eat-16		C16C2.2|sag-2	gene	taxon:6239			
+WB	WBGene00001147	eat-18		Y105E8A.7	gene	taxon:6239			
+WB	WBGene00001148	eat-20		H30A04.1|crl-1|eat-20a|eat-20b	gene	taxon:6239			
+WB	WBGene00001149	bcat-1		K02A4.1|eca-39|ECA39	gene	taxon:6239			
+WB	WBGene00001150	ech-1.1		C29F3.1|ech-1	gene	taxon:6239			
+WB	WBGene00001151	ech-2		F38H4.8	gene	taxon:6239			
+WB	WBGene00001152	ech-3		F43H9.1	gene	taxon:6239			
+WB	WBGene00001153	ech-4		R06F6.9|acbp-2	gene	taxon:6239			
+WB	WBGene00001154	ech-5		F56B3.5	gene	taxon:6239			
+WB	WBGene00001155	ech-6		T05G5.6	gene	taxon:6239			
+WB	WBGene00001156	ech-7		Y105E8A.4|Y105E8E.b	gene	taxon:6239			
+WB	WBGene00001157	ech-8		F01G10.2	gene	taxon:6239			
+WB	WBGene00001158	ech-9		F01G10.3	gene	taxon:6239			
+WB	WBGene00001159	eff-1		C26D10.5|elf-1	gene	taxon:6239			
+WB	WBGene00001160	efk-1		F42A10.4|efk1	gene	taxon:6239			
+WB	WBGene00001161	efl-1		Y102A5C.18|mex-2	gene	taxon:6239			
+WB	WBGene00001162	efl-2		Y48C3A.17	gene	taxon:6239			
+WB	WBGene00001163	efn-2		C43F9.8	gene	taxon:6239			
+WB	WBGene00001164	efn-3		F15A2.5	gene	taxon:6239			
+WB	WBGene00001165	efn-4		F56A11.3|mab-26	gene	taxon:6239			
+WB	WBGene00001166	eftu-2		ZK328.2|eft-1	gene	taxon:6239			
+WB	WBGene00001167	eef-2		F25H5.4|eft-2|P29691	gene	taxon:6239			
+WB	WBGene00001168	eef-1A.1		F31E3.5|eft-3|eln-1|glp-3	gene	taxon:6239			
+WB	WBGene00001169	eef-1A.2		R03G5.1|C54D2.a|eft-4|eln-2|R03G5.a|R03G5.b	gene	taxon:6239			
+WB	WBGene00001170	egl-1		F23B12.9	gene	taxon:6239			
+WB	WBGene00001171	egl-2		F16B3.1	gene	taxon:6239			
+WB	WBGene00001172	egl-3		C51E3.7|kpc-2|pc2	gene	taxon:6239			
+WB	WBGene00001173	egl-4		F55A8.2|cgk-1|chb-1|eat-7|F55A8.b|F55A8.d|F55A8.e|F55A8.f|F55A8.g|odr-9|pkg-1	gene	taxon:6239			
+WB	WBGene00001174	egl-5		C08C3.1|ceh-11	gene	taxon:6239			
+WB	WBGene00001175	egl-6		C46F4.1	gene	taxon:6239			
+WB	WBGene00001177	egl-8		B0348.4|pbo-2	gene	taxon:6239			
+WB	WBGene00001178	egl-9		F22E12.4	gene	taxon:6239			
+WB	WBGene00001179	egl-10		F28C1.2	gene	taxon:6239			
+WB	WBGene00001182	egl-13		T22B7.1|cog-2	gene	taxon:6239			
+WB	WBGene00001184	egl-15		F58A3.2	gene	taxon:6239			
+WB	WBGene00001185	egl-17		F38G1.2	gene	taxon:6239			
+WB	WBGene00001186	egl-18		F55A8.1|elt-5|F55A8.a|F55A8.j|pvl-3	gene	taxon:6239			
+WB	WBGene00001187	egl-19		C48A7.1|eat-12|pat-5	gene	taxon:6239			
+WB	WBGene00001188	egl-20		W08D2.1	gene	taxon:6239			
+WB	WBGene00001189	egl-21		F01D4.4	gene	taxon:6239			
+WB	WBGene00001190	egl-23		Y37A1B.11|twk-41	gene	taxon:6239			
+WB	WBGene00001193	egl-26		C23H3.1|cog-4|egl-48	gene	taxon:6239			
+WB	WBGene00001194	egl-27		C04A2.3	gene	taxon:6239			
+WB	WBGene00001196	egl-30		M01D7.7|gqa-1	gene	taxon:6239			
+WB	WBGene00001198	egl-32			gene	taxon:6239			
+WB	WBGene00001202	egl-36		R07A4.1|shw-2	gene	taxon:6239			
+WB	WBGene00001204	egl-38		C04G2.7|lin-50	gene	taxon:6239			
+WB	WBGene00001205	egl-40			gene	taxon:6239			
+WB	WBGene00001207	egl-43		R53.3	gene	taxon:6239			
+WB	WBGene00001208	egl-44		F28B12.2	gene	taxon:6239			
+WB	WBGene00001209	egl-45		C27D11.1|eif-3.A	gene	taxon:6239			
+WB	WBGene00001210	egl-46		K11G9.4	gene	taxon:6239			
+WB	WBGene00001211	egl-47		C50H2.2|gur-1	gene	taxon:6239			
+WB	WBGene00001214	ego-1		F26A3.3|ego-6	gene	taxon:6239			
+WB	WBGene00001215	ego-2		Y53H1C.2	gene	taxon:6239			
+WB	WBGene00001223	ehn-3		ZK616.10|ZK616.a	gene	taxon:6239			
+WB	WBGene00001224	ehs-1		ZK1248.3	gene	taxon:6239			
+WB	WBGene00001225	eif-3.B		Y54E2A.11	gene	taxon:6239			
+WB	WBGene00001226	eif-3.C		T23D8.4	gene	taxon:6239			
+WB	WBGene00001227	eif-3.D		R08D7.3|R08D7_3	gene	taxon:6239			
+WB	WBGene00001228	eif-3.E		B0511.10	gene	taxon:6239			
+WB	WBGene00001229	eif-3.F		D2013.7	gene	taxon:6239			
+WB	WBGene00001230	eif-3.G		F22B5.2	gene	taxon:6239			
+WB	WBGene00001231	eif-3.H		C41D11.2	gene	taxon:6239			
+WB	WBGene00001232	eif-3.I		Y74C10AR.1|Y74C10AR.b|Y74C10A_153.a	gene	taxon:6239			
+WB	WBGene00001233	eif-3.K		T16G1.11|pqn-69	gene	taxon:6239			
+WB	WBGene00001234	eif-6		C47B2.5	gene	taxon:6239			
+WB	WBGene00001235	elb-1		Y41C4A.10|3L686	gene	taxon:6239			
+WB	WBGene00001236	elc-1		Y82E9BR.15	gene	taxon:6239			
+WB	WBGene00001237	elc-2		W03H1.2	gene	taxon:6239			
+WB	WBGene00001239	elo-1		F56H11.4|ceelo1|pea-1	gene	taxon:6239			
+WB	WBGene00001240	elo-2		F11E6.5	gene	taxon:6239			
+WB	WBGene00001241	elo-3		D2024.3	gene	taxon:6239			
+WB	WBGene00001242	elo-4		C40H1.4	gene	taxon:6239			
+WB	WBGene00001243	elo-5		F41H10.7	gene	taxon:6239			
+WB	WBGene00001244	elo-6		F41H10.8	gene	taxon:6239			
+WB	WBGene00001245	elo-7		F56H11.3	gene	taxon:6239			
+WB	WBGene00001246	elo-8		Y47D3A.30	gene	taxon:6239			
+WB	WBGene00001247	elo-9		Y53F4B.2	gene	taxon:6239			
+WB	WBGene00001248	elp-1		F38A6.2	gene	taxon:6239			
+WB	WBGene00001249	elt-1		W09C2.1	gene	taxon:6239			
+WB	WBGene00001250	elt-2		C33D3.1|GATA	gene	taxon:6239			
+WB	WBGene00001251	elt-3		K02B9.4	gene	taxon:6239			
+WB	WBGene00001252	elt-4		C39B10.6	gene	taxon:6239			
+WB	WBGene00001253	elt-6		F52C12.5	gene	taxon:6239			
+WB	WBGene00001258	emb-4		Y80D3A.2|mal-2|sel-6	gene	taxon:6239			
+WB	WBGene00001259	emb-5		T04A8.14	gene	taxon:6239			
+WB	WBGene00001262	emb-8		K10D2.6|drop-8	gene	taxon:6239			
+WB	WBGene00001263	emb-9		K04H4.1|clb-2|zyg-6	gene	taxon:6239			
+WB	WBGene00001267	emb-13			gene	taxon:6239			
+WB	WBGene00001281	emb-27		F10B5.6|apc-6|pod-6	gene	taxon:6239			
+WB	WBGene00001284	emb-30		F54C8.3|apc-4	gene	taxon:6239			
+WB	WBGene00001303	sec-61.G		F32D8.6|emo-1|oar-1	gene	taxon:6239			
+WB	WBGene00001309	emr-1		M01D7.6	gene	taxon:6239			
+WB	WBGene00001310	end-1		F58E10.2	gene	taxon:6239			
+WB	WBGene00001311	end-3		F58E10.5	gene	taxon:6239			
+WB	WBGene00001320	ent-1		ZK809.4	gene	taxon:6239			
+WB	WBGene00001324	eor-1		R11E3.6	gene	taxon:6239			
+WB	WBGene00001325	eor-2		C44H4.7	gene	taxon:6239			
+WB	WBGene00001326	eos-1			gene	taxon:6239			
+WB	WBGene00001327	eos-2			gene	taxon:6239			
+WB	WBGene00001328	epi-1		K08C7.3|egf-3|lgx-3	gene	taxon:6239			
+WB	WBGene00001329	epn-1		T04C10.2	gene	taxon:6239			
+WB	WBGene00001330	eps-8		Y57G11C.24|gei-19	gene	taxon:6239			
+WB	WBGene00001331	erd-2.1		F09B9.3|erd-2|ERD2|sup-2	gene	taxon:6239			
+WB	WBGene00001332	eri-1		T07A9.5	gene	taxon:6239			
+WB	WBGene00001333	erm-1		C01G8.5	gene	taxon:6239			
+WB	WBGene00001334	ero-1		Y105E8B.8|Y105E8B.l|Y105E8B.m	gene	taxon:6239			
+WB	WBGene00001335	F35A5.8		erp-1	gene	taxon:6239			
+WB	WBGene00001336	qars-1		Y41E3.4|ers-1|qrs-5	gene	taxon:6239			
+WB	WBGene00001337	ears-1		ZC434.5|ers-2|qrs-3	gene	taxon:6239			
+WB	WBGene00001338	ears-2		T07A9.2|ers-3|qrs-6	gene	taxon:6239			
+WB	WBGene00001340	etr-1		T01D1.2	gene	taxon:6239			
+WB	WBGene00001345	fos-1		F29G9.4|evl-5	gene	taxon:6239			
+WB	WBGene00001352	evl-14		H38K22.1	gene	taxon:6239			
+WB	WBGene00001358	evl-20		F22B5.1|arf-2|ARF\/2|arl-2|arl-5	gene	taxon:6239			
+WB	WBGene00001362	exc-1		C46E1.3	gene	taxon:6239			
+WB	WBGene00001363	exc-2			gene	taxon:6239			
+WB	WBGene00001364	exc-3			gene	taxon:6239			
+WB	WBGene00001365	exc-4		Y105E8A.22|Y105E8C.a	gene	taxon:6239			
+WB	WBGene00001366	exc-5		C33D9.1|Cefgd-1|fgd-1	gene	taxon:6239			
+WB	WBGene00001368	exc-7		F35H8.5|cel-1|elr-1	gene	taxon:6239			
+WB	WBGene00001369	exc-8			gene	taxon:6239			
+WB	WBGene00001371	exl-1		F26H11.5	gene	taxon:6239			
+WB	WBGene00001372	exo-3		R09B3.1	gene	taxon:6239			
+WB	WBGene00001373	exp-1		H35N03.1	gene	taxon:6239			
+WB	WBGene00001374	exp-2		F12F3.1	gene	taxon:6239			
+WB	WBGene00001377	eya-1		C49A1.4	gene	taxon:6239			
+WB	WBGene00001385	far-1		F02A9.2	gene	taxon:6239			
+WB	WBGene00001386	far-2		F02A9.3|pes-3	gene	taxon:6239			
+WB	WBGene00001387	far-3		F15B9.1	gene	taxon:6239			
+WB	WBGene00001388	far-4		F15B9.2	gene	taxon:6239			
+WB	WBGene00001389	far-5		F15B9.3	gene	taxon:6239			
+WB	WBGene00001390	far-6		W02A2.2	gene	taxon:6239			
+WB	WBGene00001391	far-7		K01A2.2	gene	taxon:6239			
+WB	WBGene00001392	far-8		K02F3.3	gene	taxon:6239			
+WB	WBGene00001393	fat-1		Y67H2A.8	gene	taxon:6239			
+WB	WBGene00001394	fat-2		W02A2.1	gene	taxon:6239			
+WB	WBGene00001395	fat-3		W08D2.4	gene	taxon:6239			
+WB	WBGene00001396	fat-4		T13F2.1	gene	taxon:6239			
+WB	WBGene00001397	fat-5		W06D12.3	gene	taxon:6239			
+WB	WBGene00001398	fat-6		VZK822L.1	gene	taxon:6239			
+WB	WBGene00001399	fat-7		F10D2.9	gene	taxon:6239			
+WB	WBGene00001400	fax-1		F56E3.4|nhr-29	gene	taxon:6239			
+WB	WBGene00001401	fbf-1		H12I13.4|FBF	gene	taxon:6239			
+WB	WBGene00001402	fbf-2		F21H12.5|FBF|FBF2	gene	taxon:6239			
+WB	WBGene00001403	fbl-1		F56H11.1|FBLN1	gene	taxon:6239			
+WB	WBGene00001404	fbp-1		K07A3.1|fbp	gene	taxon:6239			
+WB	WBGene00001405	fce-1		C04F12.10|Ce-face-1	gene	taxon:6239			
+WB	WBGene00001406	fce-2		F48F5.5|Ce-face-2|face-2	gene	taxon:6239			
+WB	WBGene00001410	feh-1		Y54F10AM.2	gene	taxon:6239			
+WB	WBGene00001411	fem-1		F35D6.1|isx-1	gene	taxon:6239			
+WB	WBGene00001412	fem-2		T19C3.8|isx-2	gene	taxon:6239			
+WB	WBGene00001413	fem-3		C01F6.4	gene	taxon:6239			
+WB	WBGene00001414	fer-1		F43G9.6	gene	taxon:6239			
+WB	WBGene00001423	fib-1		T01C3.7	gene	taxon:6239			
+WB	WBGene00001424	fis-1		F41G3.4	gene	taxon:6239			
+WB	WBGene00001425	fis-2		F13B9.8	gene	taxon:6239			
+WB	WBGene00001426	fkb-1		F36H1.1	gene	taxon:6239			
+WB	WBGene00001427	fkb-2		Y18D10A.19	gene	taxon:6239			
+WB	WBGene00001428	fkb-3		C05C8.3|dao-1	gene	taxon:6239			
+WB	WBGene00001429	fkb-4		ZC455.10|dao-9	gene	taxon:6239			
+WB	WBGene00001430	fkb-5		C50F2.6|dao-8	gene	taxon:6239			
+WB	WBGene00001431	fkb-6		F31D4.3	gene	taxon:6239			
+WB	WBGene00001432	fkb-7		B0511.1	gene	taxon:6239			
+WB	WBGene00001433	fkb-8		Y18D10A.25	gene	taxon:6239			
+WB	WBGene00001434	fkh-2		T14G12.4	gene	taxon:6239			
+WB	WBGene00001435	fkh-3		C29F7.4	gene	taxon:6239			
+WB	WBGene00001436	fkh-4		C29F7.5|tag-39	gene	taxon:6239			
+WB	WBGene00001437	fkh-5		F26A1.2	gene	taxon:6239			
+WB	WBGene00001438	fkh-6		B0286.5	gene	taxon:6239			
+WB	WBGene00001439	fkh-7		F26D12.1|F26D12.a|F26D12.b	gene	taxon:6239			
+WB	WBGene00001440	fkh-8		F40H3.4	gene	taxon:6239			
+WB	WBGene00001441	fkh-9		K03C7.2	gene	taxon:6239			
+WB	WBGene00001442	fkh-10		C25A1.2	gene	taxon:6239			
+WB	WBGene00001443	fli-1		B0523.5|ach-1	gene	taxon:6239			
+WB	WBGene00001444	flp-1		F23B2.5	gene	taxon:6239			
+WB	WBGene00001446	flp-3		W07E11.2	gene	taxon:6239			
+WB	WBGene00001447	flp-4		C18D1.3	gene	taxon:6239			
+WB	WBGene00001448	flp-5		C03G5.7	gene	taxon:6239			
+WB	WBGene00001449	flp-6		F07D3.2	gene	taxon:6239			
+WB	WBGene00001450	flp-7		F49E10.3	gene	taxon:6239			
+WB	WBGene00001451	flp-8		F31F6.4	gene	taxon:6239			
+WB	WBGene00001452	flp-9		C36H8.3	gene	taxon:6239			
+WB	WBGene00001453	flp-10		T06C10.4	gene	taxon:6239			
+WB	WBGene00001454	flp-11		K02G10.4|flp-11a|flp-11b	gene	taxon:6239			
+WB	WBGene00001455	flp-12		C05E11.8	gene	taxon:6239			
+WB	WBGene00001456	flp-13		F33D4.3	gene	taxon:6239			
+WB	WBGene00001457	flp-14		Y37D8A.15	gene	taxon:6239			
+WB	WBGene00001459	flp-16		F15D4.8	gene	taxon:6239			
+WB	WBGene00001460	flp-17		C52D10.11	gene	taxon:6239			
+WB	WBGene00001461	flp-18		Y48D7A.2	gene	taxon:6239			
+WB	WBGene00001462	flp-19		M79.4	gene	taxon:6239			
+WB	WBGene00001463	flp-20		E01H11.3	gene	taxon:6239			
+WB	WBGene00001464	flp-21		C26F1.10	gene	taxon:6239			
+WB	WBGene00001465	flr-1		F02D10.5	gene	taxon:6239			
+WB	WBGene00001466	flr-2		F58H1.4	gene	taxon:6239			
+WB	WBGene00001468	flr-4		F09B12.6	gene	taxon:6239			
+WB	WBGene00001470	baz-2		ZK783.4|flt-1	gene	taxon:6239			
+WB	WBGene00001475	fmi-1		F15B9.7|cdh-6	gene	taxon:6239			
+WB	WBGene00001476	fmo-1		K08C7.2|fmo-11	gene	taxon:6239			
+WB	WBGene00001477	fmo-2		K08C7.5|fmo-12	gene	taxon:6239			
+WB	WBGene00001478	fmo-3		Y39A1A.19|fmo-13	gene	taxon:6239			
+WB	WBGene00001479	fmo-4		F53F4.5|fmo-14	gene	taxon:6239			
+WB	WBGene00001480	fmo-5		H24K24.5|fmo-15	gene	taxon:6239			
+WB	WBGene00001481	fog-1		Y54E10A.4|cpb-4	gene	taxon:6239			
+WB	WBGene00001482	fog-2		Y113G7B.5	gene	taxon:6239			
+WB	WBGene00001483	fog-3		C03C11.2	gene	taxon:6239			
+WB	WBGene00001484	fox-1		T07D1.4	gene	taxon:6239			
+WB	WBGene00001485	fre-1		Y113G7A.8|tag-62	gene	taxon:6239			
+WB	WBGene00001486	frh-1		F59G1.7	gene	taxon:6239			
+WB	WBGene00001487	frk-1		T04B2.2	gene	taxon:6239			
+WB	WBGene00001488	frm-1		ZK270.2	gene	taxon:6239			
+WB	WBGene00001489	frm-2		T04C9.6	gene	taxon:6239			
+WB	WBGene00001490	frm-3		H05G16.1	gene	taxon:6239			
+WB	WBGene00001491	frm-4		C24A11.8	gene	taxon:6239			
+WB	WBGene00001497	fars-1		T08B2.9|frs-1|let-396	gene	taxon:6239			
+WB	WBGene00001498	fars-3		F22B5.9|frs-2	gene	taxon:6239			
+WB	WBGene00001499	fsn-1		C26E6.5	gene	taxon:6239			
+WB	WBGene00001500	ftn-1		C54F6.14	gene	taxon:6239			
+WB	WBGene00001501	ftn-2		D1037.3	gene	taxon:6239			
+WB	WBGene00001502	ftt-2		F52D10.3	gene	taxon:6239			
+WB	WBGene00001503	fum-1		H14A12.2	gene	taxon:6239			
+WB	WBGene00001505	fut-1		K08F8.3|CEFT-1	gene	taxon:6239			
+WB	WBGene00001506	fut-2		EGAP9.2|CE2FT-1	gene	taxon:6239			
+WB	WBGene00001507	fut-4		K12H6.3|ceft-5|ft4|tag-20	gene	taxon:6239			
+WB	WBGene00001508	fut-8		C10F3.6|fut8	gene	taxon:6239			
+WB	WBGene00001509	fzo-1		ZK1248.14	gene	taxon:6239			
+WB	WBGene00001510	fzr-1		ZK1307.6	gene	taxon:6239			
+WB	WBGene00001511	fzy-1		ZK177.6|cdc-20	gene	taxon:6239			
+WB	WBGene00001512	gab-1		ZC482.1|GABAR\/1|gbr-1	gene	taxon:6239			
+WB	WBGene00001513	gad-1		T05H4.14|tag-86	gene	taxon:6239			
+WB	WBGene00001515	gap-1		T24C12.2|sli-5|suv-1	gene	taxon:6239			
+WB	WBGene00001516	gap-2		ZK899.8	gene	taxon:6239			
+WB	WBGene00001517	gar-1		C15B12.5|acm-1	gene	taxon:6239			
+WB	WBGene00001518	gar-2		F47D12.1|acm-2	gene	taxon:6239			
+WB	WBGene00001519	gar-3		Y40H4A.1|acm-3|gar-3a	gene	taxon:6239			
+WB	WBGene00001520	gas-1		K09A9.5|nduf-2.1	gene	taxon:6239			
+WB	WBGene00001522	gbh-1		D2089.5	gene	taxon:6239			
+WB	WBGene00001523	gbh-2		M05D6.7	gene	taxon:6239			
+WB	WBGene00001526	gck-1		T19A5.2	gene	taxon:6239			
+WB	WBGene00001527	gcs-1		F37B12.2	gene	taxon:6239			
+WB	WBGene00001528	gcy-1		AH6.1	gene	taxon:6239			
+WB	WBGene00001530	gcy-3		R134.1	gene	taxon:6239			
+WB	WBGene00001531	gcy-4		ZK970.5	gene	taxon:6239			
+WB	WBGene00001532	gcy-5		ZK970.6	gene	taxon:6239			
+WB	WBGene00001533	gcy-6		B0024.6	gene	taxon:6239			
+WB	WBGene00001534	gcy-7		F52E1.4	gene	taxon:6239			
+WB	WBGene00001535	gcy-8		C49H3.1	gene	taxon:6239			
+WB	WBGene00001536	gcy-9		ZK455.2	gene	taxon:6239			
+WB	WBGene00001537	gcy-11		C30G4.3	gene	taxon:6239			
+WB	WBGene00001538	gcy-12		F08B1.2	gene	taxon:6239			
+WB	WBGene00001539	gcy-13		F23H12.6	gene	taxon:6239			
+WB	WBGene00001540	gcy-14		ZC412.2	gene	taxon:6239			
+WB	WBGene00001541	gcy-15		ZC239.7|Y27F2A.a|Y27F2A.k	gene	taxon:6239			
+WB	WBGene00001542	gcy-17		W03F11.2|gcy-24	gene	taxon:6239			
+WB	WBGene00001543	gcy-18		ZK896.8|gcy-26	gene	taxon:6239			
+WB	WBGene00001544	gcy-19		C17F4.6	gene	taxon:6239			
+WB	WBGene00001545	gcy-20		F21H7.9|gcy-16	gene	taxon:6239			
+WB	WBGene00001546	gcy-21		F22E5.3|F22E5.c	gene	taxon:6239			
+WB	WBGene00001547	gcy-22		T03D8.5|che-5	gene	taxon:6239			
+WB	WBGene00001548	gcy-23		T26C12.4	gene	taxon:6239			
+WB	WBGene00001549	gcy-25		Y105C5B.2	gene	taxon:6239			
+WB	WBGene00001550	gcy-27		C06A12.4	gene	taxon:6239			
+WB	WBGene00001551	gcy-31		T07D1.1|CeGC-beta3	gene	taxon:6239			
+WB	WBGene00001552	gcy-32		C06B3.8|CeGC2	gene	taxon:6239			
+WB	WBGene00001553	gcy-33		F57F5.2|CeGC4	gene	taxon:6239			
+WB	WBGene00001554	gcy-34		M04G12.3|CeGC3	gene	taxon:6239			
+WB	WBGene00001555	gcy-35		T04D3.4|CeGC1	gene	taxon:6239			
+WB	WBGene00001556	gcy-36		C46E1.2|CeGC6	gene	taxon:6239			
+WB	WBGene00001557	gcy-37		C54E4.3|CeGC5	gene	taxon:6239			
+WB	WBGene00001558	gdi-1		Y57G11C.10	gene	taxon:6239			
+WB	WBGene00001559	gei-1		F45H7.2	gene	taxon:6239			
+WB	WBGene00001560	gei-3		T22H6.6	gene	taxon:6239			
+WB	WBGene00001561	gei-4		W07B3.2|W07B3.a|W07B3.b	gene	taxon:6239			
+WB	WBGene00001562	lin-66		B0513.1|gei-5	gene	taxon:6239			
+WB	WBGene00001564	icl-1		C05E4.9|gei-7	gene	taxon:6239			
+WB	WBGene00001565	gei-8		C14B9.6|pqn-12	gene	taxon:6239			
+WB	WBGene00001566	acdh-13		C28C12.9|gei-9	gene	taxon:6239			
+WB	WBGene00001568	snpc-4		F32H2.1|gei-11	gene	taxon:6239			
+WB	WBGene00001569	meg-3		F52D2.4|gei-12	gene	taxon:6239			
+WB	WBGene00001570	gei-13		F58A4.11	gene	taxon:6239			
+WB	WBGene00001572	gei-15		M03A8.4	gene	taxon:6239			
+WB	WBGene00001574	gei-17		W10D5.3	gene	taxon:6239			
+WB	WBGene00001575	gei-18		Y37A1B.15	gene	taxon:6239			
+WB	WBGene00001578	ges-1		R12A1.4|cest-18|ges1	gene	taxon:6239			
+WB	WBGene00001579	gex-2		F56A11.1	gene	taxon:6239			
+WB	WBGene00001580	gex-3		F28D1.10	gene	taxon:6239			
+WB	WBGene00001581	gfi-1		F57F4.3	gene	taxon:6239			
+WB	WBGene00001582	gfi-2		K02A11.1	gene	taxon:6239			
+WB	WBGene00001583	gfi-3		M163.4|apc-5	gene	taxon:6239			
+WB	WBGene00001584	nrde-4		F45E4.10|gfi-4	gene	taxon:6239			
+WB	WBGene00001585	gfl-1		M04B2.3	gene	taxon:6239			
+WB	WBGene00001586	lgc-57		C09G5.1|gbr-4|ggr-1	gene	taxon:6239			
+WB	WBGene00001587	lgc-58		C45B2.4|gbr-5|ggr-1	gene	taxon:6239			
+WB	WBGene00001588	lgc-56		F09C12.1|gbr-6|ggr-3	gene	taxon:6239			
+WB	WBGene00001589	gip-1		H04J21.3|CeGrip	gene	taxon:6239			
+WB	WBGene00001590	lipt-1		C45G3.3	gene	taxon:6239			
+WB	WBGene00001591	glc-1		F11A5.10|GluCl alpha	gene	taxon:6239			
+WB	WBGene00001592	glc-2		F25F8.2|avm-2|GluCl beta	gene	taxon:6239			
+WB	WBGene00001593	glc-3		ZC317.3	gene	taxon:6239			
+WB	WBGene00001594	glc-4		C27H5.8	gene	taxon:6239			
+WB	WBGene00001595	gld-1		T23G11.3	gene	taxon:6239			
+WB	WBGene00001596	gld-2		ZC308.1|let-606	gene	taxon:6239			
+WB	WBGene00001597	gld-3		T07F8.3	gene	taxon:6239			
+WB	WBGene00001598	glh-1		T21G5.3|rhl-2	gene	taxon:6239			
+WB	WBGene00001599	glh-2		C55B7.1	gene	taxon:6239			
+WB	WBGene00001600	glh-3		B0414.6	gene	taxon:6239			
+WB	WBGene00001601	glh-4		T12F5.3	gene	taxon:6239			
+WB	WBGene00001602	gln-1		C45B2.5	gene	taxon:6239			
+WB	WBGene00001603	gln-2		K03H1.1	gene	taxon:6239			
+WB	WBGene00001604	gln-3		Y105C5B.28	gene	taxon:6239			
+WB	WBGene00001606	gln-5		F26D10.10	gene	taxon:6239			
+WB	WBGene00001607	gln-6		C28D4.3	gene	taxon:6239			
+WB	WBGene00001609	glp-1		F02A9.6|emb-33	gene	taxon:6239			
+WB	WBGene00001612	glr-1		C06E1.4|not-3	gene	taxon:6239			
+WB	WBGene00001613	glr-2		B0280.12	gene	taxon:6239			
+WB	WBGene00001614	glr-3		K10D3.1	gene	taxon:6239			
+WB	WBGene00001615	glr-4		C06A8.9	gene	taxon:6239			
+WB	WBGene00001616	glr-5		ZC196.7	gene	taxon:6239			
+WB	WBGene00001617	glr-6		F41B4.4	gene	taxon:6239			
+WB	WBGene00001618	glr-7		C43H6.9	gene	taxon:6239			
+WB	WBGene00001619	glr-8		F22A3.3	gene	taxon:6239			
+WB	WBGene00001620	glt-1		C12D12.2|CeGlt-1|CeGlt-2|Ceglut-2|glt-2	gene	taxon:6239			
+WB	WBGene00001621	glt-3		K08F4.4	gene	taxon:6239			
+WB	WBGene00001622	glt-4		T22E5.2	gene	taxon:6239			
+WB	WBGene00001623	glt-5		Y53C12A.2	gene	taxon:6239			
+WB	WBGene00001624	glt-6		R05G6.6	gene	taxon:6239			
+WB	WBGene00001625	glt-7		W03G1.1	gene	taxon:6239			
+WB	WBGene00001626	gly-1		F44F4.6	gene	taxon:6239			
+WB	WBGene00001627	gly-2		C55B7.2	gene	taxon:6239			
+WB	WBGene00001628	gly-3		ZK688.8	gene	taxon:6239			
+WB	WBGene00001629	gly-4		Y116F11B.12|Y116F11B.m|Y116F11B.n	gene	taxon:6239			
+WB	WBGene00001630	gly-5		Y39E4B.12	gene	taxon:6239			
+WB	WBGene00001631	gly-6		H38K22.5	gene	taxon:6239			
+WB	WBGene00001632	gly-7		Y46H3A.6	gene	taxon:6239			
+WB	WBGene00001633	gly-8		Y66A7A.6	gene	taxon:6239			
+WB	WBGene00001635	gly-10		Y45F10D.3	gene	taxon:6239			
+WB	WBGene00001636	gly-11		Y75B8A.9|tag-240	gene	taxon:6239			
+WB	WBGene00001637	gly-12		F48E3.1	gene	taxon:6239			
+WB	WBGene00001638	gly-13		B0416.6	gene	taxon:6239			
+WB	WBGene00001639	gly-14		M01F1.1	gene	taxon:6239			
+WB	WBGene00001640	gly-15		C54C8.11	gene	taxon:6239			
+WB	WBGene00001641	gly-16		T15D6.2	gene	taxon:6239			
+WB	WBGene00001642	gly-17		T15D6.3	gene	taxon:6239			
+WB	WBGene00001643	gly-18		F22D6.11	gene	taxon:6239			
+WB	WBGene00001644	gly-19		F22D6.12	gene	taxon:6239			
+WB	WBGene00001645	gly-20		C03E10.4|GnT II	gene	taxon:6239			
+WB	WBGene00001646	gna-1		B0024.12|CeGNA1	gene	taxon:6239			
+WB	WBGene00001647	gna-2		T23G11.2	gene	taxon:6239			
+WB	WBGene00001648	goa-1		C26C6.2|unc-109	gene	taxon:6239			
+WB	WBGene00001649	gob-1		H13N06.3	gene	taxon:6239			
+WB	WBGene00001650	gon-1		F25H8.3	gene	taxon:6239			
+WB	WBGene00001651	gon-2		T01H8.5	gene	taxon:6239			
+WB	WBGene00001653	gon-4		K04D7.5	gene	taxon:6239			
+WB	WBGene00001660	gop-1		C34E10.3	gene	taxon:6239			
+WB	WBGene00001661	gop-2		C34E10.2	gene	taxon:6239			
+WB	WBGene00001662	gop-3		C34E10.1|C34E10.k	gene	taxon:6239			
+WB	WBGene00001663	gpa-1		T19C4.6	gene	taxon:6239			
+WB	WBGene00001664	gpa-2		F38E1.5	gene	taxon:6239			
+WB	WBGene00001665	gpa-3		E02C12.5	gene	taxon:6239			
+WB	WBGene00001666	gpa-4		T07A9.7	gene	taxon:6239			
+WB	WBGene00001667	gpa-5		F53B1.7	gene	taxon:6239			
+WB	WBGene00001668	gpa-6		F48C11.1	gene	taxon:6239			
+WB	WBGene00001669	gpa-7		R10H10.5	gene	taxon:6239			
+WB	WBGene00001670	gpa-8		F56H9.3	gene	taxon:6239			
+WB	WBGene00001671	gpa-9		F56H9.4	gene	taxon:6239			
+WB	WBGene00001672	gpa-10		C55H1.2	gene	taxon:6239			
+WB	WBGene00001673	gpa-11		C16A11.1	gene	taxon:6239			
+WB	WBGene00001674	gpa-12		F18G5.3	gene	taxon:6239			
+WB	WBGene00001675	gpa-13		F18E2.5	gene	taxon:6239			
+WB	WBGene00001676	gpa-14		B0207.3	gene	taxon:6239			
+WB	WBGene00001677	gpa-15		M04C7.1	gene	taxon:6239			
+WB	WBGene00001678	gpa-16		Y95B8A.5|spn-1	gene	taxon:6239			
+WB	WBGene00001679	gpb-1		F13D12.7	gene	taxon:6239			
+WB	WBGene00001680	gpb-2		F52A8.2|eat-11|gbp-2	gene	taxon:6239			
+WB	WBGene00001681	gpc-1		K02A4.2	gene	taxon:6239			
+WB	WBGene00001682	gpc-2		F08B6.2	gene	taxon:6239			
+WB	WBGene00001683	gpd-1		T09F3.3	gene	taxon:6239			
+WB	WBGene00001684	gpd-2		K10B3.8	gene	taxon:6239			
+WB	WBGene00001685	gpd-3		K10B3.7	gene	taxon:6239			
+WB	WBGene00001686	gpd-4		F33H1.2	gene	taxon:6239			
+WB	WBGene00001687	gpn-1		F59D12.4	gene	taxon:6239			
+WB	WBGene00001688	gpr-1		F22B7.13|ags-3.2|lap-2\/ags-3.2	gene	taxon:6239			
+WB	WBGene00001689	gpr-2		C38C10.4|ags-3.3|lap-1\/ags-3.3	gene	taxon:6239			
+WB	WBGene00001690	grd-1		R08B4.1	gene	taxon:6239			
+WB	WBGene00001691	grd-2		F46B3.5	gene	taxon:6239			
+WB	WBGene00001692	grd-3		W05E7.1	gene	taxon:6239			
+WB	WBGene00001694	grd-5		F41E6.2|F41E6	gene	taxon:6239			
+WB	WBGene00001696	grd-7		F46H5.6	gene	taxon:6239			
+WB	WBGene00001697	grd-8		C37C3.4|C37C3	gene	taxon:6239			
+WB	WBGene00001698	grd-9		C04E6.6|C04E6	gene	taxon:6239			
+WB	WBGene00001700	grd-11		K02E2.2	gene	taxon:6239			
+WB	WBGene00001707	grh-1		Y48G8AR.1|Y48G8AR.a|Y48G8AR.b	gene	taxon:6239			
+WB	WBGene00001708	grk-1		F19C6.1	gene	taxon:6239			
+WB	WBGene00001709	grk-2		W02B3.2|tag-161	gene	taxon:6239			
+WB	WBGene00001740	gro-1		ZC395.6	gene	taxon:6239			
+WB	WBGene00001743	grp-1		K06H7.4	gene	taxon:6239			
+WB	WBGene00001744	gars-1		T10F2.1|grs-1	gene	taxon:6239			
+WB	WBGene00001745	gsa-1		R06A10.2	gene	taxon:6239			
+WB	WBGene00001746	gsk-3		Y18D10A.5|sgg-1|Y18D10A.f	gene	taxon:6239			
+WB	WBGene00001747	gsp-1		F29F11.6|Ce-glc-7alpha|CeGLC-7alpha|glc-7	gene	taxon:6239			
+WB	WBGene00001748	gsp-2		F56C9.1|Ce-glc-7beta|CeGLC-7beta|glc-7	gene	taxon:6239			
+WB	WBGene00001749	gst-1		R107.7|CE00302	gene	taxon:6239			
+WB	WBGene00001750	gst-2		K08F4.6|CeGST2	gene	taxon:6239			
+WB	WBGene00001751	gst-3		K08F4.11|CeGST3	gene	taxon:6239			
+WB	WBGene00001752	gst-4		K08F4.7|CeGST1	gene	taxon:6239			
+WB	WBGene00001753	gst-5		R03D7.6	gene	taxon:6239			
+WB	WBGene00001754	gst-6		F11G11.3	gene	taxon:6239			
+WB	WBGene00001755	gst-7		F11G11.2	gene	taxon:6239			
+WB	WBGene00001756	gst-8		F11G11.1	gene	taxon:6239			
+WB	WBGene00001757	gst-9		R05F9.5	gene	taxon:6239			
+WB	WBGene00001758	gst-10		Y45G12C.2	gene	taxon:6239			
+WB	WBGene00001759	gst-11		R11G1.3	gene	taxon:6239			
+WB	WBGene00001760	gst-12		F37B1.2	gene	taxon:6239			
+WB	WBGene00001761	gst-13		T26C5.1	gene	taxon:6239			
+WB	WBGene00001762	gst-14		F37B1.3	gene	taxon:6239			
+WB	WBGene00001763	gst-15		F37B1.4	gene	taxon:6239			
+WB	WBGene00001764	gst-16		F37B1.5	gene	taxon:6239			
+WB	WBGene00001765	gst-17		F37B1.6	gene	taxon:6239			
+WB	WBGene00001766	gst-18		F37B1.7	gene	taxon:6239			
+WB	WBGene00001767	gst-19		F37B1.8	gene	taxon:6239			
+WB	WBGene00001768	gst-20		Y48E1B.10	gene	taxon:6239			
+WB	WBGene00001769	gst-21		ZK697.6	gene	taxon:6239			
+WB	WBGene00001770	gst-22		F21H7.1	gene	taxon:6239			
+WB	WBGene00001771	gst-23		T28A11.11	gene	taxon:6239			
+WB	WBGene00001772	gst-24		F37B1.1	gene	taxon:6239			
+WB	WBGene00001773	gst-25		F37F2.3	gene	taxon:6239			
+WB	WBGene00001774	gst-26		Y53F4B.29	gene	taxon:6239			
+WB	WBGene00001775	gst-27		Y53F4B.30	gene	taxon:6239			
+WB	WBGene00001776	gst-28		Y53F4B.31	gene	taxon:6239			
+WB	WBGene00001777	gst-29		Y53F4B.32	gene	taxon:6239			
+WB	WBGene00001778	gst-30		ZK546.11	gene	taxon:6239			
+WB	WBGene00001779	gst-31		Y53F4B.35	gene	taxon:6239			
+WB	WBGene00001780	gst-32		Y53F4B.37	gene	taxon:6239			
+WB	WBGene00001781	gst-33		C02A12.1	gene	taxon:6239			
+WB	WBGene00001782	gst-34		Y1H11.1	gene	taxon:6239			
+WB	WBGene00001783	gst-35		Y1H11.2	gene	taxon:6239			
+WB	WBGene00001784	gst-36		R07B1.4	gene	taxon:6239			
+WB	WBGene00001785	gst-37		Y32G9A.1	gene	taxon:6239			
+WB	WBGene00001786	gst-38		F35E8.8	gene	taxon:6239			
+WB	WBGene00001787	gst-39		Y53F4B.33	gene	taxon:6239			
+WB	WBGene00001788	gst-40		F56B3.10|Y55F3C.i	gene	taxon:6239			
+WB	WBGene00001789	gst-41		R13D7.7	gene	taxon:6239			
+WB	WBGene00001790	gst-42		D1053.1	gene	taxon:6239			
+WB	WBGene00001791	gst-43		Y71F9AL.5	gene	taxon:6239			
+WB	WBGene00001792	gst-44		F13A7.10	gene	taxon:6239			
+WB	WBGene00001793	gsy-1		Y46G5A.31	gene	taxon:6239			
+WB	WBGene00001794	gta-1		K04D7.3	gene	taxon:6239			
+WB	WBGene00001795	gtl-1		C05C12.3|tag-33	gene	taxon:6239			
+WB	WBGene00001796	gtl-2		F54D1.5	gene	taxon:6239			
+WB	WBGene00001803	lite-1		C14F11.3|gur-2	gene	taxon:6239			
+WB	WBGene00001804	gur-3		ZC504.5	gene	taxon:6239			
+WB	WBGene00001805	gur-4		K09E4.5	gene	taxon:6239			
+WB	WBGene00001806	gur-5		ZK622.2	gene	taxon:6239			
+WB	WBGene00001808	gut-2		T10G3.6|lsm-2	gene	taxon:6239			
+WB	WBGene00001811	haf-1		C30H6.6	gene	taxon:6239			
+WB	WBGene00001812	haf-2		F43E2.4	gene	taxon:6239			
+WB	WBGene00001813	haf-3		F57A10.3	gene	taxon:6239			
+WB	WBGene00001814	haf-4		W04C9.1	gene	taxon:6239			
+WB	WBGene00001815	hmt-1		W09D6.6|haf-5	gene	taxon:6239			
+WB	WBGene00001816	haf-6		Y48G8AL.11	gene	taxon:6239			
+WB	WBGene00001817	haf-7		Y50E8A.16	gene	taxon:6239			
+WB	WBGene00001818	haf-8		Y57G11C.1	gene	taxon:6239			
+WB	WBGene00001819	haf-9		ZK484.2	gene	taxon:6239			
+WB	WBGene00001820	ham-1		F53B2.6	gene	taxon:6239			
+WB	WBGene00001821	ham-2		C07A12.1	gene	taxon:6239			
+WB	WBGene00001823	hap-1		ZC395.7	gene	taxon:6239			
+WB	WBGene00001824	hbl-1		F13D11.2|lin-57	gene	taxon:6239			
+WB	WBGene00001827	hcf-1		C46A5.9	gene	taxon:6239			
+WB	WBGene00001828	hch-1		F40E10.1|nas-34	gene	taxon:6239			
+WB	WBGene00001829	hcp-1		ZK1055.1	gene	taxon:6239			
+WB	WBGene00001830	hcp-2		T06E4.1	gene	taxon:6239			
+WB	WBGene00001831	hcp-3		F58A4.3|CeCENP-A|CENP-A	gene	taxon:6239			
+WB	WBGene00001832	hcp-4		T03F1.9|CeCENP-C|let-597	gene	taxon:6239			
+WB	WBGene00001833	hcp-6		Y110A7A.1|let-108|let-594	gene	taxon:6239			
+WB	WBGene00001834	hda-1		C53A5.3|gon-10|hdc-1	gene	taxon:6239			
+WB	WBGene00001835	hda-2		C08B11.2	gene	taxon:6239			
+WB	WBGene00001836	hda-3		R06C1.1	gene	taxon:6239			
+WB	WBGene00001837	hda-4		C10E2.3|hda-7	gene	taxon:6239			
+WB	WBGene00001838	hda-10		Y51H1A.5	gene	taxon:6239			
+WB	WBGene00001839	hdl-1		ZK829.2|Fragment R	gene	taxon:6239			
+WB	WBGene00001840	hel-1		C26D10.2|hel	gene	taxon:6239			
+WB	WBGene00001841	hen-1		C36B7.7	gene	taxon:6239			
+WB	WBGene00001842	her-1		ZK287.8	gene	taxon:6239			
+WB	WBGene00001843	hgo-1		W06D4.1|HGO	gene	taxon:6239			
+WB	WBGene00001844	hid-1		K02E10.2	gene	taxon:6239			
+WB	WBGene00001845	hid-2			gene	taxon:6239			
+WB	WBGene00001847	hid-4			gene	taxon:6239			
+WB	WBGene00001851	hif-1		F38A6.3	gene	taxon:6239			
+WB	WBGene00001852	hil-1		C30G7.1|H1.X	gene	taxon:6239			
+WB	WBGene00001853	hil-2		Y73B6BL.9|H1.2	gene	taxon:6239			
+WB	WBGene00001854	hil-3		F22F1.1|H1.3	gene	taxon:6239			
+WB	WBGene00001855	hil-4		C18G1.5|H1.4	gene	taxon:6239			
+WB	WBGene00001856	hil-5		B0414.3|H1.5	gene	taxon:6239			
+WB	WBGene00001857	hil-6		F59A7.4|H1.6	gene	taxon:6239			
+WB	WBGene00001858	hil-7		C01B10.5|H1.Q	gene	taxon:6239			
+WB	WBGene00001859	hil-8		T05E8.2	gene	taxon:6239			
+WB	WBGene00001860	him-1		F28B3.7|smc-1	gene	taxon:6239			
+WB	WBGene00001862	him-3		ZK381.1	gene	taxon:6239			
+WB	WBGene00001863	him-4		F15G9.4|cpg-14	gene	taxon:6239			
+WB	WBGene00001864	him-5		D1086.4	gene	taxon:6239			
+WB	WBGene00001865	him-6		T04A11.6|blm-1	gene	taxon:6239			
+WB	WBGene00001867	him-8		T07G12.12	gene	taxon:6239			
+WB	WBGene00001869	him-10		R12B2.4	gene	taxon:6239			
+WB	WBGene00001872	him-14		ZK1127.11	gene	taxon:6239			
+WB	WBGene00001874	him-17		T09E8.2	gene	taxon:6239			
+WB	WBGene00001875	his-1		T10C6.14	gene	taxon:6239			
+WB	WBGene00001876	his-2		T10C6.13	gene	taxon:6239			
+WB	WBGene00001877	his-3		T10C6.12	gene	taxon:6239			
+WB	WBGene00001878	his-4		T10C6.11	gene	taxon:6239			
+WB	WBGene00001879	his-5		F45F2.3	gene	taxon:6239			
+WB	WBGene00001880	his-6		F45F2.13	gene	taxon:6239			
+WB	WBGene00001881	his-7		F45F2.4	gene	taxon:6239			
+WB	WBGene00001882	his-8		F45F2.12	gene	taxon:6239			
+WB	WBGene00001883	his-9		ZK131.3	gene	taxon:6239			
+WB	WBGene00001884	his-10		ZK131.4	gene	taxon:6239			
+WB	WBGene00001885	his-11		ZK131.5	gene	taxon:6239			
+WB	WBGene00001886	his-12		ZK131.6	gene	taxon:6239			
+WB	WBGene00001887	his-13		ZK131.7	gene	taxon:6239			
+WB	WBGene00001888	his-14		ZK131.8	gene	taxon:6239			
+WB	WBGene00001889	his-15		ZK131.9	gene	taxon:6239			
+WB	WBGene00001890	his-16		ZK131.10	gene	taxon:6239			
+WB	WBGene00001891	his-17		K06C4.5	gene	taxon:6239			
+WB	WBGene00001892	his-18		K06C4.10	gene	taxon:6239			
+WB	WBGene00001893	his-19		K06C4.11	gene	taxon:6239			
+WB	WBGene00001894	his-20		K06C4.4	gene	taxon:6239			
+WB	WBGene00001895	his-21		K06C4.3	gene	taxon:6239			
+WB	WBGene00001896	his-22		K06C4.12	gene	taxon:6239			
+WB	WBGene00001898	his-24		M163.3|H1.1|HH1|Histone H1.1	gene	taxon:6239			
+WB	WBGene00001899	his-25		ZK131.2	gene	taxon:6239			
+WB	WBGene00001900	his-26		ZK131.1	gene	taxon:6239			
+WB	WBGene00001901	his-27		K06C4.13	gene	taxon:6239			
+WB	WBGene00001902	his-28		K06C4.2	gene	taxon:6239			
+WB	WBGene00001903	his-29		F35H10.11	gene	taxon:6239			
+WB	WBGene00001904	his-30		F35H10.1	gene	taxon:6239			
+WB	WBGene00001905	his-31		F17E9.12	gene	taxon:6239			
+WB	WBGene00001906	his-32		F17E9.10	gene	taxon:6239			
+WB	WBGene00001907	his-33		F17E9.13	gene	taxon:6239			
+WB	WBGene00001908	his-34		F17E9.9	gene	taxon:6239			
+WB	WBGene00001909	his-35		C50F4.13	gene	taxon:6239			
+WB	WBGene00001911	his-37		C50F4.7	gene	taxon:6239			
+WB	WBGene00001912	his-38		K03A1.6	gene	taxon:6239			
+WB	WBGene00001913	his-39		F45F2.2|his-23	gene	taxon:6239			
+WB	WBGene00001914	his-40		K03A1.1	gene	taxon:6239			
+WB	WBGene00001915	his-41		C50F4.5	gene	taxon:6239			
+WB	WBGene00001916	his-42		F08G2.3	gene	taxon:6239			
+WB	WBGene00001917	his-43		F08G2.2	gene	taxon:6239			
+WB	WBGene00001918	his-44		F08G2.1|his 11	gene	taxon:6239			
+WB	WBGene00001919	his-45		B0035.10|2O113|his 9	gene	taxon:6239			
+WB	WBGene00001920	his-46		B0035.9	gene	taxon:6239			
+WB	WBGene00001921	his-47		B0035.7|his 12	gene	taxon:6239			
+WB	WBGene00001922	his-48		B0035.8	gene	taxon:6239			
+WB	WBGene00001923	his-49		F07B7.5	gene	taxon:6239			
+WB	WBGene00001924	his-50		F07B7.9	gene	taxon:6239			
+WB	WBGene00001925	his-51		F07B7.10	gene	taxon:6239			
+WB	WBGene00001926	his-52		F07B7.4	gene	taxon:6239			
+WB	WBGene00001927	his-53		F07B7.3	gene	taxon:6239			
+WB	WBGene00001928	his-54		F07B7.11	gene	taxon:6239			
+WB	WBGene00001929	his-55		F54E12.1	gene	taxon:6239			
+WB	WBGene00001930	his-56		F54E12.3	gene	taxon:6239			
+WB	WBGene00001931	his-57		F54E12.5	gene	taxon:6239			
+WB	WBGene00001932	his-58		F54E12.4	gene	taxon:6239			
+WB	WBGene00001933	his-59		F55G1.2	gene	taxon:6239			
+WB	WBGene00001934	his-60		F55G1.11	gene	taxon:6239			
+WB	WBGene00001935	his-61		F55G1.10	gene	taxon:6239			
+WB	WBGene00001936	his-62		F55G1.3	gene	taxon:6239			
+WB	WBGene00001937	his-63		F22B3.2	gene	taxon:6239			
+WB	WBGene00001938	his-64		F22B3.1|his 10	gene	taxon:6239			
+WB	WBGene00001939	his-65		H02I12.7	gene	taxon:6239			
+WB	WBGene00001940	his-66		H02I12.6	gene	taxon:6239			
+WB	WBGene00001941	his-67		T23D8.5	gene	taxon:6239			
+WB	WBGene00001942	his-68		T23D8.6	gene	taxon:6239			
+WB	WBGene00001943	his-69		E03A3.3	gene	taxon:6239			
+WB	WBGene00001944	his-70		E03A3.4	gene	taxon:6239			
+WB	WBGene00001945	his-71		F45E1.6	gene	taxon:6239			
+WB	WBGene00001946	his-72		Y49E10.6	gene	taxon:6239			
+WB	WBGene00001947	his-73		W09H1.2	gene	taxon:6239			
+WB	WBGene00001948	hlh-1		B0304.1|MyoD1	gene	taxon:6239			
+WB	WBGene00001949	hlh-2		M05B5.5	gene	taxon:6239			
+WB	WBGene00001950	hlh-3		T24B8.6	gene	taxon:6239			
+WB	WBGene00001951	hlh-4		T05G5.2	gene	taxon:6239			
+WB	WBGene00001952	hlh-6		T15H9.3	gene	taxon:6239			
+WB	WBGene00001953	hlh-8		C02B8.4	gene	taxon:6239			
+WB	WBGene00001954	hlh-10		ZK682.4|CeABF-1	gene	taxon:6239			
+WB	WBGene00001955	hlh-11		F58A4.7	gene	taxon:6239			
+WB	WBGene00001956	hlh-12		C28C12.8|mig-24	gene	taxon:6239			
+WB	WBGene00001957	hlh-13		F48D6.3|ferd-3l	gene	taxon:6239			
+WB	WBGene00001958	hlh-14		C18A3.8	gene	taxon:6239			
+WB	WBGene00001959	hlh-15		C43H6.8	gene	taxon:6239			
+WB	WBGene00001960	hlh-16		DY3.3	gene	taxon:6239			
+WB	WBGene00001961	hlh-17		F38C2.2	gene	taxon:6239			
+WB	WBGene00001962	hlh-19		F57C12.3	gene	taxon:6239			
+WB	WBGene00001964	hlh-25		C17C3.7	gene	taxon:6239			
+WB	WBGene00001965	hlh-26		C17C3.8	gene	taxon:6239			
+WB	WBGene00001966	hlh-27		C17C3.10	gene	taxon:6239			
+WB	WBGene00001967	hlh-28		F31A3.2	gene	taxon:6239			
+WB	WBGene00001968	hlh-29		F31A3.4	gene	taxon:6239			
+WB	WBGene00001971	hmg-1.1		Y48B6A.14	gene	taxon:6239			
+WB	WBGene00001972	hmg-1.2		F47D12.4|son-1	gene	taxon:6239			
+WB	WBGene00001973	hmg-3		C32F10.5	gene	taxon:6239			
+WB	WBGene00001974	hmg-4		T20B12.8	gene	taxon:6239			
+WB	WBGene00001975	hmg-5		F45E4.9	gene	taxon:6239			
+WB	WBGene00001976	hmg-11		T05A7.4|hmg-I-alpha	gene	taxon:6239			
+WB	WBGene00001977	hmg-12		Y17G7A.1|hmg-I-beta	gene	taxon:6239			
+WB	WBGene00001978	hmp-1		R13H4.4	gene	taxon:6239			
+WB	WBGene00001979	hmp-2		K05C4.6|mad-1	gene	taxon:6239			
+WB	WBGene00001980	hmr-1		W02B9.1	gene	taxon:6239			
+WB	WBGene00001981	hnd-1		C44C10.8|hlh-18|hlh-22	gene	taxon:6239			
+WB	WBGene00001983	hoe-1		E04A4.4	gene	taxon:6239			
+WB	WBGene00001984	hog-1		W06B11.4	gene	taxon:6239			
+WB	WBGene00001985	hop-1		C18E3.8	gene	taxon:6239			
+WB	WBGene00001991	hot-6		C13G3.2	gene	taxon:6239			
+WB	WBGene00001993	hpd-1		T21C12.2	gene	taxon:6239			
+WB	WBGene00001994	hpk-1		F20B6.8	gene	taxon:6239			
+WB	WBGene00001995	hpl-1		K08H2.6	gene	taxon:6239			
+WB	WBGene00001996	hpl-2		K01G5.2	gene	taxon:6239			
+WB	WBGene00001997	hpr-9		Y39A1A.23|Y39A1A	gene	taxon:6239			
+WB	WBGene00001998	hpr-17		F32A11.2	gene	taxon:6239			
+WB	WBGene00001999	hrpa-1		F42A6.7|hrp-1|rbp-1	gene	taxon:6239			
+WB	WBGene00002000	hrpr-1		F58D5.1|hrp-2	gene	taxon:6239			
+WB	WBGene00002001	hars-1		T11G6.1|hrs-1	gene	taxon:6239			
+WB	WBGene00002002	hsb-1		K08E7.2	gene	taxon:6239			
+WB	WBGene00002003	hse-5		B0285.5	gene	taxon:6239			
+WB	WBGene00002004	hsf-1		Y53C10A.12	gene	taxon:6239			
+WB	WBGene00002005	hsp-1		F26D10.3	gene	taxon:6239			
+WB	WBGene00002007	hsp-3		C15H9.6	gene	taxon:6239			
+WB	WBGene00002008	hsp-4		F43E2.8	gene	taxon:6239			
+WB	WBGene00002010	hsp-6		C37H5.8|mot-2	gene	taxon:6239			
+WB	WBGene00002011	hsp-12.2		C14B9.1	gene	taxon:6239			
+WB	WBGene00002012	hsp-12.3		F38E11.1	gene	taxon:6239			
+WB	WBGene00002013	hsp-12.6		F38E11.2|hsp-20	gene	taxon:6239			
+WB	WBGene00002015	hsp-16.1		T27E4.8|hsp-16	gene	taxon:6239			
+WB	WBGene00002016	hsp-16.2		Y46H3A.3|hsp-16|hsp16-2	gene	taxon:6239			
+WB	WBGene00002017	hsp-16.11		T27E4.2|hsp-16	gene	taxon:6239			
+WB	WBGene00002018	hsp-16.41		Y46H3A.2|hsp-16	gene	taxon:6239			
+WB	WBGene00002019	hsp-16.48		T27E4.3|hsp-16	gene	taxon:6239			
+WB	WBGene00002020	hsp-16.49		T27E4.9|hsp-16	gene	taxon:6239			
+WB	WBGene00002023	hsp-25		C09B8.6|HSP25	gene	taxon:6239			
+WB	WBGene00002025	hsp-60		Y22D7AL.5|HSP60	gene	taxon:6239			
+WB	WBGene00002026	hsp-70		C12C8.1|mtHSP70	gene	taxon:6239			
+WB	WBGene00002027	hsr-9		T05F1.6|T05F1.6a\/b	gene	taxon:6239			
+WB	WBGene00002028	hst-1		F08B4.6	gene	taxon:6239			
+WB	WBGene00002029	hst-2		C34F6.4	gene	taxon:6239			
+WB	WBGene00002030	hst-3.1		F40H3.5|hst-3	gene	taxon:6239			
+WB	WBGene00002031	hst-6		Y34B4A.3|Y34B4A.e	gene	taxon:6239			
+WB	WBGene00002032	htp-1		F41H10.10|tag-35	gene	taxon:6239			
+WB	WBGene00002033	htp-2		Y73B6BL.2	gene	taxon:6239			
+WB	WBGene00002034	htp-3		F57C9.5	gene	taxon:6239			
+WB	WBGene00002035	hum-1		F29D10.4	gene	taxon:6239			
+WB	WBGene00002036	hum-2		F36D4.3	gene	taxon:6239			
+WB	WBGene00002037	hum-4		F46C3.3	gene	taxon:6239			
+WB	WBGene00002038	hum-5		T02C12.1|mceIA	gene	taxon:6239			
+WB	WBGene00002039	hum-6		T10H10.1	gene	taxon:6239			
+WB	WBGene00002040	hum-7		F56A6.2	gene	taxon:6239			
+WB	WBGene00002041	hum-8		Y66H1A.6	gene	taxon:6239			
+WB	WBGene00002042	hus-1		H26D21.1|dam-1|H26D21.1	gene	taxon:6239			
+WB	WBGene00002043	hyl-1		C09G4.1|LAG1-1	gene	taxon:6239			
+WB	WBGene00002044	hyl-2		K02G10.6	gene	taxon:6239			
+WB	WBGene00002045	icd-1		C56C10.8	gene	taxon:6239			
+WB	WBGene00002046	icln-1		C01F6.8|ICln	gene	taxon:6239			
+WB	WBGene00002047	icp-1		Y39G10AR.13	gene	taxon:6239			
+WB	WBGene00002048	ida-1		B0244.2|ia2	gene	taxon:6239			
+WB	WBGene00002049	idf-1		|duf-1	gene	taxon:6239			
+WB	WBGene00002050	ifa-1		F38B2.1|A1|Cel IF A1|CelIF a1	gene	taxon:6239			
+WB	WBGene00002051	ifa-3		F52E10.5|A3|Cel IF A3|CelIF a3	gene	taxon:6239			
+WB	WBGene00002052	ifa-4		K05B2.3|Cel IF A4|CelIF a4	gene	taxon:6239			
+WB	WBGene00002053	ifb-1		F10C1.2|B1|Cel IF b1|CelIF b1|vab-21	gene	taxon:6239			
+WB	WBGene00002054	ifb-2		F10C1.7|CelIF b2|IF b2	gene	taxon:6239			
+WB	WBGene00002055	ifc-1		F37B4.2|Cel IF C1|CelIF c1	gene	taxon:6239			
+WB	WBGene00002056	ifc-2		M6.1|Cel IF C2|CelIF c2|ecp-1	gene	taxon:6239			
+WB	WBGene00002057	ifd-1		R04E5.10|IF D1	gene	taxon:6239			
+WB	WBGene00002058	ifd-2		F25E2.4|IF D2	gene	taxon:6239			
+WB	WBGene00002059	ife-1		F53A2.6	gene	taxon:6239			
+WB	WBGene00002060	ife-2		R04A9.4	gene	taxon:6239			
+WB	WBGene00002061	ife-3		B0348.6	gene	taxon:6239			
+WB	WBGene00002062	ife-4		C05D9.5	gene	taxon:6239			
+WB	WBGene00002063	ife-5		Y57A10A.30	gene	taxon:6239			
+WB	WBGene00002064	iff-1		T05G5.10	gene	taxon:6239			
+WB	WBGene00002065	iff-2		F54C9.1	gene	taxon:6239			
+WB	WBGene00002066	ifg-1		M110.4	gene	taxon:6239			
+WB	WBGene00002067	ifp-1		C43C3.1|IF E1	gene	taxon:6239			
+WB	WBGene00002068	ify-1		C27A2.3	gene	taxon:6239			
+WB	WBGene00002069	ikb-1		C04F12.3	gene	taxon:6239			
+WB	WBGene00002070	ile-1		K07A1.8	gene	taxon:6239			
+WB	WBGene00002071	ile-2		T04G9.3	gene	taxon:6239			
+WB	WBGene00002072	ima-1		T19B10.7	gene	taxon:6239			
+WB	WBGene00002073	ima-2		F26B1.3|1G893	gene	taxon:6239			
+WB	WBGene00002074	ima-3		F32E10.4	gene	taxon:6239			
+WB	WBGene00002075	imb-1		F28B3.8|let-595	gene	taxon:6239			
+WB	WBGene00002076	imb-2		R06A4.4	gene	taxon:6239			
+WB	WBGene00002077	imb-3		C53D5.6	gene	taxon:6239			
+WB	WBGene00002078	xpo-1		ZK742.1|imb-4	gene	taxon:6239			
+WB	WBGene00002079	xpo-2		Y48G1A.5|imb-5|Y48G1A.c|Y48G1A.d	gene	taxon:6239			
+WB	WBGene00002080	xpo-3		C49H3.10|imb-6	gene	taxon:6239			
+WB	WBGene00002081	ina-1		F54G8.3	gene	taxon:6239			
+WB	WBGene00002083	inf-1		F57B9.6|Ce1F|CeIF	gene	taxon:6239			
+WB	WBGene00002084	ins-1		F13B12.5|aho-2|ILP1	gene	taxon:6239			
+WB	WBGene00002085	ins-2		ZK75.2	gene	taxon:6239			
+WB	WBGene00002086	ins-3		ZK75.3	gene	taxon:6239			
+WB	WBGene00002087	ins-4		ZK75.1|ZK84.d	gene	taxon:6239			
+WB	WBGene00002088	ins-5		ZK84.3	gene	taxon:6239			
+WB	WBGene00002089	ins-6		ZK84.6	gene	taxon:6239			
+WB	WBGene00002090	ins-7		ZK1251.2	gene	taxon:6239			
+WB	WBGene00002091	ins-8		ZK1251.11	gene	taxon:6239			
+WB	WBGene00002092	ins-9		C06E2.8	gene	taxon:6239			
+WB	WBGene00002094	ins-11		C17C3.4	gene	taxon:6239			
+WB	WBGene00002096	ins-13		C17C3.18	gene	taxon:6239			
+WB	WBGene00002098	ins-15		F41G3.17	gene	taxon:6239			
+WB	WBGene00002100	ins-17		F56F3.6|Ceinsulin-2|ins-2	gene	taxon:6239			
+WB	WBGene00002101	ins-18		T28B8.2|Ceinsulin-1|igf-1|ins-1	gene	taxon:6239			
+WB	WBGene00002102	ins-19		T10D4.13	gene	taxon:6239			
+WB	WBGene00002103	ins-20		ZK84.7	gene	taxon:6239			
+WB	WBGene00002104	ins-21		M04D8.1	gene	taxon:6239			
+WB	WBGene00002105	ins-22		M04D8.2	gene	taxon:6239			
+WB	WBGene00002106	ins-23		M04D8.3	gene	taxon:6239			
+WB	WBGene00002107	ins-24		ZC334.3	gene	taxon:6239			
+WB	WBGene00002108	ins-25		ZC334.8	gene	taxon:6239			
+WB	WBGene00002109	ins-26		ZC334.1	gene	taxon:6239			
+WB	WBGene00002110	ins-27		ZC334.11	gene	taxon:6239			
+WB	WBGene00002111	ins-28		ZC334.9	gene	taxon:6239			
+WB	WBGene00002112	ins-29		ZC334.10	gene	taxon:6239			
+WB	WBGene00002113	ins-30		ZC334.2	gene	taxon:6239			
+WB	WBGene00002114	ins-31		T10D4.4	gene	taxon:6239			
+WB	WBGene00002115	ins-32		Y8A9A.6	gene	taxon:6239			
+WB	WBGene00002116	ins-33		W09C5.4	gene	taxon:6239			
+WB	WBGene00002118	ins-35		K02E2.4	gene	taxon:6239			
+WB	WBGene00002120	ins-37		F08G2.6	gene	taxon:6239			
+WB	WBGene00002123	inx-1		C16E9.4|opu-1|pcr55	gene	taxon:6239			
+WB	WBGene00002124	inx-2		F08G12.10|opu-2|XL914	gene	taxon:6239			
+WB	WBGene00002125	inx-3		F22F4.2|opu-3	gene	taxon:6239			
+WB	WBGene00002127	inx-5		R09F10.4|opu-5	gene	taxon:6239			
+WB	WBGene00002128	inx-6		C36H8.2|opu-6	gene	taxon:6239			
+WB	WBGene00002129	inx-7		K02B2.4|opu-7	gene	taxon:6239			
+WB	WBGene00002130	inx-8		ZK792.2|opu-8	gene	taxon:6239			
+WB	WBGene00002131	inx-9		ZK792.3|opu-9	gene	taxon:6239			
+WB	WBGene00002132	inx-10		T18H9.5|opu-10	gene	taxon:6239			
+WB	WBGene00002133	inx-11		W04D2.3|opu-11	gene	taxon:6239			
+WB	WBGene00002134	inx-12		ZK770.3|let-368|opu-12	gene	taxon:6239			
+WB	WBGene00002135	inx-13		Y8G1A.2|let-585|opu-13	gene	taxon:6239			
+WB	WBGene00002136	inx-14		F07A5.1|opu-14	gene	taxon:6239			
+WB	WBGene00002137	inx-15		R12E2.9|opu-15	gene	taxon:6239			
+WB	WBGene00002138	inx-16		R12E2.5|opu-16	gene	taxon:6239			
+WB	WBGene00002139	inx-17		R12E2.4|1E733|opu-17	gene	taxon:6239			
+WB	WBGene00002140	inx-18		C18H7.2|opu-18	gene	taxon:6239			
+WB	WBGene00002141	inx-19		T16H5.1|nsy-5|opu-19	gene	taxon:6239			
+WB	WBGene00002142	inx-20		T23H4.1|opu-20	gene	taxon:6239			
+WB	WBGene00002143	inx-21		Y47G6A.1|opu-21	gene	taxon:6239			
+WB	WBGene00002144	inx-22		Y47G6A.2	gene	taxon:6239			
+WB	WBGene00002146	ipp-5		C09B8.1	gene	taxon:6239			
+WB	WBGene00002147	ire-1		C41C4.4	gene	taxon:6239			
+WB	WBGene00002148	gon-14		F44C4.4|iri-1	gene	taxon:6239			
+WB	WBGene00002149	irk-1		R03E9.4|irk-4	gene	taxon:6239			
+WB	WBGene00002150	irk-2		M02A10.2	gene	taxon:6239			
+WB	WBGene00002151	irk-3		K04G11.5	gene	taxon:6239			
+WB	WBGene00002152	iars-1		R11A8.6|irs-1	gene	taxon:6239			
+WB	WBGene00002153	iars-2		C25A1.7|irs-2	gene	taxon:6239			
+WB	WBGene00002162	isp-1		F42G8.12	gene	taxon:6239			
+WB	WBGene00002163	ist-1		C54D1.3	gene	taxon:6239			
+WB	WBGene00002169	isw-1		F37A4.8	gene	taxon:6239			
+WB	WBGene00002173	itr-1		F33D4.2|dec-4|lfe-1	gene	taxon:6239			
+WB	WBGene00002174	itx-1		W03D8.6	gene	taxon:6239			
+WB	WBGene00002175	jac-1		Y105C5B.21	gene	taxon:6239			
+WB	WBGene00002177	jkk-1		F35C8.3|sek-2	gene	taxon:6239			
+WB	WBGene00002178	jnk-1		B0478.1|sak-1	gene	taxon:6239			
+WB	WBGene00002179	jph-1		T22C1.7|JP	gene	taxon:6239			
+WB	WBGene00002180	jtr-1		Y77E11A.4	gene	taxon:6239			
+WB	WBGene00002181	kal-1		K03D10.1	gene	taxon:6239			
+WB	WBGene00002182	kap-1		F08F8.3	gene	taxon:6239			
+WB	WBGene00002183	kat-1		T02G5.8	gene	taxon:6239			
+WB	WBGene00002187	kgb-1		T07A9.3	gene	taxon:6239			
+WB	WBGene00002188	kgb-2		ZC416.4	gene	taxon:6239			
+WB	WBGene00002189	kin-1		ZK909.2	gene	taxon:6239			
+WB	WBGene00002190	kin-2		R07E4.6	gene	taxon:6239			
+WB	WBGene00002191	kin-3		B0205.7|casein kinase II|CKIIalpha	gene	taxon:6239			
+WB	WBGene00002192	kin-4		C10C6.1	gene	taxon:6239			
+WB	WBGene00002193	kin-5		T13H10.1	gene	taxon:6239			
+WB	WBGene00002195	kin-9		F08F1.1	gene	taxon:6239			
+WB	WBGene00002196	kin-10		T01G9.6|kin-5	gene	taxon:6239			
+WB	WBGene00002198	kin-14		F22D6.1	gene	taxon:6239			
+WB	WBGene00002199	kin-15		M176.6	gene	taxon:6239			
+WB	WBGene00002200	kin-16		M176.7	gene	taxon:6239			
+WB	WBGene00002201	kin-18		T17E9.1|Sulu	gene	taxon:6239			
+WB	WBGene00002202	kin-19		C03C10.1	gene	taxon:6239			
+WB	WBGene00002203	kin-20		F46F2.2	gene	taxon:6239			
+WB	WBGene00002204	kin-21		W08D2.8	gene	taxon:6239			
+WB	WBGene00002206	kin-24		K07F5.4	gene	taxon:6239			
+WB	WBGene00002207	sid-3		B0302.1|kin-25	gene	taxon:6239			
+WB	WBGene00002208	kin-26		T06C10.6	gene	taxon:6239			
+WB	WBGene00002210	kin-29		F58H12.1|sma-11|sns-8	gene	taxon:6239			
+WB	WBGene00002211	kin-30		M01B2.1	gene	taxon:6239			
+WB	WBGene00002213	kin-32		C30F8.4|C30F8.c	gene	taxon:6239			
+WB	WBGene00002214	klc-1		M7.2	gene	taxon:6239			
+WB	WBGene00002215	klc-2		C18C4.10	gene	taxon:6239			
+WB	WBGene00002216	klp-3		T09A5.2	gene	taxon:6239			
+WB	WBGene00002217	klp-4		F56E3.3	gene	taxon:6239			
+WB	WBGene00002218	klp-6		R144.1	gene	taxon:6239			
+WB	WBGene00002219	klp-7		K11D9.1|11d9	gene	taxon:6239			
+WB	WBGene00002222	klp-11		F20C5.2|krp95	gene	taxon:6239			
+WB	WBGene00002223	klp-12		T01G1.1	gene	taxon:6239			
+WB	WBGene00002224	klp-13		F22F4.3	gene	taxon:6239			
+WB	WBGene00002225	klp-15		M01E11.6	gene	taxon:6239			
+WB	WBGene00002226	klp-16		C41G7.2	gene	taxon:6239			
+WB	WBGene00002227	klp-17		W02B12.7	gene	taxon:6239			
+WB	WBGene00002228	klp-18		C06G3.2	gene	taxon:6239			
+WB	WBGene00002229	klp-19		Y43F4B.6	gene	taxon:6239			
+WB	WBGene00002230	klp-20		Y50D7A.6|krp85	gene	taxon:6239			
+WB	WBGene00002231	knl-1		C02F5.1	gene	taxon:6239			
+WB	WBGene00002232	kpc-1		F11A6.1	gene	taxon:6239			
+WB	WBGene00002233	kqt-1		C25B8.1|klq-1	gene	taxon:6239			
+WB	WBGene00002234	kqt-2		M60.5|klq-2	gene	taxon:6239			
+WB	WBGene00002235	kqt-3		Y54G9A.3	gene	taxon:6239			
+WB	WBGene00002238	kars-1		T02G5.9|krs-1	gene	taxon:6239			
+WB	WBGene00002239	ksr-1		F13B9.5|sar-2|sur-3	gene	taxon:6239			
+WB	WBGene00002240	ksr-2		F58D5.4|pex-1	gene	taxon:6239			
+WB	WBGene00002242	kvs-1		C53C9.3	gene	taxon:6239			
+WB	WBGene00002243	lad-2		Y54G2A.25|Y54G2A.i|Y54G2A.j|Y54G2A.k|Y54G2A.l	gene	taxon:6239			
+WB	WBGene00002244	laf-1		Y71H2AM.19	gene	taxon:6239			
+WB	WBGene00002245	lag-1		K08B4.1	gene	taxon:6239			
+WB	WBGene00002246	lag-2		Y73C8B.4|let-461|sel-3	gene	taxon:6239			
+WB	WBGene00002247	lam-1		W03F8.5|LAMB\/1	gene	taxon:6239			
+WB	WBGene00002248	lam-3		T22A3.8|lama1\/2	gene	taxon:6239			
+WB	WBGene00002249	lap-1		ZK353.6	gene	taxon:6239			
+WB	WBGene00002250	lap-2		W07G4.4	gene	taxon:6239			
+WB	WBGene00002251	lat-1		B0457.1	gene	taxon:6239			
+WB	WBGene00002252	lat-2		B0286.2|tag-12	gene	taxon:6239			
+WB	WBGene00002253	lbp-1		F40F4.3	gene	taxon:6239			
+WB	WBGene00002254	lbp-2		F40F4.2	gene	taxon:6239			
+WB	WBGene00002255	lbp-3		F40F4.4	gene	taxon:6239			
+WB	WBGene00002256	lbp-4		ZK742.5	gene	taxon:6239			
+WB	WBGene00002257	lbp-5		W02D3.7	gene	taxon:6239			
+WB	WBGene00002258	lbp-6		W02D3.5	gene	taxon:6239			
+WB	WBGene00002259	lbp-7		T22G5.2	gene	taxon:6239			
+WB	WBGene00002260	lbp-8		T22G5.6	gene	taxon:6239			
+WB	WBGene00002261	ldb-1		F58A3.1	gene	taxon:6239			
+WB	WBGene00002262	ldh-1		F13D12.2|LDH	gene	taxon:6239			
+WB	WBGene00002263	lea-1		K08H10.1|Ce-LEA|lea	gene	taxon:6239			
+WB	WBGene00002264	lec-1		W09H1.6	gene	taxon:6239			
+WB	WBGene00002265	lec-2		F52H3.7	gene	taxon:6239			
+WB	WBGene00002266	lec-3		ZK892.1	gene	taxon:6239			
+WB	WBGene00002267	lec-4		C44F1.3	gene	taxon:6239			
+WB	WBGene00002268	lec-5		ZK1248.16	gene	taxon:6239			
+WB	WBGene00002269	lec-6		Y55B1AR.1	gene	taxon:6239			
+WB	WBGene00002270	lec-7		R07B1.2	gene	taxon:6239			
+WB	WBGene00002271	lec-8		R07B1.10	gene	taxon:6239			
+WB	WBGene00002272	lec-9		C16H3.2	gene	taxon:6239			
+WB	WBGene00002273	lec-10		W01A11.4	gene	taxon:6239			
+WB	WBGene00002274	lec-11		F38A5.3	gene	taxon:6239			
+WB	WBGene00002275	lem-2		W01G7.5|CeMAN1|Y39G8C.a	gene	taxon:6239			
+WB	WBGene00002276	lem-3		F42H11.2|rad-1	gene	taxon:6239			
+WB	WBGene00002278	lep-2		Y55F3AM.6	gene	taxon:6239			
+WB	WBGene00002279	let-1			gene	taxon:6239			
+WB	WBGene00002280	let-2		F01G12.5|alpha-2 (IV) collagen|clb-1|let-8|sup-20	gene	taxon:6239			
+WB	WBGene00002281	let-3			gene	taxon:6239			
+WB	WBGene00002282	let-4		C44H4.2|sym-5	gene	taxon:6239			
+WB	WBGene00002283	let-5			gene	taxon:6239			
+WB	WBGene00002284	let-6			gene	taxon:6239			
+WB	WBGene00002285	let-7		C05G5.6	gene	taxon:6239			
+WB	WBGene00002295	let-19		K08F8.6|mdt-13|pqn-49|psa-7|TRAP240	gene	taxon:6239			
+WB	WBGene00002297	ect-2		T19E10.1|let-21	gene	taxon:6239			
+WB	WBGene00002299	let-23		ZK1067.1|kin-7	gene	taxon:6239			
+WB	WBGene00002324	let-49		Y54E5B.3|mdt-7|med-7	gene	taxon:6239			
+WB	WBGene00002335	let-60		ZK792.6|lin-34	gene	taxon:6239			
+WB	WBGene00002344	let-70		M7.1|ubc-2	gene	taxon:6239			
+WB	WBGene00002348	myo-1		R06C7.10|myosin I	gene	taxon:6239			
+WB	WBGene00002363	let-92		F38H4.9	gene	taxon:6239			
+WB	WBGene00002368	let-99		K08E7.3	gene	taxon:6239			
+WB	WBGene00002393	lpr-1		Y65B4BR.2|let-124	gene	taxon:6239			
+WB	WBGene00002466	let-237			gene	taxon:6239			
+WB	WBGene00002497	let-268		F52H3.1	gene	taxon:6239			
+WB	WBGene00002572	let-350			gene	taxon:6239			
+WB	WBGene00002583	let-363		B0261.2|CeTor|let-103|let-526|let-603|let-631|TOR	gene	taxon:6239			
+WB	WBGene00002601	let-381		F26B1.7	gene	taxon:6239			
+WB	WBGene00002632	let-413		F26D11.11	gene	taxon:6239			
+WB	WBGene00002637	let-418		F26F12.7|chd-4|evl-11	gene	taxon:6239			
+WB	WBGene00002694	let-502		C10H11.9|let-531	gene	taxon:6239			
+WB	WBGene00002696	let-504		E01A2.4	gene	taxon:6239			
+WB	WBGene00002717	let-526		C01G8.9|F48C1.h|let-104|let-519|lss-4|psa-10|swsn-8	gene	taxon:6239			
+WB	WBGene00002783	let-607		F57B10.1	gene	taxon:6239			
+WB	WBGene00002804	let-630		Y110A7A.19|let-596	gene	taxon:6239			
+WB	WBGene00002827	let-653		C29E6.1	gene	taxon:6239			
+WB	WBGene00002845	let-711		F57B9.2|ntl-1|spn-3	gene	taxon:6239			
+WB	WBGene00002850	let-716		C16A3.3	gene	taxon:6239			
+WB	WBGene00002855	let-721		C05D11.12	gene	taxon:6239			
+WB	WBGene00002879	let-754		C29E4.8	gene	taxon:6239			
+WB	WBGene00002881	let-756		C05D11.4	gene	taxon:6239			
+WB	WBGene00002889	let-765		F20H11.2|let-745|nsh-1	gene	taxon:6239			
+WB	WBGene00002891	let-767		C56G2.6|dhs-10	gene	taxon:6239			
+WB	WBGene00002915	let-805		H19M22.2|H19M22.a|H19M22.b|H19M22.e|Y71H2AL.d|Y71H2AL.e|Y71H2AL.f	gene	taxon:6239			
+WB	WBGene00002957	let-858		F33A8.1	gene	taxon:6239			
+WB	WBGene00002974	lev-1		F09E8.7|acr-1|tmr-1	gene	taxon:6239			
+WB	WBGene00002975	lev-8		C35C5.5|acr-13	gene	taxon:6239			
+WB	WBGene00002976	lev-9		T07H6.5	gene	taxon:6239			
+WB	WBGene00002977	lev-10		Y105E8A.7|1O991|Y105E8E.f	gene	taxon:6239			
+WB	WBGene00002978	lev-11		Y105E8B.1|CeTM|tmy-1|Y105E8B.c	gene	taxon:6239			
+WB	WBGene00002979	lfe-2		C46H11.4|C46H11.g	gene	taxon:6239			
+WB	WBGene00002980	lgg-1		C32D5.9|2G636|atg-8.1	gene	taxon:6239			
+WB	WBGene00002981	lgg-2		ZK593.6|atg-8.2	gene	taxon:6239			
+WB	WBGene00002982	lgg-3		B0336.8|atg-12	gene	taxon:6239			
+WB	WBGene00002983	lgx-1		C54G7.3|pqn-23	gene	taxon:6239			
+WB	WBGene00002985	lig-1		C29A12.3	gene	taxon:6239			
+WB	WBGene00002986	lig-4		C07H6.1	gene	taxon:6239			
+WB	WBGene00002987	lim-4		ZC64.4|nss-1	gene	taxon:6239			
+WB	WBGene00002988	lim-6		K03E6.1	gene	taxon:6239			
+WB	WBGene00002989	lim-7		C04F1.3|let-377	gene	taxon:6239			
+WB	WBGene00002990	lin-1		C37F5.1|elk-1	gene	taxon:6239			
+WB	WBGene00002991	lin-2		F17E5.1	gene	taxon:6239			
+WB	WBGene00002992	lin-3		F36H1.4|let-94|sli-4	gene	taxon:6239			
+WB	WBGene00002993	lin-4		F59G1.6	gene	taxon:6239			
+WB	WBGene00002994	lin-5		T09A5.10	gene	taxon:6239			
+WB	WBGene00002996	lin-7		Y54G11A.10	gene	taxon:6239			
+WB	WBGene00002997	lin-8		B0454.1|Y25C1A.i	gene	taxon:6239			
+WB	WBGene00002998	lin-9		ZK637.7	gene	taxon:6239			
+WB	WBGene00002999	lin-10		C09H6.2	gene	taxon:6239			
+WB	WBGene00003000	lin-11		ZC247.3	gene	taxon:6239			
+WB	WBGene00003001	lin-12		R107.8	gene	taxon:6239			
+WB	WBGene00003002	lin-13		C03B8.4|lin-51	gene	taxon:6239			
+WB	WBGene00003003	lin-14		T25C12.1	gene	taxon:6239			
+WB	WBGene00003006	lin-17		Y71F9B.5	gene	taxon:6239			
+WB	WBGene00003007	lin-18		C16B8.1	gene	taxon:6239			
+WB	WBGene00003008	lin-22		Y54G2A.1|4D656|hlh-9	gene	taxon:6239			
+WB	WBGene00003009	lin-23		K10B2.1|stu-1	gene	taxon:6239			
+WB	WBGene00003011	lin-25		F56H9.5|mdt-24	gene	taxon:6239			
+WB	WBGene00003012	lin-26		F18A1.2	gene	taxon:6239			
+WB	WBGene00003014	lin-28		F02E9.2	gene	taxon:6239			
+WB	WBGene00003015	lin-29		W03C9.4|egl-29	gene	taxon:6239			
+WB	WBGene00003017	lin-31		K10G6.1|K10G6.a	gene	taxon:6239			
+WB	WBGene00003018	lin-32		T14F9.5|hlh-7	gene	taxon:6239			
+WB	WBGene00003020	lin-35		C32F10.2	gene	taxon:6239			
+WB	WBGene00003021	lin-36		F44B9.6	gene	taxon:6239			
+WB	WBGene00003022	lin-37		ZK418.4	gene	taxon:6239			
+WB	WBGene00003024	lin-39		C07H6.7|ceh-15	gene	taxon:6239			
+WB	WBGene00003025	lin-40		T27C4.4|egr-1|let-432	gene	taxon:6239			
+WB	WBGene00003026	lin-41		C12C8.3|lep-1|lin-41A|lin-41B	gene	taxon:6239			
+WB	WBGene00003029	lin-44		E01A2.3	gene	taxon:6239			
+WB	WBGene00003030	lin-45		Y73B6A.5|raf-1	gene	taxon:6239			
+WB	WBGene00003031	lin-46		R186.4	gene	taxon:6239			
+WB	WBGene00003033	lin-48		F34D10.5	gene	taxon:6239			
+WB	WBGene00003034	lin-49		F42A9.2	gene	taxon:6239			
+WB	WBGene00003035	lin-52		ZK632.13	gene	taxon:6239			
+WB	WBGene00003036	lin-53		K07A1.12|rba-2	gene	taxon:6239			
+WB	WBGene00003037	lin-54		JC8.6	gene	taxon:6239			
+WB	WBGene00003038	lin-56		ZK673.3	gene	taxon:6239			
+WB	WBGene00003039	mir-48		F56A12.3|lin-58	gene	taxon:6239			
+WB	WBGene00003040	lin-59		T12F5.4	gene	taxon:6239			
+WB	WBGene00003041	lin-61		R06C7.7|rls-1	gene	taxon:6239			
+WB	WBGene00003043	lip-1		C05B10.1	gene	taxon:6239			
+WB	WBGene00003044	lir-1		F18A1.3	gene	taxon:6239			
+WB	WBGene00003045	lir-2		F18A1.4	gene	taxon:6239			
+WB	WBGene00003046	lir-3		F37H8.1|moag-2	gene	taxon:6239			
+WB	WBGene00003047	lis-1		T03F6.5|pnm-1	gene	taxon:6239			
+WB	WBGene00003048	lit-1		W06F12.1	gene	taxon:6239			
+WB	WBGene00003052	lmn-1		DY3.2|Lam1	gene	taxon:6239			
+WB	WBGene00003053	lmp-1		C03B1.12	gene	taxon:6239			
+WB	WBGene00003055	lon-1		F48E8.1|F48C8.1	gene	taxon:6239			
+WB	WBGene00003056	lon-2		C39E6.1	gene	taxon:6239			
+WB	WBGene00003057	lon-3		ZK836.1	gene	taxon:6239			
+WB	WBGene00003058	lov-1		ZK945.9|pkd-1	gene	taxon:6239			
+WB	WBGene00003060	lpd-3		Y47G6A.23	gene	taxon:6239			
+WB	WBGene00003061	lpd-5		ZK973.10|nduf-4	gene	taxon:6239			
+WB	WBGene00003062	lpd-6		K09H9.6	gene	taxon:6239			
+WB	WBGene00003063	lpd-7		R13A5.12	gene	taxon:6239			
+WB	WBGene00003064	nfu-1		R10H10.1|ldp-8	gene	taxon:6239			
+WB	WBGene00003065	lpd-9		T21C9.5	gene	taxon:6239			
+WB	WBGene00003066	lpl-1		ZC410.7|Ny	gene	taxon:6239			
+WB	WBGene00003068	lrk-1		T27C10.6|LRRK2	gene	taxon:6239			
+WB	WBGene00003069	lrn-1			gene	taxon:6239			
+WB	WBGene00003070	lrn-2			gene	taxon:6239			
+WB	WBGene00003071	lrp-1		F29D11.1|egf-4	gene	taxon:6239			
+WB	WBGene00003072	lrp-2		T21E3.3|tag-162	gene	taxon:6239			
+WB	WBGene00003073	lars-1		R74.1|lrs-1	gene	taxon:6239			
+WB	WBGene00003074	lars-2		ZK524.3|lrs-2	gene	taxon:6239			
+WB	WBGene00003076	lsm-1		F40F8.9	gene	taxon:6239			
+WB	WBGene00003077	lsm-3		Y62E10A.12	gene	taxon:6239			
+WB	WBGene00003078	lsm-4		F32A5.7	gene	taxon:6239			
+WB	WBGene00003079	lsm-5		F28F8.3	gene	taxon:6239			
+WB	WBGene00003080	lsm-6		Y71G12B.14	gene	taxon:6239			
+WB	WBGene00003081	lsm-7		ZK593.7	gene	taxon:6239			
+WB	WBGene00003082	lsm-8		Y73B6BL.32	gene	taxon:6239			
+WB	WBGene00003083	lst-1		T22A3.3	gene	taxon:6239			
+WB	WBGene00003084	lst-2		R160.7	gene	taxon:6239			
+WB	WBGene00003085	ccar-1		Y37A1B.1|lst-3|sup-38	gene	taxon:6239			
+WB	WBGene00003086	lst-4		Y37A1B.2	gene	taxon:6239			
+WB	WBGene00003088	lsy-6		C32C4.6	gene	taxon:6239			
+WB	WBGene00003089	ltd-1		K02C4.4	gene	taxon:6239			
+WB	WBGene00003090	lys-1		Y22F5A.4	gene	taxon:6239			
+WB	WBGene00003091	lys-2		Y22F5A.5	gene	taxon:6239			
+WB	WBGene00003092	lys-3		Y22F5A.6|kreg-2	gene	taxon:6239			
+WB	WBGene00003093	lys-4		F58B3.1	gene	taxon:6239			
+WB	WBGene00003094	lys-5		F58B3.2	gene	taxon:6239			
+WB	WBGene00003095	lys-6		F58B3.3	gene	taxon:6239			
+WB	WBGene00003096	lys-7		C02A12.4	gene	taxon:6239			
+WB	WBGene00003097	lys-8		C17G10.5	gene	taxon:6239			
+WB	WBGene00003100	mab-3		Y53C12B.5	gene	taxon:6239			
+WB	WBGene00003102	mab-5		C08C3.3|lin-21	gene	taxon:6239			
+WB	WBGene00003104	mab-7		ZC13.4	gene	taxon:6239			
+WB	WBGene00003106	mab-9		T27A1.6|Ce-tbx-12|tbx-12	gene	taxon:6239			
+WB	WBGene00003107	mab-10		R166.1	gene	taxon:6239			
+WB	WBGene00003111	mab-20		Y71G12B.20	gene	taxon:6239			
+WB	WBGene00003112	mab-21		F35G12.6	gene	taxon:6239			
+WB	WBGene00003114	mab-23		C32C4.5	gene	taxon:6239			
+WB	WBGene00003119	mac-1		Y48C3A.7	gene	taxon:6239			
+WB	WBGene00003123	mag-1		R09B3.5	gene	taxon:6239			
+WB	WBGene00003124	mai-1		K10B3.9	gene	taxon:6239			
+WB	WBGene00003129	map-1		Y37E11AL.7|Y37E11AL.c|Y37E11AL.d	gene	taxon:6239			
+WB	WBGene00003130	map-2		Y116A8A.9	gene	taxon:6239			
+WB	WBGene00003132	mat-1		Y110A7A.17|apc-3|cdc-27|let-364|pod-5	gene	taxon:6239			
+WB	WBGene00003133	mat-2		W10C6.1|apc-1|evl-22|pod-3	gene	taxon:6239			
+WB	WBGene00003134	mat-3		F10C5.1|apc-8|cdc-23|pod-4|szy-13|vex-2	gene	taxon:6239			
+WB	WBGene00003136	mau-2		C09H6.3	gene	taxon:6239			
+WB	WBGene00003142	mau-8		Y62E10A.8|phlp-1	gene	taxon:6239			
+WB	WBGene00003143	max-1		C34B4.1|frm-6	gene	taxon:6239			
+WB	WBGene00003144	max-2		Y38F1A.10|pak-8	gene	taxon:6239			
+WB	WBGene00003148	mbf-1		H21P03.1	gene	taxon:6239			
+WB	WBGene00003149	mbk-1		T04C10.1	gene	taxon:6239			
+WB	WBGene00003150	mbk-2		F49E11.1	gene	taxon:6239			
+WB	WBGene00003151	mca-1		W09C2.3	gene	taxon:6239			
+WB	WBGene00003153	mca-3		Y67D8C.10|cup-7	gene	taxon:6239			
+WB	WBGene00003154	mcm-2		Y17G7B.5	gene	taxon:6239			
+WB	WBGene00003155	mcm-3		C25D7.6	gene	taxon:6239			
+WB	WBGene00003156	mcm-4		Y39G10AR.14|let-358|lin-6	gene	taxon:6239			
+WB	WBGene00003157	mcm-5		R10E4.4	gene	taxon:6239			
+WB	WBGene00003158	mcm-6		ZK632.1|3J887	gene	taxon:6239			
+WB	WBGene00003159	mcm-7		F32D1.10	gene	taxon:6239			
+WB	WBGene00003160	mdf-1		C50F4.11|mad-1	gene	taxon:6239			
+WB	WBGene00003161	mdf-2		Y69A2AR.30|mad-2|Y69A2A_2326.a	gene	taxon:6239			
+WB	WBGene00003162	mdh-2		F20H11.3|mdh-1	gene	taxon:6239			
+WB	WBGene00003163	mdl-1		R03E9.1	gene	taxon:6239			
+WB	WBGene00003164	mdt-6		Y57E12AL.5|let-425|med-6	gene	taxon:6239			
+WB	WBGene00003165	mec-1		T07H8.4|che-4	gene	taxon:6239			
+WB	WBGene00003166	mec-2		F14D12.4	gene	taxon:6239			
+WB	WBGene00003167	mec-3		F01D4.6	gene	taxon:6239			
+WB	WBGene00003168	mec-4		T01C8.7|mec-13	gene	taxon:6239			
+WB	WBGene00003169	mec-5		E03G2.3	gene	taxon:6239			
+WB	WBGene00003170	mec-6		W02D3.3	gene	taxon:6239			
+WB	WBGene00003171	mec-7		ZK154.3	gene	taxon:6239			
+WB	WBGene00003172	mec-8		F46A9.6	gene	taxon:6239			
+WB	WBGene00003173	mec-9		C50H2.3	gene	taxon:6239			
+WB	WBGene00003174	mec-10		F16F9.5|deg-2	gene	taxon:6239			
+WB	WBGene00003175	mec-12		C44B11.3|Alpha-tubulin|tba-3	gene	taxon:6239			
+WB	WBGene00003176	mec-14		F37C12.12	gene	taxon:6239			
+WB	WBGene00003177	mec-15		T01E8.4	gene	taxon:6239			
+WB	WBGene00003178	mec-17		F57H12.7|atat-1	gene	taxon:6239			
+WB	WBGene00003179	mec-18		C52B9.9|acs-8	gene	taxon:6239			
+WB	WBGene00003180	med-1		T24D3.1	gene	taxon:6239			
+WB	WBGene00003181	med-2		K04C2.6	gene	taxon:6239			
+WB	WBGene00003182	mef-2		W10D5.1	gene	taxon:6239			
+WB	WBGene00003183	mei-1		T01G9.5	gene	taxon:6239			
+WB	WBGene00003184	mei-2		F57B10.12	gene	taxon:6239			
+WB	WBGene00003185	mek-1		K08A8.1|kin-17	gene	taxon:6239			
+WB	WBGene00003186	mek-2		Y54E10BL.6|glv-1|let-537	gene	taxon:6239			
+WB	WBGene00003187	mel-1			gene	taxon:6239			
+WB	WBGene00003189	mel-3			gene	taxon:6239			
+WB	WBGene00003190	mel-4			gene	taxon:6239			
+WB	WBGene00003191	mel-5			gene	taxon:6239			
+WB	WBGene00003192	mel-7			gene	taxon:6239			
+WB	WBGene00003193	mel-8		|mel-6	gene	taxon:6239			
+WB	WBGene00003194	mel-9			gene	taxon:6239			
+WB	WBGene00003195	mel-10			gene	taxon:6239			
+WB	WBGene00003196	mel-11		C06C3.1	gene	taxon:6239			
+WB	WBGene00003197	mel-12			gene	taxon:6239			
+WB	WBGene00003198	mel-13			gene	taxon:6239			
+WB	WBGene00003199	mel-14			gene	taxon:6239			
+WB	WBGene00003201	mel-16			gene	taxon:6239			
+WB	WBGene00003202	mel-17			gene	taxon:6239			
+WB	WBGene00003203	mel-18			gene	taxon:6239			
+WB	WBGene00003204	mel-20			gene	taxon:6239			
+WB	WBGene00003205	mel-22			gene	taxon:6239			
+WB	WBGene00003209	mel-26		ZK858.4	gene	taxon:6239			
+WB	WBGene00003210	mel-28		C38D4.3	gene	taxon:6239			
+WB	WBGene00003214	mel-32		C05D11.11	gene	taxon:6239			
+WB	WBGene00003218	mep-1		M04B2.1|gei-2	gene	taxon:6239			
+WB	WBGene00003219	mes-1		F54F7.5	gene	taxon:6239			
+WB	WBGene00003220	mes-2		R06A4.7	gene	taxon:6239			
+WB	WBGene00003221	mes-3		F54C1.3	gene	taxon:6239			
+WB	WBGene00003222	mes-4		Y2H9A.1	gene	taxon:6239			
+WB	WBGene00003224	mes-6		C09G4.5	gene	taxon:6239			
+WB	WBGene00003225	mev-1		T07C4.7|cyt-1|sdhc-1	gene	taxon:6239			
+WB	WBGene00003228	mex-1		W03C9.7|mel-21	gene	taxon:6239			
+WB	WBGene00003229	mex-3		F53G12.5	gene	taxon:6239			
+WB	WBGene00003230	mex-5		W02A2.7	gene	taxon:6239			
+WB	WBGene00003231	mex-6		AH6.5	gene	taxon:6239			
+WB	WBGene00003232	mgl-1		ZC506.4	gene	taxon:6239			
+WB	WBGene00003233	mgl-2		F45H11.4	gene	taxon:6239			
+WB	WBGene00003236	mif-3		F13G3.9	gene	taxon:6239			
+WB	WBGene00003238	mig-1		Y34D9B.1|cfz-1|CNT1|frizzled 1	gene	taxon:6239			
+WB	WBGene00003239	mig-2		C35C5.4	gene	taxon:6239			
+WB	WBGene00003241	mig-5		T05C12.6	gene	taxon:6239			
+WB	WBGene00003242	mig-6		C37C3.6|cpg-17|ppn-1	gene	taxon:6239			
+WB	WBGene00003243	mig-10		F10E9.6	gene	taxon:6239			
+WB	WBGene00003245	mig-13		F43C9.4	gene	taxon:6239			
+WB	WBGene00003246	mig-14		R06B9.6|let-553|mom-3|pvl-2	gene	taxon:6239			
+WB	WBGene00003247	mig-15		ZC504.4|qid-7|qid-8	gene	taxon:6239			
+WB	WBGene00003248	mig-17		F57B7.4	gene	taxon:6239			
+WB	WBGene00003249	mig-18		F11F1.6	gene	taxon:6239			
+WB	WBGene00003252	mig-21		F01F1.13	gene	taxon:6239			
+WB	WBGene00003253	mig-22		PAR2.4|pfc-1	gene	taxon:6239			
+WB	WBGene00003254	mig-23		R07E4.4	gene	taxon:6239			
+WB	WBGene00003258	cogc-1		Y54E10A.2|let-576|mig-30|Y54E10a.m	gene	taxon:6239			
+WB	WBGene00003261	mir-2		M04C9.7|cel-mir-2	gene	taxon:6239			
+WB	WBGene00003262	mir-34		Y41G9A.7|cel-mir-34	gene	taxon:6239			
+WB	WBGene00003263	mir-35		Y62F5A.2|cel-mir-35	gene	taxon:6239			
+WB	WBGene00003264	mir-36		Y62F5A.3|cel-mir-36	gene	taxon:6239			
+WB	WBGene00003265	mir-37		Y62F5A.4|cel-mir-37	gene	taxon:6239			
+WB	WBGene00003284	mir-56		F09A5.8|cel-mir-56	gene	taxon:6239			
+WB	WBGene00003289	mir-61		F55A11.9|cel-mir-61	gene	taxon:6239			
+WB	WBGene00003299	mir-71		F16A11.4|cel-mir-71	gene	taxon:6239			
+WB	WBGene00003308	mir-80		K01F9.3|cel-mir-80|mir-227	gene	taxon:6239			
+WB	WBGene00003312	mir-84		B0395.4|cel-mir-84	gene	taxon:6239			
+WB	WBGene00003335	mir-241		F56A12.4|cel-mir-241	gene	taxon:6239			
+WB	WBGene00003366	mir-273		E01F3.2|cel-mir-273	gene	taxon:6239			
+WB	WBGene00003367	mix-1		M106.1|let-29|smc-2	gene	taxon:6239			
+WB	WBGene00003368	mkk-4		F42G10.2	gene	taxon:6239			
+WB	WBGene00003369	mlc-1		C36E6.3|C36E6.f	gene	taxon:6239			
+WB	WBGene00003370	mlc-2		C36E6.5	gene	taxon:6239			
+WB	WBGene00003371	mlc-3		F09F7.2	gene	taxon:6239			
+WB	WBGene00003372	mlc-4		C56G7.1	gene	taxon:6239			
+WB	WBGene00003373	mlh-1		T28A8.7	gene	taxon:6239			
+WB	WBGene00003374	mlk-1		K11D12.10|Y58A7A.f	gene	taxon:6239			
+WB	WBGene00003375	mlp-1		T04C9.4	gene	taxon:6239			
+WB	WBGene00003376	mls-1		H14A12.4|tbx-17	gene	taxon:6239			
+WB	WBGene00003377	mls-2		C39E6.4	gene	taxon:6239			
+WB	WBGene00003378	mml-1		T20B12.6|mio	gene	taxon:6239			
+WB	WBGene00003380	mnm-2		C10A4.8	gene	taxon:6239			
+WB	WBGene00003384	moc-1		T06H11.4	gene	taxon:6239			
+WB	WBGene00003385	moc-2		W01A11.6	gene	taxon:6239			
+WB	WBGene00003386	mod-1		K06C4.6	gene	taxon:6239			
+WB	WBGene00003387	mod-5		Y54E10BR.7|Y54E10BR.b	gene	taxon:6239			
+WB	WBGene00003388	moe-3		F32A11.6	gene	taxon:6239			
+WB	WBGene00003389	mog-1		K03H1.2	gene	taxon:6239			
+WB	WBGene00003390	mog-2		H20J04.8|sap-1|tag-247	gene	taxon:6239			
+WB	WBGene00003391	mog-3		F52C9.7	gene	taxon:6239			
+WB	WBGene00003392	mog-4		C04H5.6	gene	taxon:6239			
+WB	WBGene00003393	mog-5		EEED8.5|CeHRH-1	gene	taxon:6239			
+WB	WBGene00003394	mom-1		T07H6.2|bop-1	gene	taxon:6239			
+WB	WBGene00003395	mom-2		F38E1.7	gene	taxon:6239			
+WB	WBGene00003396	mom-4		F52F12.3	gene	taxon:6239			
+WB	WBGene00003397	mom-5		T23D8.1	gene	taxon:6239			
+WB	WBGene00003400	dapk-1		K12C11.4|K12C11.a|K12C11.b|K12C11.h|K12C11.i|mor-3|tag-119	gene	taxon:6239			
+WB	WBGene00003401	mpk-1		F43C1.2|sur-1	gene	taxon:6239			
+WB	WBGene00003402	mpk-2		C04G6.1	gene	taxon:6239			
+WB	WBGene00003403	mps-1		C29F5.4	gene	taxon:6239			
+WB	WBGene00003404	mpz-1		C52A11.4	gene	taxon:6239			
+WB	WBGene00003405	mre-11		ZC302.1	gene	taxon:6239			
+WB	WBGene00003406	mrg-1		Y37D8A.9	gene	taxon:6239			
+WB	WBGene00003407	mrp-1		F57C12.5|sdf-14	gene	taxon:6239			
+WB	WBGene00003408	mrp-2		F57C12.4	gene	taxon:6239			
+WB	WBGene00003409	mrp-3		E03G2.2	gene	taxon:6239			
+WB	WBGene00003410	mrp-4		F21G4.2	gene	taxon:6239			
+WB	WBGene00003411	mrp-5		F14F4.3	gene	taxon:6239			
+WB	WBGene00003412	mrp-6		F20B6.3	gene	taxon:6239			
+WB	WBGene00003413	mrp-7		Y43F8C.12	gene	taxon:6239			
+WB	WBGene00003414	mrp-8		Y75B8A.26	gene	taxon:6239			
+WB	WBGene00003415	mars-1		F58B3.5|let-65|mrs-1	gene	taxon:6239			
+WB	WBGene00003417	mrt-2		Y41C4A.14|hpr-1	gene	taxon:6239			
+WB	WBGene00003418	msh-2		H26D21.2	gene	taxon:6239			
+WB	WBGene00003421	msh-5		F09E8.3	gene	taxon:6239			
+WB	WBGene00003422	msh-6		Y47G6A.11|Y47G6A_242.c	gene	taxon:6239			
+WB	WBGene00003423	msi-1		R10E9.1	gene	taxon:6239			
+WB	WBGene00003424	msp-3		F26G1.7	gene	taxon:6239			
+WB	WBGene00003425	msp-10		K07F5.2	gene	taxon:6239			
+WB	WBGene00003426	msp-19		F36H12.7	gene	taxon:6239			
+WB	WBGene00003430	msp-32		R05F9.3	gene	taxon:6239			
+WB	WBGene00003431	msp-33		R05F9.8	gene	taxon:6239			
+WB	WBGene00003434	msp-38		K08F4.8	gene	taxon:6239			
+WB	WBGene00003442	msp-49		C34F11.6	gene	taxon:6239			
+WB	WBGene00003448	msp-55		C09B9.6	gene	taxon:6239			
+WB	WBGene00003456	msp-63		K05F1.7	gene	taxon:6239			
+WB	WBGene00003464	msp-77		F32B6.6	gene	taxon:6239			
+WB	WBGene00003465	msp-78		T13F2.11	gene	taxon:6239			
+WB	WBGene00003470	msp-152		ZK546.6	gene	taxon:6239			
+WB	WBGene00003471	mtd-1		ZK337.5	gene	taxon:6239			
+WB	WBGene00003472	mtk-1		B0414.7	gene	taxon:6239			
+WB	WBGene00003473	mtl-1		K11G9.6|met-I	gene	taxon:6239			
+WB	WBGene00003474	mtl-2		T08G5.10|met-II	gene	taxon:6239			
+WB	WBGene00003475	mtm-1		Y110A7A.5	gene	taxon:6239			
+WB	WBGene00003476	mtm-3		T24A11.1	gene	taxon:6239			
+WB	WBGene00003477	mtm-5		H28G03.6|tag-87	gene	taxon:6239			
+WB	WBGene00003478	mtm-6		F53A2.8|cup-6	gene	taxon:6239			
+WB	WBGene00003479	mtm-9		Y39H10A.3|cup-10|Y39H10A.b|Y39H10A.f	gene	taxon:6239			
+WB	WBGene00003480	klf-3		F54H5.4|mua-1	gene	taxon:6239			
+WB	WBGene00003482	mua-3		K08E5.3	gene	taxon:6239			
+WB	WBGene00003485	mua-6		W10G6.3|A2|Cel IF A2|CelIF a2|ifa-2	gene	taxon:6239			
+WB	WBGene00003495	mup-2		T22E5.5|tnt-1	gene	taxon:6239			
+WB	WBGene00003497	mup-4		K07D8.1	gene	taxon:6239			
+WB	WBGene00003499	mut-2		K04F10.6|rde-3	gene	taxon:6239			
+WB	WBGene00003504	mut-7		ZK1098.8	gene	taxon:6239			
+WB	WBGene00003507	mut-14		C14C11.6	gene	taxon:6239			
+WB	WBGene00003508	mut-16		B0379.3|pqn-3|rde-6	gene	taxon:6239			
+WB	WBGene00003509	mxl-1		T19B10.11	gene	taxon:6239			
+WB	WBGene00003510	mxl-2		F40G9.11	gene	taxon:6239			
+WB	WBGene00003511	mxl-3		F46G10.6|hlh-23	gene	taxon:6239			
+WB	WBGene00003514	myo-2		T18D3.4	gene	taxon:6239			
+WB	WBGene00003515	myo-3		K12F2.1|sup-3	gene	taxon:6239			
+WB	WBGene00003516	nab-1		C43E11.6	gene	taxon:6239			
+WB	WBGene00003517	nac-1		F31F6.6|cenadc1|indy-1|nad-1	gene	taxon:6239			
+WB	WBGene00003518	nac-2		R107.1|C. elegans NaCT|indy-3|nat-1	gene	taxon:6239			
+WB	WBGene00003519	nac-3		K08E5.2|cenadc2|indy-2|nad-2	gene	taxon:6239			
+WB	WBGene00003520	nas-1		F45G2.1	gene	taxon:6239			
+WB	WBGene00003521	nas-2		F56A4.1	gene	taxon:6239			
+WB	WBGene00003522	nas-3		K06A4.1	gene	taxon:6239			
+WB	WBGene00003523	nas-4		C05D11.6	gene	taxon:6239			
+WB	WBGene00003524	nas-5		T23H4.3	gene	taxon:6239			
+WB	WBGene00003525	nas-6		4R79.1	gene	taxon:6239			
+WB	WBGene00003526	nas-7		C07D10.4	gene	taxon:6239			
+WB	WBGene00003527	nas-8		C34D4.9	gene	taxon:6239			
+WB	WBGene00003528	nas-9		C37H5.9	gene	taxon:6239			
+WB	WBGene00003529	nas-10		K09C8.3	gene	taxon:6239			
+WB	WBGene00003530	nas-11		K11G12.1	gene	taxon:6239			
+WB	WBGene00003531	nas-12		C24F3.3	gene	taxon:6239			
+WB	WBGene00003532	nas-13		F39D8.4	gene	taxon:6239			
+WB	WBGene00003533	nas-14		F09E8.6	gene	taxon:6239			
+WB	WBGene00003534	nas-15		T04G9.2	gene	taxon:6239			
+WB	WBGene00003535	nas-16		K03B8.1	gene	taxon:6239			
+WB	WBGene00003536	nas-17		K03B8.2	gene	taxon:6239			
+WB	WBGene00003537	nas-18		K03B8.3	gene	taxon:6239			
+WB	WBGene00003538	nas-19		K03B8.5	gene	taxon:6239			
+WB	WBGene00003539	nas-20		T11F9.3	gene	taxon:6239			
+WB	WBGene00003540	nas-21		T11F9.5	gene	taxon:6239			
+WB	WBGene00003541	nas-22		T11F9.6	gene	taxon:6239			
+WB	WBGene00003542	nas-23		R10H1.5	gene	taxon:6239			
+WB	WBGene00003543	nas-24		F20G2.4	gene	taxon:6239			
+WB	WBGene00003544	nas-25		F46C5.3	gene	taxon:6239			
+WB	WBGene00003545	nas-27		T23F4.4	gene	taxon:6239			
+WB	WBGene00003546	nas-28		F42A10.8	gene	taxon:6239			
+WB	WBGene00003547	nas-29		F58A6.4	gene	taxon:6239			
+WB	WBGene00003548	nas-30		Y95B8A.1	gene	taxon:6239			
+WB	WBGene00003549	nas-31		F58B4.1	gene	taxon:6239			
+WB	WBGene00003550	nas-32		T02B11.7	gene	taxon:6239			
+WB	WBGene00003551	nas-33		K04E7.3	gene	taxon:6239			
+WB	WBGene00003552	nas-36		C26C6.3	gene	taxon:6239			
+WB	WBGene00003553	nas-37		C17G1.6	gene	taxon:6239			
+WB	WBGene00003554	nas-38		F57C12.1	gene	taxon:6239			
+WB	WBGene00003555	nas-39		F38E9.2	gene	taxon:6239			
+WB	WBGene00003558	nca-2		C27F2.2	gene	taxon:6239			
+WB	WBGene00003559	ncl-1		ZK112.2	gene	taxon:6239			
+WB	WBGene00003561	ncr-1		F02E8.6|npc-1	gene	taxon:6239			
+WB	WBGene00003562	ncr-2		F09G8.4|npc-2	gene	taxon:6239			
+WB	WBGene00003563	ncs-1		C44C1.3	gene	taxon:6239			
+WB	WBGene00003564	ncs-2		F10G8.5	gene	taxon:6239			
+WB	WBGene00003565	ncs-3		K03E6.3	gene	taxon:6239			
+WB	WBGene00003566	ncx-1		Y113G7A.4	gene	taxon:6239			
+WB	WBGene00003567	ncx-2		C10G8.5	gene	taxon:6239			
+WB	WBGene00003568	ncx-3		ZC168.1	gene	taxon:6239			
+WB	WBGene00003569	ncx-4		F35C12.2	gene	taxon:6239			
+WB	WBGene00003570	ncx-5		Y32F6B.2	gene	taxon:6239			
+WB	WBGene00003571	ncx-6		C07A9.4	gene	taxon:6239			
+WB	WBGene00003572	ncx-7		C07A9.11	gene	taxon:6239			
+WB	WBGene00003573	ncx-8		C13D9.7	gene	taxon:6239			
+WB	WBGene00003574	ncx-9		C13D9.8	gene	taxon:6239			
+WB	WBGene00003575	ncx-10		Y97E10B.7|Y97E10B.b|Y97E10B.f	gene	taxon:6239			
+WB	WBGene00003576	ndc-80		W01B6.9|cogc-7	gene	taxon:6239			
+WB	WBGene00003577	ndg-4		F56F3.2	gene	taxon:6239			
+WB	WBGene00003578	ndx-1		T26E3.2	gene	taxon:6239			
+WB	WBGene00003579	ndx-2		W02G9.1	gene	taxon:6239			
+WB	WBGene00003580	ndx-3		Y38A8.1	gene	taxon:6239			
+WB	WBGene00003581	ndx-4		Y37H9A.6|Ap(4)A hydrolase|Diadenosine Tetraphosphate Hydrolase	gene	taxon:6239			
+WB	WBGene00003582	dcap-2		F52G2.1|dcp2|ndx-5	gene	taxon:6239			
+WB	WBGene00003583	ndx-6		EEED8.8	gene	taxon:6239			
+WB	WBGene00003584	ndx-7		C43E11.7	gene	taxon:6239			
+WB	WBGene00003585	ndx-8		Y87G2A.14	gene	taxon:6239			
+WB	WBGene00003586	ndx-9		F13H10.2	gene	taxon:6239			
+WB	WBGene00003587	ned-8		F45H11.2	gene	taxon:6239			
+WB	WBGene00003588	nex-1		ZC155.1	gene	taxon:6239			
+WB	WBGene00003589	nex-2		T07C4.9	gene	taxon:6239			
+WB	WBGene00003590	nex-3		C28A5.3	gene	taxon:6239			
+WB	WBGene00003591	nex-4		C37H5.1	gene	taxon:6239			
+WB	WBGene00003592	nfi-1		ZK1290.4|gei-21	gene	taxon:6239			
+WB	WBGene00003593	nfm-1		F42A10.2	gene	taxon:6239			
+WB	WBGene00003594	nft-1		Y56A3A.13|NitFhit	gene	taxon:6239			
+WB	WBGene00003595	ngn-1		Y69A2AR.29	gene	taxon:6239			
+WB	WBGene00003596	ngp-1		T19A6.2	gene	taxon:6239			
+WB	WBGene00003597	nhl-1		F54G8.4	gene	taxon:6239			
+WB	WBGene00003598	nhl-2		F26F4.7	gene	taxon:6239			
+WB	WBGene00003599	nhl-3		W04H10.3	gene	taxon:6239			
+WB	WBGene00003600	nhr-1		R09G11.2|crf-1	gene	taxon:6239			
+WB	WBGene00003601	nhr-2		C32F10.6|crf-2	gene	taxon:6239			
+WB	WBGene00003602	nhr-3		H01A20.1	gene	taxon:6239			
+WB	WBGene00003603	nhr-4		F32B6.1	gene	taxon:6239			
+WB	WBGene00003604	nhr-5		Y73F8A.21	gene	taxon:6239			
+WB	WBGene00003605	nhr-6		C48D5.1|ceb-1|cnr-8|cnr8	gene	taxon:6239			
+WB	WBGene00003606	nhr-7		F54D1.4	gene	taxon:6239			
+WB	WBGene00003607	nhr-8		F33D4.1	gene	taxon:6239			
+WB	WBGene00003608	nhr-9		ZK418.1	gene	taxon:6239			
+WB	WBGene00003609	nhr-10		B0280.8	gene	taxon:6239			
+WB	WBGene00003610	nhr-11		ZC410.1	gene	taxon:6239			
+WB	WBGene00003611	nhr-12		R04B5.4	gene	taxon:6239			
+WB	WBGene00003612	nhr-13		Y5H2B.2|Y5H2B.d|Y5H2B.h	gene	taxon:6239			
+WB	WBGene00003613	nhr-14		T01B10.4	gene	taxon:6239			
+WB	WBGene00003614	nhr-15		F33E11.1	gene	taxon:6239			
+WB	WBGene00003615	nhr-16		T12C9.6	gene	taxon:6239			
+WB	WBGene00003616	nhr-17		C02B4.2	gene	taxon:6239			
+WB	WBGene00003617	nhr-18		F44C8.3	gene	taxon:6239			
+WB	WBGene00003618	nhr-19		E02H1.7	gene	taxon:6239			
+WB	WBGene00003619	nhr-20		F43C1.4	gene	taxon:6239			
+WB	WBGene00003620	nhr-21		F21D12.1|nhr-21a|nhr-21b	gene	taxon:6239			
+WB	WBGene00003621	nhr-22		K06A1.4	gene	taxon:6239			
+WB	WBGene00003622	nhr-23		C01H6.5|chr3|cnr-3|let-527	gene	taxon:6239			
+WB	WBGene00003623	nhr-25		F11C1.6	gene	taxon:6239			
+WB	WBGene00003624	nhr-28		C11G6.4	gene	taxon:6239			
+WB	WBGene00003625	nhr-31		C26B2.3	gene	taxon:6239			
+WB	WBGene00003626	nhr-32		K08H2.8	gene	taxon:6239			
+WB	WBGene00003627	nhr-34		F58G6.5	gene	taxon:6239			
+WB	WBGene00003628	nhr-35		C07A12.3	gene	taxon:6239			
+WB	WBGene00003629	nhr-38		K01H12.3	gene	taxon:6239			
+WB	WBGene00003630	nhr-40		T03G6.2	gene	taxon:6239			
+WB	WBGene00003632	nhr-42		C33G8.6	gene	taxon:6239			
+WB	WBGene00003633	nhr-43		C29E6.5	gene	taxon:6239			
+WB	WBGene00003634	nhr-44		T19A5.4	gene	taxon:6239			
+WB	WBGene00003635	nhr-45		F16H11.5	gene	taxon:6239			
+WB	WBGene00003636	nhr-46		C45E5.6	gene	taxon:6239			
+WB	WBGene00003637	nhr-47		C24G6.4|csr-1|nhr-279	gene	taxon:6239			
+WB	WBGene00003638	nhr-48		ZK662.3	gene	taxon:6239			
+WB	WBGene00003639	nhr-49		K10C3.6	gene	taxon:6239			
+WB	WBGene00003640	nhr-50		C06C6.5	gene	taxon:6239			
+WB	WBGene00003641	nhr-51		K06B4.1	gene	taxon:6239			
+WB	WBGene00003642	nhr-52		K06B4.2	gene	taxon:6239			
+WB	WBGene00003643	nhr-53		K06B4.11	gene	taxon:6239			
+WB	WBGene00003644	nhr-54		F36D3.2	gene	taxon:6239			
+WB	WBGene00003645	nhr-55		T01G6.7	gene	taxon:6239			
+WB	WBGene00003646	nhr-56		F44C8.6|F44C8.a|F44C8.f	gene	taxon:6239			
+WB	WBGene00003647	nhr-57		T05B4.2	gene	taxon:6239			
+WB	WBGene00003648	nhr-58		R11G11.2	gene	taxon:6239			
+WB	WBGene00003649	nhr-59		T27B7.1	gene	taxon:6239			
+WB	WBGene00003650	nhr-60		F57A10.5	gene	taxon:6239			
+WB	WBGene00003651	nhr-61		W01D2.2	gene	taxon:6239			
+WB	WBGene00003652	nhr-62		Y67A6A.2	gene	taxon:6239			
+WB	WBGene00003653	nhr-63		C06C6.4	gene	taxon:6239			
+WB	WBGene00003654	nhr-64		C45E1.1	gene	taxon:6239			
+WB	WBGene00003655	nhr-65		Y17D7A.3	gene	taxon:6239			
+WB	WBGene00003656	nhr-66		T09A12.4	gene	taxon:6239			
+WB	WBGene00003657	nhr-67		C08F8.8|lsy-9	gene	taxon:6239			
+WB	WBGene00003658	nhr-68		H12C20.3	gene	taxon:6239			
+WB	WBGene00003659	nhr-69		T23H4.2	gene	taxon:6239			
+WB	WBGene00003660	nhr-70		Y51A2D.17	gene	taxon:6239			
+WB	WBGene00003661	nhr-71		K11E4.5	gene	taxon:6239			
+WB	WBGene00003662	nhr-72		C17A2.8	gene	taxon:6239			
+WB	WBGene00003663	nhr-73		C27C7.4	gene	taxon:6239			
+WB	WBGene00003664	nhr-74		C27C7.3	gene	taxon:6239			
+WB	WBGene00003667	nhr-77		T15D6.6	gene	taxon:6239			
+WB	WBGene00003668	nhr-78		F36A4.14	gene	taxon:6239			
+WB	WBGene00003669	nhr-79		T26H2.9	gene	taxon:6239			
+WB	WBGene00003670	nhr-80		H10E21.3	gene	taxon:6239			
+WB	WBGene00003671	nhr-81		C47F8.8	gene	taxon:6239			
+WB	WBGene00003672	nhr-82		F41D3.1	gene	taxon:6239			
+WB	WBGene00003674	nhr-84		T06C12.7	gene	taxon:6239			
+WB	WBGene00003675	nhr-85		W05B5.3	gene	taxon:6239			
+WB	WBGene00003676	nhr-86		Y40B10A.8	gene	taxon:6239			
+WB	WBGene00003677	nhr-87		Y41D4B.7	gene	taxon:6239			
+WB	WBGene00003678	nhr-88		K08A2.5|K08A2.a	gene	taxon:6239			
+WB	WBGene00003679	nhr-89		E03H4.13	gene	taxon:6239			
+WB	WBGene00003680	nhr-90		ZK488.2	gene	taxon:6239			
+WB	WBGene00003681	nhr-91		Y15E3A.1	gene	taxon:6239			
+WB	WBGene00003682	nhr-92		Y41D4B.8	gene	taxon:6239			
+WB	WBGene00003683	nhr-93		T24A6.9	gene	taxon:6239			
+WB	WBGene00003684	nhr-94		C12D5.8	gene	taxon:6239			
+WB	WBGene00003685	nhr-95		Y39B6A.17|Y39B6B.d	gene	taxon:6239			
+WB	WBGene00003686	nhr-96		F44C8.11	gene	taxon:6239			
+WB	WBGene00003687	nhr-97		H27C11.1	gene	taxon:6239			
+WB	WBGene00003688	nhr-98		M02H5.6|M02H5.e	gene	taxon:6239			
+WB	WBGene00003689	nhr-99		M02H5.1|M02H5.h	gene	taxon:6239			
+WB	WBGene00003690	nhr-100		C28D4.1	gene	taxon:6239			
+WB	WBGene00003691	nhr-101		H12C20.6	gene	taxon:6239			
+WB	WBGene00003692	nhr-102		T06C12.6	gene	taxon:6239			
+WB	WBGene00003693	nhr-103		F44C8.4	gene	taxon:6239			
+WB	WBGene00003694	nhr-104		R11E3.5	gene	taxon:6239			
+WB	WBGene00003695	nhr-105		C06G3.1	gene	taxon:6239			
+WB	WBGene00003696	nhr-106		T01G6.4	gene	taxon:6239			
+WB	WBGene00003697	nhr-107		C33G8.11	gene	taxon:6239			
+WB	WBGene00003698	nhr-108		F35E8.12	gene	taxon:6239			
+WB	WBGene00003699	nhr-109		T12C9.5	gene	taxon:6239			
+WB	WBGene00003700	nhr-110		Y46H3D.5	gene	taxon:6239			
+WB	WBGene00003701	nhr-111		F44G3.9	gene	taxon:6239			
+WB	WBGene00003702	nhr-112		Y70C5C.6	gene	taxon:6239			
+WB	WBGene00003703	nhr-113		ZK1025.9	gene	taxon:6239			
+WB	WBGene00003704	nhr-114		Y45G5AM.1	gene	taxon:6239			
+WB	WBGene00003705	nhr-115		T27B7.4	gene	taxon:6239			
+WB	WBGene00003706	nhr-116		F09C6.9	gene	taxon:6239			
+WB	WBGene00003707	nhr-117		F16B4.12	gene	taxon:6239			
+WB	WBGene00003708	nhr-118		F13A2.8|Y47D7A.k	gene	taxon:6239			
+WB	WBGene00003709	nhr-119		K12H6.1|Y110A2B.a	gene	taxon:6239			
+WB	WBGene00003710	nhr-120		C25B8.6	gene	taxon:6239			
+WB	WBGene00003711	nhr-121		E02H9.8	gene	taxon:6239			
+WB	WBGene00003712	nhr-122		Y41D4B.9	gene	taxon:6239			
+WB	WBGene00003713	nhr-123		M02H5.7|M02H5.d	gene	taxon:6239			
+WB	WBGene00003714	nhr-124		C17E7.8	gene	taxon:6239			
+WB	WBGene00003715	nhr-125		R02D1.1	gene	taxon:6239			
+WB	WBGene00003716	nhr-126		F44C8.10|F44C8.f	gene	taxon:6239			
+WB	WBGene00003717	nhr-127		T13F3.3	gene	taxon:6239			
+WB	WBGene00003718	nhr-128		F44C8.5	gene	taxon:6239			
+WB	WBGene00003719	nhr-129		C50B6.14	gene	taxon:6239			
+WB	WBGene00003720	nhr-130		T01G6.8	gene	taxon:6239			
+WB	WBGene00003721	nhr-131		T01G6.2	gene	taxon:6239			
+WB	WBGene00003722	nhr-132		R11G11.1	gene	taxon:6239			
+WB	WBGene00003723	nhr-133		F44C8.8|F44C8.d	gene	taxon:6239			
+WB	WBGene00003724	nhr-134		F44C8.2	gene	taxon:6239			
+WB	WBGene00003725	nhr-135		VC5.5	gene	taxon:6239			
+WB	WBGene00003726	nhr-136		C13C4.3	gene	taxon:6239			
+WB	WBGene00003727	nhr-137		C56E10.4	gene	taxon:6239			
+WB	WBGene00003728	nhr-138		C28D4.9	gene	taxon:6239			
+WB	WBGene00003729	nhx-1		B0395.1	gene	taxon:6239			
+WB	WBGene00003730	nhx-2		B0495.4	gene	taxon:6239			
+WB	WBGene00003731	nhx-3		C54F6.13	gene	taxon:6239			
+WB	WBGene00003732	nhx-4		F14B8.1	gene	taxon:6239			
+WB	WBGene00003733	nhx-5		F57C7.2	gene	taxon:6239			
+WB	WBGene00003734	nhx-6		F58E1.6	gene	taxon:6239			
+WB	WBGene00003735	nhx-8		Y18D10A.6	gene	taxon:6239			
+WB	WBGene00003736	nhx-9		ZK822.3	gene	taxon:6239			
+WB	WBGene00003738	nid-1		F54F3.1	gene	taxon:6239			
+WB	WBGene00003739	nlp-1		C01C4.1	gene	taxon:6239			
+WB	WBGene00003740	nlp-2		T24D8.5|T24D8.e	gene	taxon:6239			
+WB	WBGene00003741	nlp-3		F48C11.3	gene	taxon:6239			
+WB	WBGene00003742	nlp-4		F59C6.6	gene	taxon:6239			
+WB	WBGene00003743	nlp-5		F35C11.1	gene	taxon:6239			
+WB	WBGene00003744	nlp-6		T23E7.4	gene	taxon:6239			
+WB	WBGene00003745	nlp-7		F18E9.2	gene	taxon:6239			
+WB	WBGene00003746	nlp-8		D2005.2	gene	taxon:6239			
+WB	WBGene00003747	nlp-9		E03D2.2	gene	taxon:6239			
+WB	WBGene00003748	nlp-10		F37A8.4	gene	taxon:6239			
+WB	WBGene00003749	nlp-11		ZK1320.10	gene	taxon:6239			
+WB	WBGene00003750	nlp-12		M01D7.5	gene	taxon:6239			
+WB	WBGene00003751	nlp-13		E03D2.1	gene	taxon:6239			
+WB	WBGene00003752	nlp-14		D1009.4	gene	taxon:6239			
+WB	WBGene00003753	nlp-15		CC4.2	gene	taxon:6239			
+WB	WBGene00003754	nlp-16		T13A10.5	gene	taxon:6239			
+WB	WBGene00003755	nlp-17		Y45F10A.5	gene	taxon:6239			
+WB	WBGene00003756	nlp-18		F33A8.2	gene	taxon:6239			
+WB	WBGene00003757	nlp-19		K09C8.6	gene	taxon:6239			
+WB	WBGene00003758	nlp-20		F45E4.8	gene	taxon:6239			
+WB	WBGene00003759	nlp-21		Y47D3B.2	gene	taxon:6239			
+WB	WBGene00003760	nlp-22		T24D8.3	gene	taxon:6239			
+WB	WBGene00003761	nlp-23		T24D8.4	gene	taxon:6239			
+WB	WBGene00003762	nlp-24		F35B12.7	gene	taxon:6239			
+WB	WBGene00003763	nlp-25		Y43F8C.1	gene	taxon:6239			
+WB	WBGene00003764	nlp-26		Y43F8C.2	gene	taxon:6239			
+WB	WBGene00003765	nlp-27		B0213.2	gene	taxon:6239			
+WB	WBGene00003766	nlp-28		B0213.3	gene	taxon:6239			
+WB	WBGene00003767	nlp-29		B0213.4	gene	taxon:6239			
+WB	WBGene00003768	nlp-30		B0213.5	gene	taxon:6239			
+WB	WBGene00003769	nlp-31		B0213.6	gene	taxon:6239			
+WB	WBGene00003770	nlp-32		F30H5.2	gene	taxon:6239			
+WB	WBGene00003771	nlp-33		T19C4.7	gene	taxon:6239			
+WB	WBGene00003772	nlr-1		F20B10.1	gene	taxon:6239			
+WB	WBGene00003773	nlt-1		ZK892.2	gene	taxon:6239			
+WB	WBGene00003774	nmr-1		F07F6.6|F56D1.b|F56D1.c	gene	taxon:6239			
+WB	WBGene00003775	nmr-2		T01C3.10	gene	taxon:6239			
+WB	WBGene00003776	nmy-1		F52B10.1	gene	taxon:6239			
+WB	WBGene00003777	nmy-2		F20G4.3	gene	taxon:6239			
+WB	WBGene00003778	nnt-1		C15H9.1	gene	taxon:6239			
+WB	WBGene00003779	nob-1		Y75B8A.2	gene	taxon:6239			
+WB	WBGene00003783	nos-1		R03D7.7	gene	taxon:6239			
+WB	WBGene00003784	nos-2		ZK1127.1	gene	taxon:6239			
+WB	WBGene00003785	nos-3		Y53C12B.3|Nanos|pqn-86|syt-1	gene	taxon:6239			
+WB	WBGene00003787	npp-1		K07F5.13	gene	taxon:6239			
+WB	WBGene00003788	npp-2		T01G9.4|kup-2	gene	taxon:6239			
+WB	WBGene00003789	npp-3		K12D12.2	gene	taxon:6239			
+WB	WBGene00003790	npp-4		Y54E5A.4	gene	taxon:6239			
+WB	WBGene00003791	npp-5		F07A11.3|Nup107	gene	taxon:6239			
+WB	WBGene00003792	npp-6		F56A3.3|let-101	gene	taxon:6239			
+WB	WBGene00003793	npp-7		T19B4.2|Nup153	gene	taxon:6239			
+WB	WBGene00003794	npp-8		Y41D4B.19|Nup155|Y41D4A_3457.d	gene	taxon:6239			
+WB	WBGene00003795	npp-9		F59A2.1|Nup358	gene	taxon:6239			
+WB	WBGene00003796	npp-10		ZK328.5|Nup96|Nup98	gene	taxon:6239			
+WB	WBGene00003797	npp-11		F53F10.5	gene	taxon:6239			
+WB	WBGene00003798	npp-12		T23H2.1	gene	taxon:6239			
+WB	WBGene00003799	npp-13		Y37E3.15|CeNup93	gene	taxon:6239			
+WB	WBGene00003800	npp-14		C03D6.4|CeNup214	gene	taxon:6239			
+WB	WBGene00003801	npp-15		C29E4.4|CeNup133	gene	taxon:6239			
+WB	WBGene00003803	rae-1		F10G8.3|CeRAE1|npp-17	gene	taxon:6239			
+WB	WBGene00003804	npp-18		Y43F4B.4|CeSeh1	gene	taxon:6239			
+WB	WBGene00003805	npp-19		R06F6.5|CeNup35|Nup35	gene	taxon:6239			
+WB	WBGene00003806	npp-20		Y77E11A.13|CeSec13R|sec-13|Y77E11A_3670.c	gene	taxon:6239			
+WB	WBGene00003807	npr-1		C39E6.6|bor-1	gene	taxon:6239			
+WB	WBGene00003808	npr-2		T05A1.1	gene	taxon:6239			
+WB	WBGene00003812	nrf-5		F55B12.5	gene	taxon:6239			
+WB	WBGene00003813	nrf-6		C08B11.4	gene	taxon:6239			
+WB	WBGene00003815	nars-1		F22D6.3|let-389|nrs-1	gene	taxon:6239			
+WB	WBGene00003816	asns-1		F25G6.6	gene	taxon:6239			
+WB	WBGene00003818	nsf-1		H15N14.2	gene	taxon:6239			
+WB	WBGene00003821	nst-1		K01C8.9	gene	taxon:6239			
+WB	WBGene00003822	nsy-1		F59A6.1|ask-1|esp-8|srf-6|xts-1	gene	taxon:6239			
+WB	WBGene00003825	ntl-2		B0286.4	gene	taxon:6239			
+WB	WBGene00003826	ntl-3		Y56A3A.1|Y56A3A.a	gene	taxon:6239			
+WB	WBGene00003827	ntl-4		C49H3.5	gene	taxon:6239			
+WB	WBGene00003828	nuc-1		C07B5.5	gene	taxon:6239			
+WB	WBGene00003829	nud-1		F53A2.4	gene	taxon:6239			
+WB	WBGene00003830	num-1		T03D8.1|cka-1	gene	taxon:6239			
+WB	WBGene00003831	nuo-1		C09H10.3	gene	taxon:6239			
+WB	WBGene00003834	nxf-1		C15H11.3|nfx-1	gene	taxon:6239			
+WB	WBGene00003835	nxf-2		C15H11.6|nfx-2	gene	taxon:6239			
+WB	WBGene00003836	nxt-1		Y71F9AM.5|NXT1	gene	taxon:6239			
+WB	WBGene00003837	oat-1		T01B11.7	gene	taxon:6239			
+WB	WBGene00003838	ocr-1		F28H7.10	gene	taxon:6239			
+WB	WBGene00003839	ocr-2		T09A12.3	gene	taxon:6239			
+WB	WBGene00003840	ocr-3		T10B10.7	gene	taxon:6239			
+WB	WBGene00003841	ocr-4		Y40C5A.2	gene	taxon:6239			
+WB	WBGene00003842	oct-1		F52F12.1	gene	taxon:6239			
+WB	WBGene00003843	oct-2		ZK455.8	gene	taxon:6239			
+WB	WBGene00003844	odc-1		K11C4.4|ODC\/1	gene	taxon:6239			
+WB	WBGene00003845	odd-1		B0280.4	gene	taxon:6239			
+WB	WBGene00003846	odd-2		C34H3.2	gene	taxon:6239			
+WB	WBGene00003847	blmp-1		F25D7.3|dpy-24|odd-3	gene	taxon:6239			
+WB	WBGene00003848	odr-1		R01E6.1|gcy-10	gene	taxon:6239			
+WB	WBGene00003849	odr-2		T01C4.2	gene	taxon:6239			
+WB	WBGene00003850	odr-3		C34D1.3	gene	taxon:6239			
+WB	WBGene00003851	odr-4		Y102E9.1	gene	taxon:6239			
+WB	WBGene00003854	odr-7		T18D3.2	gene	taxon:6239			
+WB	WBGene00003856	odr-10		C53B7.5	gene	taxon:6239			
+WB	WBGene00003858	ogt-1		K04G7.3|C. elegans OGT|Ogt	gene	taxon:6239			
+WB	WBGene00003859	oig-1		C09E7.3|C09E7.f	gene	taxon:6239			
+WB	WBGene00003860	oig-2		Y38F1A.9	gene	taxon:6239			
+WB	WBGene00003862	old-1		C08H9.5|tkr-1	gene	taxon:6239			
+WB	WBGene00003863	old-2		ZK938.5|kin-28|tkr-2	gene	taxon:6239			
+WB	WBGene00003864	oma-1		C09G9.6|moe-1	gene	taxon:6239			
+WB	WBGene00003865	oma-2		ZC513.6|dao-7|moe-2	gene	taxon:6239			
+WB	WBGene00003866	ooc-1			gene	taxon:6239			
+WB	WBGene00003868	ooc-3		B0334.11|mel-19	gene	taxon:6239			
+WB	WBGene00003870	ooc-5		C18E9.11	gene	taxon:6239			
+WB	WBGene00003876	pept-2		C06G8.2|CPTA|opt-1|pep-1	gene	taxon:6239			
+WB	WBGene00003877	pept-1		K04E7.2|opt-2|pep-2	gene	taxon:6239			
+WB	WBGene00003878	pept-3		F56F4.5|opt-3	gene	taxon:6239			
+WB	WBGene00003882	orc-2		F59E10.1|ceOrc2	gene	taxon:6239			
+WB	WBGene00003883	osm-1		T27B1.1	gene	taxon:6239			
+WB	WBGene00003884	osm-3		M02B7.3|caf-1|klp-2	gene	taxon:6239			
+WB	WBGene00003885	osm-5		Y41G9A.1	gene	taxon:6239			
+WB	WBGene00003886	osm-6		R31.3	gene	taxon:6239			
+WB	WBGene00003887	osm-7		T05D4.4	gene	taxon:6239			
+WB	WBGene00003888	osm-8		R07G3.6	gene	taxon:6239			
+WB	WBGene00003889	osm-9		B0212.5|nss-2	gene	taxon:6239			
+WB	WBGene00003890	osm-10		T20H4.1	gene	taxon:6239			
+WB	WBGene00003891	osm-11		F11C7.5|sel-14	gene	taxon:6239			
+WB	WBGene00003892	osm-12		Y75B8A.12|bbs-7	gene	taxon:6239			
+WB	WBGene00003893	ost-1		C44B12.2|SPARC|SPARC\/1	gene	taxon:6239			
+WB	WBGene00003898	oxi-1		Y39A1C.2	gene	taxon:6239			
+WB	WBGene00003901	paa-1		F48E8.5	gene	taxon:6239			
+WB	WBGene00003902	pab-1		Y106G6H.2	gene	taxon:6239			
+WB	WBGene00003903	pab-2		F18H3.3	gene	taxon:6239			
+WB	WBGene00003904	pabp-2		C17E4.5|pab-3	gene	taxon:6239			
+WB	WBGene00003905	pad-1		Y18D10A.13|Y18D10A15	gene	taxon:6239			
+WB	WBGene00003906	paf-1		W03G9.6	gene	taxon:6239			
+WB	WBGene00003907	paf-2		C52B9.7	gene	taxon:6239			
+WB	WBGene00003909	pag-3		F45B8.4	gene	taxon:6239			
+WB	WBGene00003911	pak-1		C09B8.7|CePAK	gene	taxon:6239			
+WB	WBGene00003912	pal-1		C38D4.6|ceh-3|nob-2	gene	taxon:6239			
+WB	WBGene00003914	pam-1		F49E8.3|scu-1	gene	taxon:6239			
+WB	WBGene00003915	pan-1		M88.6	gene	taxon:6239			
+WB	WBGene00003916	par-1		H39E23.1|zyg-14	gene	taxon:6239			
+WB	WBGene00003917	par-2		F58B6.3	gene	taxon:6239			
+WB	WBGene00003918	par-3		F54E7.3	gene	taxon:6239			
+WB	WBGene00003919	par-4		Y59A8B.14	gene	taxon:6239			
+WB	WBGene00003920	par-5		M117.2|ftt-1	gene	taxon:6239			
+WB	WBGene00003921	par-6		T26E3.3	gene	taxon:6239			
+WB	WBGene00003922	pas-1		C15H11.7	gene	taxon:6239			
+WB	WBGene00003923	pas-2		D1054.2|tag-166	gene	taxon:6239			
+WB	WBGene00003924	pas-3		Y110A7A.14	gene	taxon:6239			
+WB	WBGene00003925	pas-4		C36B1.4	gene	taxon:6239			
+WB	WBGene00003926	pas-5		F25H2.9|syt-2	gene	taxon:6239			
+WB	WBGene00003927	pas-6		CD4.6	gene	taxon:6239			
+WB	WBGene00003928	pas-7		ZK945.2	gene	taxon:6239			
+WB	WBGene00003929	pat-2		F54F2.1|vab-20	gene	taxon:6239			
+WB	WBGene00003930	pat-3		ZK1058.2|epi-2|INTB\/1	gene	taxon:6239			
+WB	WBGene00003931	pat-4		C29F9.7	gene	taxon:6239			
+WB	WBGene00003932	pat-6		T21D12.4	gene	taxon:6239			
+WB	WBGene00003933	pat-9		T27B1.2|ztf-19	gene	taxon:6239			
+WB	WBGene00003934	pat-10		F54C1.7|let-646|tnc-1	gene	taxon:6239			
+WB	WBGene00003936	pat-12		T17H7.4|gei-16	gene	taxon:6239			
+WB	WBGene00003937	pax-1		K07C11.1	gene	taxon:6239			
+WB	WBGene00003938	pax-2		K06B9.5	gene	taxon:6239			
+WB	WBGene00003939	pax-3		F27E5.2	gene	taxon:6239			
+WB	WBGene00003941	pbo-1		Y71H2AL.1|Y71H2AL.b|Y71H2AL.c|Y71H2AL.g	gene	taxon:6239			
+WB	WBGene00003943	pbo-4		K09C8.1|nhx-7	gene	taxon:6239			
+WB	WBGene00003947	pbs-1		K08D12.1	gene	taxon:6239			
+WB	WBGene00003948	pbs-2		C47B2.4	gene	taxon:6239			
+WB	WBGene00003949	pbs-3		Y38A8.2	gene	taxon:6239			
+WB	WBGene00003950	pbs-4		T20F5.2	gene	taxon:6239			
+WB	WBGene00003951	pbs-5		K05C4.1	gene	taxon:6239			
+WB	WBGene00003952	pbs-6		C02F5.9|3I332	gene	taxon:6239			
+WB	WBGene00003953	pbs-7		F39H11.5	gene	taxon:6239			
+WB	WBGene00003954	pcm-1		C10F3.5	gene	taxon:6239			
+WB	WBGene00003955	pcn-1		W03D2.4	gene	taxon:6239			
+WB	WBGene00003956	pcp-1		ZK112.1	gene	taxon:6239			
+WB	WBGene00003957	pcp-2		F23B2.12	gene	taxon:6239			
+WB	WBGene00003958	pcp-3		F23B2.11	gene	taxon:6239			
+WB	WBGene00003959	pcp-4		Y116F11B.3	gene	taxon:6239			
+WB	WBGene00003960	pcs-1		F54D5.1|CePCS|TFIIE-beta	gene	taxon:6239			
+WB	WBGene00003961	pct-1		C07G1.3|pct	gene	taxon:6239			
+WB	WBGene00003962	pdi-1		C14B1.1	gene	taxon:6239			
+WB	WBGene00003963	pdi-2		C07A12.4	gene	taxon:6239			
+WB	WBGene00003964	pdi-3		H06O01.1	gene	taxon:6239			
+WB	WBGene00003965	pdk-1		H42K12.1	gene	taxon:6239			
+WB	WBGene00003966	pdl-1		C27H5.1	gene	taxon:6239			
+WB	WBGene00003967	pdr-1		K08E3.7	gene	taxon:6239			
+WB	WBGene00003968	peb-1		T14F9.4	gene	taxon:6239			
+WB	WBGene00003969	pef-1		F23H11.8	gene	taxon:6239			
+WB	WBGene00003970	pek-1		F46C3.1|perk	gene	taxon:6239			
+WB	WBGene00003975	pen-2		T28D6.9	gene	taxon:6239			
+WB	WBGene00003976	pes-1		T28H11.4	gene	taxon:6239			
+WB	WBGene00003978	pes-4		Y119D3B.17|Y119D3_447.a	gene	taxon:6239			
+WB	WBGene00003979	pes-5		T27D12.4	gene	taxon:6239			
+WB	WBGene00003980	pes-7		F09C3.1|tag-2	gene	taxon:6239			
+WB	WBGene00003981	pes-8		F18G5.2	gene	taxon:6239			
+WB	WBGene00003982	pes-9		R11H6.1	gene	taxon:6239			
+WB	WBGene00003983	pes-10		Y46G5A.27	gene	taxon:6239			
+WB	WBGene00003986	mct-4		K05B2.5|pes-22	gene	taxon:6239			
+WB	WBGene00003987	pes-23		F14B8.3	gene	taxon:6239			
+WB	WBGene00003989	pfn-1		Y18D10A.20	gene	taxon:6239			
+WB	WBGene00003990	pfn-2		F35C8.6	gene	taxon:6239			
+WB	WBGene00003991	pfn-3		K03E6.6	gene	taxon:6239			
+WB	WBGene00003992	pgl-1		ZK381.4	gene	taxon:6239			
+WB	WBGene00003993	pgl-2		B0523.3	gene	taxon:6239			
+WB	WBGene00003994	pgl-3		C18G1.4|tag-136	gene	taxon:6239			
+WB	WBGene00003995	pgp-1		K08E7.9|cepgpA	gene	taxon:6239			
+WB	WBGene00003996	pgp-2		C34G6.4|glo-5	gene	taxon:6239			
+WB	WBGene00003997	pgp-3		ZK455.7|cepgpC	gene	taxon:6239			
+WB	WBGene00003998	pgp-4		F42E11.1	gene	taxon:6239			
+WB	WBGene00003999	pgp-5		C05A9.1	gene	taxon:6239			
+WB	WBGene00004000	pgp-6		T21E8.1	gene	taxon:6239			
+WB	WBGene00004001	pgp-7		T21E8.2	gene	taxon:6239			
+WB	WBGene00004002	pgp-8		T21E8.3	gene	taxon:6239			
+WB	WBGene00004003	pgp-9		C47A10.1	gene	taxon:6239			
+WB	WBGene00004004	pgp-10		C54D1.1	gene	taxon:6239			
+WB	WBGene00004005	pgp-11		DH11.3	gene	taxon:6239			
+WB	WBGene00004006	pgp-12		F22E10.1	gene	taxon:6239			
+WB	WBGene00004007	pgp-13		F22E10.2	gene	taxon:6239			
+WB	WBGene00004008	pgp-14		F22E10.3	gene	taxon:6239			
+WB	WBGene00004010	pha-1		Y48A6C.5|pha1	gene	taxon:6239			
+WB	WBGene00004011	pha-2		M6.3	gene	taxon:6239			
+WB	WBGene00004012	pha-3			gene	taxon:6239			
+WB	WBGene00004013	pha-4		F38A6.1|Ce-fkh-1|fkh-1	gene	taxon:6239			
+WB	WBGene00004014	phb-1		Y37E3.9	gene	taxon:6239			
+WB	WBGene00004015	phb-2		T24H7.1	gene	taxon:6239			
+WB	WBGene00004016	phf-5		Y54F10BM.14	gene	taxon:6239			
+WB	WBGene00004017	phg-1		F27E5.4|phas-1	gene	taxon:6239			
+WB	WBGene00004020	pho-1		EGAP2.3	gene	taxon:6239			
+WB	WBGene00004024	php-3		Y75B8A.1|lep-3	gene	taxon:6239			
+WB	WBGene00004025	phy-2		F35G2.4	gene	taxon:6239			
+WB	WBGene00004026	phy-3		T20B3.7	gene	taxon:6239			
+WB	WBGene00004027	pie-1		Y49E10.14|pic-1	gene	taxon:6239			
+WB	WBGene00004028	pif-1		Y18H1A.6|cePIF1	gene	taxon:6239			
+WB	WBGene00004029	pik-1		K09B11.1	gene	taxon:6239			
+WB	WBGene00004030	pin-2		F07C6.1	gene	taxon:6239			
+WB	WBGene00004031	pis-1		T13F2.3|T12F2\/3a\/b	gene	taxon:6239			
+WB	WBGene00004032	pkc-1		F57F5.5|kin-13|ttx-4	gene	taxon:6239			
+WB	WBGene00004033	pkc-2		E01H11.1|kin-11|PKC2A|PKC2B	gene	taxon:6239			
+WB	WBGene00004034	pkc-3		F09E5.1	gene	taxon:6239			
+WB	WBGene00004035	pkd-2		Y73F8A.1|pdk-2	gene	taxon:6239			
+WB	WBGene00004036	plc-1		F31B12.1|frm-9|PLC210	gene	taxon:6239			
+WB	WBGene00004037	plc-2		Y75B12B.6	gene	taxon:6239			
+WB	WBGene00004038	plc-3		T01E8.3	gene	taxon:6239			
+WB	WBGene00004039	plc-4		R05G6.8	gene	taxon:6239			
+WB	WBGene00004040	pld-1		C04G6.3|PLD	gene	taxon:6239			
+WB	WBGene00004042	plk-1		C14B9.4|plc1	gene	taxon:6239			
+WB	WBGene00004043	plk-2		Y71F9B.7	gene	taxon:6239			
+WB	WBGene00004044	plk-3		F55G1.8	gene	taxon:6239			
+WB	WBGene00004045	pll-1		K10F12.3	gene	taxon:6239			
+WB	WBGene00004046	plp-1		F45E4.2	gene	taxon:6239			
+WB	WBGene00004047	plx-1		Y55F3AL.1|cep-2	gene	taxon:6239			
+WB	WBGene00004048	plx-2		K04B12.1|cep-1	gene	taxon:6239			
+WB	WBGene00004049	parp-1		Y71F9AL.18|pme-1	gene	taxon:6239			
+WB	WBGene00004050	parp-2		E02H1.4|pme-2|prm-2	gene	taxon:6239			
+WB	WBGene00004051	parg-1		F20C5.1|pme-3	gene	taxon:6239			
+WB	WBGene00004052	parg-2		H23L24.5|pme-4	gene	taxon:6239			
+WB	WBGene00004053	tank-1		ZK1005.1|pme-5	gene	taxon:6239			
+WB	WBGene00004055	pmk-1		B0218.3	gene	taxon:6239			
+WB	WBGene00004056	pmk-2		F42G8.3	gene	taxon:6239			
+WB	WBGene00004057	pmk-3		F42G8.4	gene	taxon:6239			
+WB	WBGene00004058	pmp-1		C44B7.8	gene	taxon:6239			
+WB	WBGene00004059	pmp-2		C44B7.9	gene	taxon:6239			
+WB	WBGene00004060	pmp-3		C54G10.3	gene	taxon:6239			
+WB	WBGene00004061	pmp-4		T02D1.5|tag-14	gene	taxon:6239			
+WB	WBGene00004062	pmp-5		T10H9.5	gene	taxon:6239			
+WB	WBGene00004063	pmr-1		ZK256.1|pmr1	gene	taxon:6239			
+WB	WBGene00004064	pms-2		H12C20.2	gene	taxon:6239			
+WB	WBGene00004068	pnk-1		C10G11.5	gene	taxon:6239			
+WB	WBGene00004075	pod-1		Y76A2B.1	gene	taxon:6239			
+WB	WBGene00004076	pod-2		W09B6.1|phi-47	gene	taxon:6239			
+WB	WBGene00004077	pop-1		W10C8.2|sys-2	gene	taxon:6239			
+WB	WBGene00004078	pos-1		F52E1.1	gene	taxon:6239			
+WB	WBGene00004083	pph-1		C05A2.1|pph1-C	gene	taxon:6239			
+WB	WBGene00004084	pph-2		C29E6.3|pph2A-c	gene	taxon:6239			
+WB	WBGene00004085	pph-4.1		Y75B8A.30	gene	taxon:6239			
+WB	WBGene00004086	pph-4.2		Y49E10.3	gene	taxon:6239			
+WB	WBGene00004087	ppk-1		F55A12.3	gene	taxon:6239			
+WB	WBGene00004088	ppk-2		Y48G9A.8|Y48G9A.h	gene	taxon:6239			
+WB	WBGene00004089	ppk-3		VF11C1L.1	gene	taxon:6239			
+WB	WBGene00004090	eif-2Bgamma		C15F1.4|ppp-1	gene	taxon:6239			
+WB	WBGene00004091	pps-1		T14G10.1	gene	taxon:6239			
+WB	WBGene00004092	ppt-1		F44C4.5	gene	taxon:6239			
+WB	WBGene00004093	ppw-1		C18E3.7|wago-7	gene	taxon:6239			
+WB	WBGene00004094	ppw-2		Y110A7A.18|wago-3	gene	taxon:6239			
+WB	WBGene00004095	pqe-1		F52C9.8	gene	taxon:6239			
+WB	WBGene00004096	pqm-1		F40F8.7|CePqM132|pqm-132	gene	taxon:6239			
+WB	WBGene00004099	abu-15		C03A7.4|pqn-5	gene	taxon:6239			
+WB	WBGene00004100	pqn-8		C05B5.3	gene	taxon:6239			
+WB	WBGene00004101	hgrs-1		C07G1.5|pqn-9|vps-27	gene	taxon:6239			
+WB	WBGene00004102	pqn-10		C09E7.2	gene	taxon:6239			
+WB	WBGene00004105	szy-20		C18E9.3|pqn-14	gene	taxon:6239			
+WB	WBGene00004106	pqn-15		C24A8.3	gene	taxon:6239			
+WB	WBGene00004109	stam-1		C34G6.7|pqn-19	gene	taxon:6239			
+WB	WBGene00004111	pqn-21		C37A2.5	gene	taxon:6239			
+WB	WBGene00004113	pqn-24		D1007.14	gene	taxon:6239			
+WB	WBGene00004114	pqn-25		D1044.3	gene	taxon:6239			
+WB	WBGene00004117	sin-3		F02E9.4|pqn-28	gene	taxon:6239			
+WB	WBGene00004121	ptrn-1		F35B3.5|pqn-34	gene	taxon:6239			
+WB	WBGene00004122	pqn-35		F35D11.2	gene	taxon:6239			
+WB	WBGene00004127	abu-12		F52D1.3|pqn-40	gene	taxon:6239			
+WB	WBGene00004128	pqn-41		F53A3.4	gene	taxon:6239			
+WB	WBGene00004130	ketn-1		F54E2.3|MH44|pqn-43	gene	taxon:6239			
+WB	WBGene00004131	tent-5		F55A12.9|pqn-44	gene	taxon:6239			
+WB	WBGene00004132	ifet-1		F56F3.1|pqn-45|spn-2	gene	taxon:6239			
+WB	WBGene00004134	myrf-1		F59B10.1|pqn-47	gene	taxon:6239			
+WB	WBGene00004135	pqn-48		K07D4.8	gene	taxon:6239			
+WB	WBGene00004136	pqn-51		K11D12.2	gene	taxon:6239			
+WB	WBGene00004138	pqn-53		R07B7.3	gene	taxon:6239			
+WB	WBGene00004139	pqn-54		R09B5.5	gene	taxon:6239			
+WB	WBGene00004140	ebax-1		R09E10.7|pqn-55	gene	taxon:6239			
+WB	WBGene00004143	pqn-59		R119.4|prp-1	gene	taxon:6239			
+WB	WBGene00004144	pqn-60		R11G11.7	gene	taxon:6239			
+WB	WBGene00004147	larp-5		T12F5.5|larp-2|pqn-64|T12F5.h	gene	taxon:6239			
+WB	WBGene00004149	trpl-5		T16A1.7|pqn-66	gene	taxon:6239			
+WB	WBGene00004151	pqn-68		T16G1.10	gene	taxon:6239			
+WB	WBGene00004153	pqn-71		T23F1.6	gene	taxon:6239			
+WB	WBGene00004155	pqn-73		W01C9.3	gene	taxon:6239			
+WB	WBGene00004156	pqn-74		W02A2.3	gene	taxon:6239			
+WB	WBGene00004164	pqn-83		Y39E4B.3	gene	taxon:6239			
+WB	WBGene00004165	pqn-84		Y41C4A.5	gene	taxon:6239			
+WB	WBGene00004166	scc-2		Y43H11AL.3|pqn-85|Y43H11AL.a|Y43H11AL.b|Y43H11AL.e|Y43H11AL.f	gene	taxon:6239			
+WB	WBGene00004169	pqn-89		Y73B6BR.1|Y73B6BR.a	gene	taxon:6239			
+WB	WBGene00004174	abu-14		ZK1067.7|pqn-95	gene	taxon:6239			
+WB	WBGene00004176	pqn-97		ZK488.10	gene	taxon:6239			
+WB	WBGene00004177	pqn-98		ZK488.7	gene	taxon:6239			
+WB	WBGene00004178	prg-1		D2030.6	gene	taxon:6239			
+WB	WBGene00004180	pri-1		F58A4.4	gene	taxon:6239			
+WB	WBGene00004181	pri-2		W02D9.1	gene	taxon:6239			
+WB	WBGene00004182	prk-1		C06E8.3	gene	taxon:6239			
+WB	WBGene00004183	prk-2		F45H7.4	gene	taxon:6239			
+WB	WBGene00004184	T19D2.2		prl-1	gene	taxon:6239			
+WB	WBGene00004185	pro-1		R166.4	gene	taxon:6239			
+WB	WBGene00004186	prpf-4		F22D6.5|let-400|prp-4	gene	taxon:6239			
+WB	WBGene00004187	prp-8		C50C3.6	gene	taxon:6239			
+WB	WBGene00004188	prp-21		W07E6.4|Ceprp21	gene	taxon:6239			
+WB	WBGene00004189	pars-1		T20H4.3|prs-1	gene	taxon:6239			
+WB	WBGene00004190	pars-2		T27F6.5|prs-2	gene	taxon:6239			
+WB	WBGene00004191	prx-1		C11H1.4|C11H1.6|pex-1|pex1	gene	taxon:6239			
+WB	WBGene00004192	prx-2		ZK809.7	gene	taxon:6239			
+WB	WBGene00004193	prx-3		C15H9.8	gene	taxon:6239			
+WB	WBGene00004194	prx-5		C34C6.6	gene	taxon:6239			
+WB	WBGene00004195	prx-6		F39G3.7|pex-6	gene	taxon:6239			
+WB	WBGene00004196	prx-11		C47B2.8	gene	taxon:6239			
+WB	WBGene00004197	prx-12		F08B12.2	gene	taxon:6239			
+WB	WBGene00004198	prx-13		F32A5.6	gene	taxon:6239			
+WB	WBGene00004199	prx-14		R07H5.1	gene	taxon:6239			
+WB	WBGene00004201	prx-19		F54F2.8	gene	taxon:6239			
+WB	WBGene00004202	pry-1		C37A5.9|Axin	gene	taxon:6239			
+WB	WBGene00004203	swsn-1		Y113G7B.23|psa-1	gene	taxon:6239			
+WB	WBGene00004204	swsn-4		F01G4.1|psa-4	gene	taxon:6239			
+WB	WBGene00004205	psr-1		F29B9.4|tag-159	gene	taxon:6239			
+WB	WBGene00004206	pst-1		M03F8.2|let-462	gene	taxon:6239			
+WB	WBGene00004207	ptb-1		D2089.4	gene	taxon:6239			
+WB	WBGene00004208	ptc-1		ZK675.1	gene	taxon:6239			
+WB	WBGene00004210	ptc-3		Y110A2AL.8|Y110A2AL.j	gene	taxon:6239			
+WB	WBGene00004211	ptd-2		F07C3.1	gene	taxon:6239			
+WB	WBGene00004212	ptl-1		F42G9.9|tau-1	gene	taxon:6239			
+WB	WBGene00004213	ptp-1		C48D5.2|nemPTP	gene	taxon:6239			
+WB	WBGene00004214	ptp-2		F59G1.5|stp-1	gene	taxon:6239			
+WB	WBGene00004215	ptp-3		C09D8.1|ptp-1|ptp-3A|ptp-3B|qid-5|ypp-1|YPP\/1	gene	taxon:6239			
+WB	WBGene00004216	ptr-1		C24B5.3	gene	taxon:6239			
+WB	WBGene00004217	ptr-2		C32E8.8|let-575	gene	taxon:6239			
+WB	WBGene00004218	ptr-3		C41D7.2	gene	taxon:6239			
+WB	WBGene00004219	ptr-4		C45B2.7	gene	taxon:6239			
+WB	WBGene00004220	ptr-5		C53C11.3	gene	taxon:6239			
+WB	WBGene00004221	ptr-6		C54A12.1	gene	taxon:6239			
+WB	WBGene00004222	ptr-8		F44F4.4	gene	taxon:6239			
+WB	WBGene00004223	ptr-9		F54G8.5	gene	taxon:6239			
+WB	WBGene00004224	ptr-10		F55F8.1	gene	taxon:6239			
+WB	WBGene00004225	ptr-11		F56C11.2	gene	taxon:6239			
+WB	WBGene00004226	ptr-12		K07A3.2	gene	taxon:6239			
+WB	WBGene00004227	ptr-13		K07C10.1	gene	taxon:6239			
+WB	WBGene00004228	ptr-14		R09H10.4	gene	taxon:6239			
+WB	WBGene00004229	ptr-15		T07H8.6|bus-13	gene	taxon:6239			
+WB	WBGene00004230	ptr-16		T21H3.2	gene	taxon:6239			
+WB	WBGene00004231	ptr-17		Y18D10A.7	gene	taxon:6239			
+WB	WBGene00004232	ptr-18		Y38F1A.3	gene	taxon:6239			
+WB	WBGene00004233	ptr-19		Y39A1B.2	gene	taxon:6239			
+WB	WBGene00004234	ptr-20		Y53F4B.28	gene	taxon:6239			
+WB	WBGene00004235	ptr-21		Y65B4BR.3	gene	taxon:6239			
+WB	WBGene00004236	ptr-22		Y80D3A.7	gene	taxon:6239			
+WB	WBGene00004237	ptr-23		ZK270.1	gene	taxon:6239			
+WB	WBGene00004238	ptr-24		F46G10.5	gene	taxon:6239			
+WB	WBGene00004239	puf-3		Y45F10A.2	gene	taxon:6239			
+WB	WBGene00004241	puf-5		F54C9.8	gene	taxon:6239			
+WB	WBGene00004242	puf-6		F18A11.1	gene	taxon:6239			
+WB	WBGene00004243	puf-7		B0273.2	gene	taxon:6239			
+WB	WBGene00004244	puf-8		C30G12.7|teg-2	gene	taxon:6239			
+WB	WBGene00004245	puf-9		W06B11.2	gene	taxon:6239			
+WB	WBGene00004248	pus-1		W06H3.2	gene	taxon:6239			
+WB	WBGene00004249	pvf-1		Y39A3CL.6	gene	taxon:6239			
+WB	WBGene00004254	pxf-1		T14G10.2|ra-gef|yk17d8.3	gene	taxon:6239			
+WB	WBGene00004255	epac-1		T20G5.5	gene	taxon:6239			
+WB	WBGene00004256	pxn-1		ZK994.3	gene	taxon:6239			
+WB	WBGene00004257	pxn-2		K09C8.5	gene	taxon:6239			
+WB	WBGene00004258	pyc-1		D2023.2	gene	taxon:6239			
+WB	WBGene00004259	pyr-1		D2085.1	gene	taxon:6239			
+WB	WBGene00004264	qua-1		T05C12.10	gene	taxon:6239			
+WB	WBGene00004265	qui-1		Y45F10B.10	gene	taxon:6239			
+WB	WBGene00004266	rab-1		C39F7.4|Rab protein	gene	taxon:6239			
+WB	WBGene00004267	rab-3		C18A3.6|rab3|RAB3\/A|rbl-3	gene	taxon:6239			
+WB	WBGene00004268	rab-5		F26H9.6	gene	taxon:6239			
+WB	WBGene00004269	rab-6.1		F59B2.7|P34213	gene	taxon:6239			
+WB	WBGene00004270	rab-6.2		T25G12.4	gene	taxon:6239			
+WB	WBGene00004271	rab-7		W03C9.3	gene	taxon:6239			
+WB	WBGene00004272	rab-8		D1037.4|rab8	gene	taxon:6239			
+WB	WBGene00004273	rab-10		T23H2.5|gum-1	gene	taxon:6239			
+WB	WBGene00004274	rab-11.1		F53G12.1|rab-11	gene	taxon:6239			
+WB	WBGene00004275	rab-11.2		W04G5.2	gene	taxon:6239			
+WB	WBGene00004276	rab-14		K09A9.2	gene	taxon:6239			
+WB	WBGene00004277	rab-18		Y92C3B.3|pra-1	gene	taxon:6239			
+WB	WBGene00004278	rab-19		Y62E10A.9	gene	taxon:6239			
+WB	WBGene00004279	rab-21		T01B7.3	gene	taxon:6239			
+WB	WBGene00004281	rab-28		Y11D7A.4	gene	taxon:6239			
+WB	WBGene00004282	rab-30		Y45F3A.2	gene	taxon:6239			
+WB	WBGene00004283	rab-33		F43D9.2	gene	taxon:6239			
+WB	WBGene00004284	rab-35		Y47D3A.25|rme-5	gene	taxon:6239			
+WB	WBGene00004285	rab-37		W01H2.3	gene	taxon:6239			
+WB	WBGene00004286	rab-39		D2013.1	gene	taxon:6239			
+WB	WBGene00004287	rac-2		K03D3.10	gene	taxon:6239			
+WB	WBGene00004291	rad-4			gene	taxon:6239			
+WB	WBGene00004293	rad-7			gene	taxon:6239			
+WB	WBGene00004295	rad-9			gene	taxon:6239			
+WB	WBGene00004296	rad-50		T04H1.4|RAD50	gene	taxon:6239			
+WB	WBGene00004297	rad-51		Y43C5A.6|rad51|rdh-1	gene	taxon:6239			
+WB	WBGene00004298	rad-54.L		W06D4.6|rad-54	gene	taxon:6239			
+WB	WBGene00004300	ram-2		F38A3.2|col-82|ram-3	gene	taxon:6239			
+WB	WBGene00004301	ram-5		T24C2.1	gene	taxon:6239			
+WB	WBGene00004302	ran-1		K01G5.4	gene	taxon:6239			
+WB	WBGene00004303	ran-2		C29E4.3|pna-3	gene	taxon:6239			
+WB	WBGene00004304	ran-3		C26D10.1	gene	taxon:6239			
+WB	WBGene00004305	ran-4		R05D11.3	gene	taxon:6239			
+WB	WBGene00004306	ran-5		R12C12.2	gene	taxon:6239			
+WB	WBGene00004307	rap-1		C27B7.8|rrp-1	gene	taxon:6239			
+WB	WBGene00004308	rap-2		C25D7.7	gene	taxon:6239			
+WB	WBGene00004309	rap-3		C08F8.7|rrp-2	gene	taxon:6239			
+WB	WBGene00004310	ras-1		C44C11.1|R-ras1|ras1	gene	taxon:6239			
+WB	WBGene00004311	ras-2		F17C8.4|Ras2	gene	taxon:6239			
+WB	WBGene00004312	rba-1		K07A1.11	gene	taxon:6239			
+WB	WBGene00004315	rbd-1		T23F6.4	gene	taxon:6239			
+WB	WBGene00004316	rbf-1		F37A4.7|Rabph	gene	taxon:6239			
+WB	WBGene00004317	rbg-1		F20D1.6|Rab3-GAP	gene	taxon:6239			
+WB	WBGene00004318	rbg-2		T22C1.10	gene	taxon:6239			
+WB	WBGene00004319	rbr-2		ZK593.4|rbp-2	gene	taxon:6239			
+WB	WBGene00004320	rbx-1		ZK287.5|Ce-rbx-1	gene	taxon:6239			
+WB	WBGene00004321	rcan-1		F54E7.7|DSCR1L|rcn-1|SC	gene	taxon:6239			
+WB	WBGene00004322	rcq-5		E03A3.2	gene	taxon:6239			
+WB	WBGene00004323	rde-1		K08H10.7	gene	taxon:6239			
+WB	WBGene00004324	rde-2		F21C3.4|mut-8	gene	taxon:6239			
+WB	WBGene00004326	rde-4		T20G5.11	gene	taxon:6239			
+WB	WBGene00004328	rdy-2		F53F4.6	gene	taxon:6239			
+WB	WBGene00004332	rec-1		Y18H1A.7	gene	taxon:6239			
+WB	WBGene00004333	rec-8		W02A2.6	gene	taxon:6239			
+WB	WBGene00004334	ref-1		T01E8.2|hlh-24	gene	taxon:6239			
+WB	WBGene00004335	ref-2		C47C12.3	gene	taxon:6239			
+WB	WBGene00004336	ret-1		W06A7.3|reticulon|rtn|RTNL-A1|RTNL-A2|RTNL-B1|RTNL-B2|RTNL-C	gene	taxon:6239			
+WB	WBGene00004337	rfc-1		C54G10.2	gene	taxon:6239			
+WB	WBGene00004338	rfc-2		F58F6.4	gene	taxon:6239			
+WB	WBGene00004339	rfc-3		C39E9.13	gene	taxon:6239			
+WB	WBGene00004340	rfc-4		F31E3.3	gene	taxon:6239			
+WB	WBGene00004341	rfl-1		F11H8.1|cyk-5|uba-3	gene	taxon:6239			
+WB	WBGene00004342	rfs-1		C30A5.2|him-15	gene	taxon:6239			
+WB	WBGene00004343	rgr-1		C38C10.5|mdt-14	gene	taxon:6239			
+WB	WBGene00004344	rgs-1		C05B5.7	gene	taxon:6239			
+WB	WBGene00004345	rgs-2		F16H9.1	gene	taxon:6239			
+WB	WBGene00004346	rgs-3		C29H12.3	gene	taxon:6239			
+WB	WBGene00004348	rgs-5		B0336.4	gene	taxon:6239			
+WB	WBGene00004349	rgs-6		C41G11.3	gene	taxon:6239			
+WB	WBGene00004350	rgs-7		F56B6.2	gene	taxon:6239			
+WB	WBGene00004352	rgs-9		ZC53.7	gene	taxon:6239			
+WB	WBGene00004353	rgs-10		F45B8.2|tag-215	gene	taxon:6239			
+WB	WBGene00004354	rgs-11		F45B8.1	gene	taxon:6239			
+WB	WBGene00004355	rha-1		T07D4.3	gene	taxon:6239			
+WB	WBGene00004356	rhi-1		F46H6.1|CeRhoGDI	gene	taxon:6239			
+WB	WBGene00004357	rho-1		Y51H4A.3|RhoA|Y51H4A.B	gene	taxon:6239			
+WB	WBGene00004358	rhr-1		F08F3.3	gene	taxon:6239			
+WB	WBGene00004359	rhr-2		B0240.1	gene	taxon:6239			
+WB	WBGene00004360	rib-1		F12F6.3	gene	taxon:6239			
+WB	WBGene00004361	rib-2		K01G5.6	gene	taxon:6239			
+WB	WBGene00004362	ric-1		|lan-5|osm-13|ric-5	gene	taxon:6239			
+WB	WBGene00004363	ric-3		T14A8.1|des-5	gene	taxon:6239			
+WB	WBGene00004364	ric-4		Y22F5A.3|snap-25	gene	taxon:6239			
+WB	WBGene00004367	ric-8		Y69A2AR.2	gene	taxon:6239			
+WB	WBGene00004368	ric-19		C32E8.7	gene	taxon:6239			
+WB	WBGene00004369	rig-1		K09E2.4	gene	taxon:6239			
+WB	WBGene00004370	rig-3		C53B7.1	gene	taxon:6239			
+WB	WBGene00004371	rig-4		Y42H9B.2|Y42H9B.b	gene	taxon:6239			
+WB	WBGene00004373	rme-1		W06H8.1|W06H8.e	gene	taxon:6239			
+WB	WBGene00004374	rme-2		T11F8.3	gene	taxon:6239			
+WB	WBGene00004375	rme-4		F46F6.1	gene	taxon:6239			
+WB	WBGene00004377	rme-6		F49E7.1	gene	taxon:6239			
+WB	WBGene00004378	rme-8		F18C12.2	gene	taxon:6239			
+WB	WBGene00004380	rnf-1		C06A5.9|tag-54	gene	taxon:6239			
+WB	WBGene00004381	rnf-5		C16C10.7	gene	taxon:6239			
+WB	WBGene00004382	rnh-1.0		F59A6.6|rnh-1	gene	taxon:6239			
+WB	WBGene00004383	rnh-2		T13H5.7|rnh2	gene	taxon:6239			
+WB	WBGene00004384	rnp-1		ZK863.7	gene	taxon:6239			
+WB	WBGene00004385	rnp-2		K08D10.4	gene	taxon:6239			
+WB	WBGene00004386	rnp-3		K08D10.3	gene	taxon:6239			
+WB	WBGene00004387	rnp-4		R07E5.14|Ce-Y14	gene	taxon:6239			
+WB	WBGene00004388	rnp-5		K02F3.11	gene	taxon:6239			
+WB	WBGene00004389	rnp-6		Y47G6A.20|let-147	gene	taxon:6239			
+WB	WBGene00004390	rnp-7		K04G7.10	gene	taxon:6239			
+WB	WBGene00004391	rnr-1		T23G5.1	gene	taxon:6239			
+WB	WBGene00004392	rnr-2		C03C10.3	gene	taxon:6239			
+WB	WBGene00004393	rnt-1		B0414.2|mab-2|run|run-1	gene	taxon:6239			
+WB	WBGene00004394	rol-1		Y57A10A.11	gene	taxon:6239			
+WB	WBGene00004395	rol-3		C16D9.2|let-333	gene	taxon:6239			
+WB	WBGene00004397	rol-6		T01B7.7	gene	taxon:6239			
+WB	WBGene00004398	rol-8		ZK1290.3|col-6|col6	gene	taxon:6239			
+WB	WBGene00004400	rom-1		F26F4.3	gene	taxon:6239			
+WB	WBGene00004401	rom-2		C48B4.2	gene	taxon:6239			
+WB	WBGene00004402	rom-3		Y116A8C.14	gene	taxon:6239			
+WB	WBGene00004403	rom-4		Y116A8C.16	gene	taxon:6239			
+WB	WBGene00004404	rom-5		Y54E10A.14	gene	taxon:6239			
+WB	WBGene00004405	rop-1		C12D8.11|Ro|rop1	gene	taxon:6239			
+WB	WBGene00004408	rla-0		F25H2.10|rpa-0	gene	taxon:6239			
+WB	WBGene00004409	rla-1		Y37E3.7	gene	taxon:6239			
+WB	WBGene00004410	rla-2		Y62E10A.1	gene	taxon:6239			
+WB	WBGene00004411	rpc-1		C42D4.8|rpo-1	gene	taxon:6239			
+WB	WBGene00004412	rpl-1		Y71F9AL.13|rpl-10a	gene	taxon:6239			
+WB	WBGene00004413	rpl-2		B0250.1	gene	taxon:6239			
+WB	WBGene00004414	rpl-3		F13B10.2	gene	taxon:6239			
+WB	WBGene00004415	rpl-4		B0041.4	gene	taxon:6239			
+WB	WBGene00004416	rpl-5		F54C9.5	gene	taxon:6239			
+WB	WBGene00004417	rpl-6		R151.3	gene	taxon:6239			
+WB	WBGene00004418	rpl-7		F53G12.10	gene	taxon:6239			
+WB	WBGene00004419	rpl-7A		Y24D9A.4|phi-22|rpl-8|Surf-3	gene	taxon:6239			
+WB	WBGene00004420	rpl-9		R13A5.8	gene	taxon:6239			
+WB	WBGene00004421	rpl-10		F10B5.1	gene	taxon:6239			
+WB	WBGene00004422	rpl-11.1		T22F3.4|nog-1	gene	taxon:6239			
+WB	WBGene00004423	rpl-11.2		F07D10.1	gene	taxon:6239			
+WB	WBGene00004424	rpl-12		JC8.3	gene	taxon:6239			
+WB	WBGene00004425	rpl-13		C32E8.2	gene	taxon:6239			
+WB	WBGene00004426	rpl-14		C04F12.4	gene	taxon:6239			
+WB	WBGene00004427	rpl-15		K11H12.2	gene	taxon:6239			
+WB	WBGene00004428	rpl-16		M01F1.2	gene	taxon:6239			
+WB	WBGene00004429	rpl-17		Y48G8AL.8	gene	taxon:6239			
+WB	WBGene00004430	rpl-18		Y45F10D.12	gene	taxon:6239			
+WB	WBGene00004431	rpl-19		C09D4.5	gene	taxon:6239			
+WB	WBGene00004432	rpl-20		E04A4.8|E04A4.a	gene	taxon:6239			
+WB	WBGene00004433	rpl-21		C14B9.7	gene	taxon:6239			
+WB	WBGene00004434	rpl-22		C27A2.2	gene	taxon:6239			
+WB	WBGene00004435	rpl-23		B0336.10	gene	taxon:6239			
+WB	WBGene00004436	rpl-24.1		D1007.12	gene	taxon:6239			
+WB	WBGene00004437	rpl-24.2		C03D6.8	gene	taxon:6239			
+WB	WBGene00004438	rpl-25.1		F55D10.2	gene	taxon:6239			
+WB	WBGene00004439	rpl-25.2		F52B5.6	gene	taxon:6239			
+WB	WBGene00004440	rpl-26		F28C6.7	gene	taxon:6239			
+WB	WBGene00004441	rpl-27		C53H9.1	gene	taxon:6239			
+WB	WBGene00004442	rpl-28		R11D1.8	gene	taxon:6239			
+WB	WBGene00004443	rpl-29		B0513.3	gene	taxon:6239			
+WB	WBGene00004444	rpl-30		Y106G6H.3	gene	taxon:6239			
+WB	WBGene00004445	rpl-31		W09C5.6	gene	taxon:6239			
+WB	WBGene00004446	rpl-32		T24B8.1	gene	taxon:6239			
+WB	WBGene00004447	rpl-33		F10E7.7	gene	taxon:6239			
+WB	WBGene00004448	rpl-34		C42C1.14	gene	taxon:6239			
+WB	WBGene00004449	rpl-35		ZK652.4	gene	taxon:6239			
+WB	WBGene00004450	rpl-36		F37C12.4	gene	taxon:6239			
+WB	WBGene00004451	rpl-37		C54C6.1	gene	taxon:6239			
+WB	WBGene00004452	rpl-38		C06B8.8	gene	taxon:6239			
+WB	WBGene00004453	rpl-39		C26F1.9|5I256	gene	taxon:6239			
+WB	WBGene00004454	rpl-36.A		C09H10.2|2L388|rpl-41	gene	taxon:6239			
+WB	WBGene00004455	rpl-42		C09H10.1	gene	taxon:6239			
+WB	WBGene00004456	rpl-43		Y48B6A.2	gene	taxon:6239			
+WB	WBGene00004457	rpm-1		C01B7.6|rpm-3|sad-3|sam-1|syd-3	gene	taxon:6239			
+WB	WBGene00004458	rpn-1		T22D1.9	gene	taxon:6239			
+WB	WBGene00004459	rpn-2		C23G10.4	gene	taxon:6239			
+WB	WBGene00004460	rpn-3		C30C11.2	gene	taxon:6239			
+WB	WBGene00004462	rpn-6.1		F57B9.10|rpn-6	gene	taxon:6239			
+WB	WBGene00004463	rpn-7		F49C12.8	gene	taxon:6239			
+WB	WBGene00004464	rpn-8		R12E2.3	gene	taxon:6239			
+WB	WBGene00004465	rpn-9		T06D8.8	gene	taxon:6239			
+WB	WBGene00004466	rpn-10		B0205.3|mcb-1	gene	taxon:6239			
+WB	WBGene00004467	rpn-11		K07D4.3	gene	taxon:6239			
+WB	WBGene00004468	rpn-12		ZK20.5	gene	taxon:6239			
+WB	WBGene00004469	rps-0		B0393.1	gene	taxon:6239			
+WB	WBGene00004470	rps-1		F56F3.5	gene	taxon:6239			
+WB	WBGene00004471	rps-2		C49H3.11	gene	taxon:6239			
+WB	WBGene00004472	rps-3		C23G10.3	gene	taxon:6239			
+WB	WBGene00004473	rps-4		Y43B11AR.4	gene	taxon:6239			
+WB	WBGene00004474	rps-5		T05E11.1	gene	taxon:6239			
+WB	WBGene00004475	rps-6		Y71A12B.1	gene	taxon:6239			
+WB	WBGene00004476	rps-7		ZC434.2	gene	taxon:6239			
+WB	WBGene00004477	rps-8		F42C5.8	gene	taxon:6239			
+WB	WBGene00004478	rps-9		F40F8.10	gene	taxon:6239			
+WB	WBGene00004479	rps-10		D1007.6	gene	taxon:6239			
+WB	WBGene00004480	rps-11		F40F11.1	gene	taxon:6239			
+WB	WBGene00004481	rps-12		F54E7.2	gene	taxon:6239			
+WB	WBGene00004482	rps-13		C16A3.9	gene	taxon:6239			
+WB	WBGene00004483	rps-14		F37C12.9	gene	taxon:6239			
+WB	WBGene00004484	rps-15		F36A2.6	gene	taxon:6239			
+WB	WBGene00004485	rps-16		T01C3.6	gene	taxon:6239			
+WB	WBGene00004486	rps-17		T08B2.10	gene	taxon:6239			
+WB	WBGene00004487	rps-18		Y57G11C.16	gene	taxon:6239			
+WB	WBGene00004488	rps-19		T05F1.3|rpS19	gene	taxon:6239			
+WB	WBGene00004489	rps-20		Y105E8A.16|Y105E8E.s	gene	taxon:6239			
+WB	WBGene00004490	rps-21		F37C12.11	gene	taxon:6239			
+WB	WBGene00004491	rps-22		F53A3.3	gene	taxon:6239			
+WB	WBGene00004492	rps-23		F28D1.7	gene	taxon:6239			
+WB	WBGene00004493	rps-24		T07A9.11	gene	taxon:6239			
+WB	WBGene00004494	rps-25		K02B2.5	gene	taxon:6239			
+WB	WBGene00004495	rps-26		F39B2.6	gene	taxon:6239			
+WB	WBGene00004496	rps-27		F56E10.4	gene	taxon:6239			
+WB	WBGene00004497	rps-28		Y41D4B.5	gene	taxon:6239			
+WB	WBGene00004498	rps-29		B0412.4	gene	taxon:6239			
+WB	WBGene00004499	rps-30		C26F1.4	gene	taxon:6239			
+WB	WBGene00004501	rpt-1		C52E4.4	gene	taxon:6239			
+WB	WBGene00004502	rpt-2		F29G9.5	gene	taxon:6239			
+WB	WBGene00004503	rpt-3		F23F12.6	gene	taxon:6239			
+WB	WBGene00004504	rpt-4		F23F1.8	gene	taxon:6239			
+WB	WBGene00004505	rpt-5		F56H1.4	gene	taxon:6239			
+WB	WBGene00004506	rpt-6		Y49E10.1	gene	taxon:6239			
+WB	WBGene00004507	rpy-1		C18H9.7|rap-1	gene	taxon:6239			
+WB	WBGene00004508	rrf-1		F26A3.8	gene	taxon:6239			
+WB	WBGene00004509	rrf-2		M01G12.12	gene	taxon:6239			
+WB	WBGene00004510	rrf-3		F10B5.7|fer-15	gene	taxon:6239			
+WB	WBGene00004679	rars-1		F26F4.10|rrt-1	gene	taxon:6239			
+WB	WBGene00004680	rars-2		C29H12.1|rrt-2	gene	taxon:6239			
+WB	WBGene00004681	rsd-2		F52G2.2	gene	taxon:6239			
+WB	WBGene00004684	rsd-6		F16D3.2	gene	taxon:6239			
+WB	WBGene00004698	rsp-1		W02B12.3|CeSRp75|srp-5	gene	taxon:6239			
+WB	WBGene00004699	rsp-2		W02B12.2|CeSRp40|srp-4	gene	taxon:6239			
+WB	WBGene00004700	rsp-3		Y111B2A.18|CeSF2|CeSF2\/ASF|Y111B2G.i	gene	taxon:6239			
+WB	WBGene00004701	rsp-4		EEED8.7|CeSC35|srp-2	gene	taxon:6239			
+WB	WBGene00004702	rsp-5		T28D9.2|CeSC35-2|srp-3	gene	taxon:6239			
+WB	WBGene00004703	rsp-6		C33H5.12|CeSRp20|srp-1	gene	taxon:6239			
+WB	WBGene00004704	rsp-7		D2089.1	gene	taxon:6239			
+WB	WBGene00004705	rsp-8		C18D11.4	gene	taxon:6239			
+WB	WBGene00004706	rsr-1		F28D9.1|CeSRm160	gene	taxon:6239			
+WB	WBGene00004719	sad-1		F15A2.6	gene	taxon:6239			
+WB	WBGene00004721	san-1		ZC328.4|mad-3|mdf-3	gene	taxon:6239			
+WB	WBGene00004723	sap-49		C08B11.5	gene	taxon:6239			
+WB	WBGene00004726	sas-4		F10E9.8|dcd-1	gene	taxon:6239			
+WB	WBGene00004727	sax-1		R11G1.4	gene	taxon:6239			
+WB	WBGene00004728	sax-2		F21H11.2	gene	taxon:6239			
+WB	WBGene00004729	sax-3		ZK377.2	gene	taxon:6239			
+WB	WBGene00004732	sax-7		C18F3.2|lad-1	gene	taxon:6239			
+WB	WBGene00004735	sbp-1		Y47D3B.7|hlh-20|lpd-1|SREBP	gene	taxon:6239			
+WB	WBGene00004736	sca-1		K11D9.2|mca-4|ser-1	gene	taxon:6239			
+WB	WBGene00004737	scc-1		F10G7.4|coh-2|rad-21.1	gene	taxon:6239			
+WB	WBGene00004738	scc-3		F18E2.3	gene	taxon:6239			
+WB	WBGene00004740	scd-2		T10H9.2	gene	taxon:6239			
+WB	WBGene00004742	scl-1		F49E11.9	gene	taxon:6239			
+WB	WBGene00004743	scm-1		M01D7.2	gene	taxon:6239			
+WB	WBGene00004744	scp-1		D2013.8	gene	taxon:6239			
+WB	WBGene00004745	sdc-1		F52E10.1|egl-16	gene	taxon:6239			
+WB	WBGene00004746	sdc-2		C35C5.1	gene	taxon:6239			
+WB	WBGene00004747	sdc-3		C25D7.3|dpy-29	gene	taxon:6239			
+WB	WBGene00004748	sdf-9		Y44A6D.4|eak-5	gene	taxon:6239			
+WB	WBGene00004749	sdn-1		F57C7.3	gene	taxon:6239			
+WB	WBGene00004750	sea-1		F19B10.9|Ce-tbx-18|tbx-18	gene	taxon:6239			
+WB	WBGene00004751	sea-2		K10G6.3|pqn-50	gene	taxon:6239			
+WB	WBGene00004752	sec-5		T23G7.4	gene	taxon:6239			
+WB	WBGene00004753	sec-8		Y106G6H.7	gene	taxon:6239			
+WB	WBGene00004754	sec-23		Y113G7A.3|Y113G7A.n	gene	taxon:6239			
+WB	WBGene00004755	sec-24.1		F12F6.6	gene	taxon:6239			
+WB	WBGene00004756	sec-24.2		ZC518.2	gene	taxon:6239			
+WB	WBGene00004758	sek-1		R03G5.2|esp-2	gene	taxon:6239			
+WB	WBGene00004759	sel-1		F45D3.5|sup-25	gene	taxon:6239			
+WB	WBGene00004760	sel-2		F10F2.1	gene	taxon:6239			
+WB	WBGene00004762	sel-5		F35G12.3	gene	taxon:6239			
+WB	WBGene00004764	sel-7		K04G11.2	gene	taxon:6239			
+WB	WBGene00004765	sel-8		C32A3.1|lag-3|pqn-17	gene	taxon:6239			
+WB	WBGene00004766	sel-9		W02D7.7|tmed-2	gene	taxon:6239			
+WB	WBGene00004767	sel-10		F55B12.3|egl-41	gene	taxon:6239			
+WB	WBGene00004768	sel-11		F55A11.3|hrd-1	gene	taxon:6239			
+WB	WBGene00004769	sel-12		F35H12.3|sum-1	gene	taxon:6239			
+WB	WBGene00004771	sem-2		C32E12.5|sox-1	gene	taxon:6239			
+WB	WBGene00004773	sem-4		F15C11.1	gene	taxon:6239			
+WB	WBGene00004774	sem-5		C14F5.5	gene	taxon:6239			
+WB	WBGene00004775	sep-1		Y47G6A.12|let-365|stu-4	gene	taxon:6239			
+WB	WBGene00004776	ser-1		F59C12.2|5-HT2CeL|5-HT2CeS	gene	taxon:6239			
+WB	WBGene00004777	ser-2		C02D4.2	gene	taxon:6239			
+WB	WBGene00004778	ser-3		K02F2.6|K02F2.b	gene	taxon:6239			
+WB	WBGene00004779	ser-4		Y22D7AR.13|5HT-Ce|cer-1	gene	taxon:6239			
+WB	WBGene00004780	ser-7		C09B7.1	gene	taxon:6239			
+WB	WBGene00004781	set-1		T26A5.7	gene	taxon:6239			
+WB	WBGene00004782	set-2		C26E6.9	gene	taxon:6239			
+WB	WBGene00004783	seu-1		Y73B6BL.5	gene	taxon:6239			
+WB	WBGene00004784	seu-2			gene	taxon:6239			
+WB	WBGene00004785	seu-3			gene	taxon:6239			
+WB	WBGene00004786	sex-1		F44A6.2|cnr14|nhr-24	gene	taxon:6239			
+WB	WBGene00004787	sft-1		H06I04.2|Surf-1	gene	taxon:6239			
+WB	WBGene00004788	sft-4		C54H2.5|SURF-4	gene	taxon:6239			
+WB	WBGene00004789	sgk-1		W10G6.2|tag-74	gene	taxon:6239			
+WB	WBGene00004790	sgn-1		F07H5.2	gene	taxon:6239			
+WB	WBGene00004793	shw-3		R186.5|kht-1	gene	taxon:6239			
+WB	WBGene00004795	sid-1		C04F5.1|rde-7|rsd-8	gene	taxon:6239			
+WB	WBGene00004796	sid-2		ZK520.2	gene	taxon:6239			
+WB	WBGene00004798	sip-1		F43D9.4|sec-1|SIP\/1	gene	taxon:6239			
+WB	WBGene00004800	sir-2.1		R11A8.4	gene	taxon:6239			
+WB	WBGene00004801	sir-2.2		F46G10.7	gene	taxon:6239			
+WB	WBGene00004802	sir-2.3		F46G10.3	gene	taxon:6239			
+WB	WBGene00004803	sir-2.4		C06A5.11	gene	taxon:6239			
+WB	WBGene00004804	skn-1		T19E7.2|skinhead 1|sow-1|xrep-3	gene	taxon:6239			
+WB	WBGene00004806	skp-1		T27F2.1	gene	taxon:6239			
+WB	WBGene00004807	skr-1		F46A9.5	gene	taxon:6239			
+WB	WBGene00004808	skr-2		F46A9.4	gene	taxon:6239			
+WB	WBGene00004809	skr-3		F44G3.6	gene	taxon:6239			
+WB	WBGene00004810	skr-4		Y60A3A.18	gene	taxon:6239			
+WB	WBGene00004811	skr-5		F47H4.10	gene	taxon:6239			
+WB	WBGene00004812	skr-6		Y37H2C.2	gene	taxon:6239			
+WB	WBGene00004813	skr-7		Y47D7A.1	gene	taxon:6239			
+WB	WBGene00004814	skr-8		C52D10.9	gene	taxon:6239			
+WB	WBGene00004815	skr-9		C52D10.7	gene	taxon:6239			
+WB	WBGene00004816	skr-10		Y105C5B.13	gene	taxon:6239			
+WB	WBGene00004818	skr-12		C52D10.6	gene	taxon:6239			
+WB	WBGene00004819	skr-13		C52D10.8	gene	taxon:6239			
+WB	WBGene00004820	skr-14		Y47D7A.8|Y47D7A.g	gene	taxon:6239			
+WB	WBGene00004821	skr-15		F54D10.1	gene	taxon:6239			
+WB	WBGene00004822	skr-16		C42D4.6	gene	taxon:6239			
+WB	WBGene00004823	skr-17		C06A8.4	gene	taxon:6239			
+WB	WBGene00004824	F56B3.4			gene	taxon:6239			
+WB	WBGene00004825	skr-19		R12H7.3	gene	taxon:6239			
+WB	WBGene00004826	skr-20		R12H7.5	gene	taxon:6239			
+WB	WBGene00004827	skr-21		K08H2.1	gene	taxon:6239			
+WB	WBGene00004828	sle-1		|slo-1	gene	taxon:6239			
+WB	WBGene00004829	sli-1		M02A10.3	gene	taxon:6239			
+WB	WBGene00004830	slo-1		Y51A2D.19|nsy-3	gene	taxon:6239			
+WB	WBGene00004831	slo-2		F08B12.3	gene	taxon:6239			
+WB	WBGene00004854	slt-1		F40E10.4	gene	taxon:6239			
+WB	WBGene00004855	sma-1		R31.1|sma-7|sma1	gene	taxon:6239			
+WB	WBGene00004856	sma-2		ZK370.2|cem-1	gene	taxon:6239			
+WB	WBGene00004857	sma-3		R13F6.9	gene	taxon:6239			
+WB	WBGene00004858	sma-4		R12B2.1	gene	taxon:6239			
+WB	WBGene00004859	sma-5		W06B3.2	gene	taxon:6239			
+WB	WBGene00004860	sma-6		C32D5.2	gene	taxon:6239			
+WB	WBGene00004862	sma-9		T05A10.1	gene	taxon:6239			
+WB	WBGene00004864	sma-12			gene	taxon:6239			
+WB	WBGene00004865	sma-13			gene	taxon:6239			
+WB	WBGene00004866	sma-14			gene	taxon:6239			
+WB	WBGene00004868	sma-16			gene	taxon:6239			
+WB	WBGene00004869	sma-17			gene	taxon:6239			
+WB	WBGene00004870	sma-18			gene	taxon:6239			
+WB	WBGene00004871	sma-19			gene	taxon:6239			
+WB	WBGene00004872	sma-20			gene	taxon:6239			
+WB	WBGene00004873	smc-3		Y47D3A.26|Y47D3A	gene	taxon:6239			
+WB	WBGene00004874	smc-4		F35G12.8	gene	taxon:6239			
+WB	WBGene00004875	smd-1		F47G4.7|samdc	gene	taxon:6239			
+WB	WBGene00004876	smf-1		K11G12.4	gene	taxon:6239			
+WB	WBGene00004877	smf-2		K11G12.3	gene	taxon:6239			
+WB	WBGene00004878	smf-3		Y69A2AR.4	gene	taxon:6239			
+WB	WBGene00004879	smg-1		C48B6.6|mab-1	gene	taxon:6239			
+WB	WBGene00004880	smg-2		Y48G8AL.6|mab-11|Y48G8A_3304.a	gene	taxon:6239			
+WB	WBGene00004881	smg-3		Y73B6BL.18|mab-13	gene	taxon:6239			
+WB	WBGene00004882	smg-4		F46B6.3|mab-14	gene	taxon:6239			
+WB	WBGene00004883	smg-5		W02D3.8|mab-15	gene	taxon:6239			
+WB	WBGene00004884	smg-6		Y54F10AL.2|est-1|mab-16|NM_065164|NM_065165|NM_001047420|spr-8|Y54F10AL.a	gene	taxon:6239			
+WB	WBGene00004885	smg-7		Y73B6A.4	gene	taxon:6239			
+WB	WBGene00004886	smi-1		Y39A3CR.1	gene	taxon:6239			
+WB	WBGene00004887	smn-1		C41G7.1|SMN	gene	taxon:6239			
+WB	WBGene00004888	smo-1		K12C11.2|K12C11.f|SMT3	gene	taxon:6239			
+WB	WBGene00004889	smp-1		Y54E5B.1|cesema	gene	taxon:6239			
+WB	WBGene00004890	smp-2		D1037.2	gene	taxon:6239			
+WB	WBGene00004892	sms-1		H21P03.3	gene	taxon:6239			
+WB	WBGene00004893	sms-2		F53H8.4	gene	taxon:6239			
+WB	WBGene00004894	sms-3		Y22D7AL.8	gene	taxon:6239			
+WB	WBGene00004895	smu-1		CC4.3	gene	taxon:6239			
+WB	WBGene00004896	smu-2		Y49F6B.4	gene	taxon:6239			
+WB	WBGene00004897	snb-1		T10H9.4|sup-8|VAMP\/1	gene	taxon:6239			
+WB	WBGene00004898	snb-2		F23H12.1	gene	taxon:6239			
+WB	WBGene00004899	snb-5		C30A5.5	gene	taxon:6239			
+WB	WBGene00004900	snf-1		W03G9.1	gene	taxon:6239			
+WB	WBGene00004901	snf-2		F55H12.1	gene	taxon:6239			
+WB	WBGene00004902	snf-3		T13B5.1	gene	taxon:6239			
+WB	WBGene00004904	snf-5		Y46G5A.30	gene	taxon:6239			
+WB	WBGene00004905	snf-6		M01G5.5	gene	taxon:6239			
+WB	WBGene00004906	snf-7		ZK1010.9	gene	taxon:6239			
+WB	WBGene00004908	snf-9		C49C3.1	gene	taxon:6239			
+WB	WBGene00004909	snf-10		Y32F6A.2	gene	taxon:6239			
+WB	WBGene00004910	snf-11		T03F7.1|gat-1	gene	taxon:6239			
+WB	WBGene00004911	snf-12		T25B6.7|nipi-2	gene	taxon:6239			
+WB	WBGene00004912	sng-1		T08A9.3|sng1	gene	taxon:6239			
+WB	WBGene00004913	snn-1		Y38C1BA.2|syn	gene	taxon:6239			
+WB	WBGene00004914	snr-1		Y116A8C.42	gene	taxon:6239			
+WB	WBGene00004915	snr-2		W08E3.1	gene	taxon:6239			
+WB	WBGene00004916	snr-3		T28D9.10	gene	taxon:6239			
+WB	WBGene00004917	snr-4		C52E4.3	gene	taxon:6239			
+WB	WBGene00004918	snr-5		ZK652.1	gene	taxon:6239			
+WB	WBGene00004919	snr-6		Y49E10.15	gene	taxon:6239			
+WB	WBGene00004920	snr-7		Y71F9B.4|1D295	gene	taxon:6239			
+WB	WBGene00004921	snt-1		F31E8.2|ric-2|syt-1|syt1|unc-121	gene	taxon:6239			
+WB	WBGene00004922	snt-2		F42G9.7	gene	taxon:6239			
+WB	WBGene00004923	snt-3		Y75B7AL.3	gene	taxon:6239			
+WB	WBGene00004924	snt-4		T23H2.2	gene	taxon:6239			
+WB	WBGene00004925	snt-5		R12A1.2	gene	taxon:6239			
+WB	WBGene00004926	snt-6		C08G5.4	gene	taxon:6239			
+WB	WBGene00004927	snx-1		C05D9.1|vps-5	gene	taxon:6239			
+WB	WBGene00004928	soc-1		F41F3.2	gene	taxon:6239			
+WB	WBGene00004929	soc-2		AC7.2|sur-8	gene	taxon:6239			
+WB	WBGene00004930	sod-1		C15F1.7	gene	taxon:6239			
+WB	WBGene00004931	sod-2		F10D11.1|sdm-1	gene	taxon:6239			
+WB	WBGene00004932	sod-3		C08A9.1|MnSOD	gene	taxon:6239			
+WB	WBGene00004933	sod-4		F55H2.1|SOD4-1	gene	taxon:6239			
+WB	WBGene00004935	sog-2			gene	taxon:6239			
+WB	WBGene00004936	sog-3			gene	taxon:6239			
+WB	WBGene00004937	sog-4			gene	taxon:6239			
+WB	WBGene00004938	sog-5			gene	taxon:6239			
+WB	WBGene00004939	sog-6			gene	taxon:6239			
+WB	WBGene00004943	sog-10			gene	taxon:6239			
+WB	WBGene00004944	sol-1		C15A11.3	gene	taxon:6239			
+WB	WBGene00004945	sop-2		C50E10.4	gene	taxon:6239			
+WB	WBGene00004946	sop-3		Y71F9B.10|mdt-1.1	gene	taxon:6239			
+WB	WBGene00004947	sos-1		T28F12.3|let-341|Y61A9LA.g	gene	taxon:6239			
+WB	WBGene00004949	sox-2		K08A8.2	gene	taxon:6239			
+WB	WBGene00004950	sox-3		F40E10.2	gene	taxon:6239			
+WB	WBGene00004951	spc-1		K10B3.10|imo-1	gene	taxon:6239			
+WB	WBGene00004952	spd-1		Y34D9A.4|Y34D9A.d|Y34D9A.e|Y34D9A.h|Y34D9A.i	gene	taxon:6239			
+WB	WBGene00004953	spd-2		F32H2.3	gene	taxon:6239			
+WB	WBGene00004954	spd-3		H34C03.1	gene	taxon:6239			
+WB	WBGene00004955	spd-5		F56A3.4	gene	taxon:6239			
+WB	WBGene00004958	spe-4		ZK524.1	gene	taxon:6239			
+WB	WBGene00004959	spe-5		Y110A7A.12|tag-300	gene	taxon:6239			
+WB	WBGene00004960	spe-6		Y66D12A.20	gene	taxon:6239			
+WB	WBGene00004961	spe-7			gene	taxon:6239			
+WB	WBGene00004962	spe-8		F53G12.6	gene	taxon:6239			
+WB	WBGene00004963	spe-9		C17D12.6	gene	taxon:6239			
+WB	WBGene00004964	spe-10		AC3.10	gene	taxon:6239			
+WB	WBGene00004965	spe-11		F48C1.7	gene	taxon:6239			
+WB	WBGene00004966	spe-12		T02E1.1	gene	taxon:6239			
+WB	WBGene00004967	spe-13			gene	taxon:6239			
+WB	WBGene00004969	spe-15		F47G6.4|hum-3	gene	taxon:6239			
+WB	WBGene00004971	spe-17		ZK617.3	gene	taxon:6239			
+WB	WBGene00004972	spe-26		R10H10.2	gene	taxon:6239			
+WB	WBGene00004973	spe-27		C06E7.6	gene	taxon:6239			
+WB	WBGene00004974	spe-29		F25H8.7	gene	taxon:6239			
+WB	WBGene00004975	spe-39		ZC404.3	gene	taxon:6239			
+WB	WBGene00004976	spe-41		K01A11.4|strpc3|trp-3	gene	taxon:6239			
+WB	WBGene00004978	spg-7		Y47G6A.10|let-517|phi-23|Y47G6A_247.g	gene	taxon:6239			
+WB	WBGene00004979	sph-1		F42G8.11	gene	taxon:6239			
+WB	WBGene00004980	spk-1		B0464.5|rsk-1|srk-1	gene	taxon:6239			
+WB	WBGene00004981	spl-1		Y66H1B.4|spl	gene	taxon:6239			
+WB	WBGene00004984	spn-4		ZC404.8|gei-20|pip-1	gene	taxon:6239			
+WB	WBGene00004985	spo-11		T05E11.4	gene	taxon:6239			
+WB	WBGene00004986	spp-1		T07C4.4	gene	taxon:6239			
+WB	WBGene00004987	spp-2		T08A9.12	gene	taxon:6239			
+WB	WBGene00004988	spp-3		T08A9.7	gene	taxon:6239			
+WB	WBGene00004990	spp-5		T08A9.9	gene	taxon:6239			
+WB	WBGene00004995	spp-10		C28C12.7	gene	taxon:6239			
+WB	WBGene00004997	spp-12		T22G5.7|dod-5	gene	taxon:6239			
+WB	WBGene00005003	spp-18		F27C8.4	gene	taxon:6239			
+WB	WBGene00005004	spp-19		K04A8.9	gene	taxon:6239			
+WB	WBGene00005006	spr-1		D1014.8|slr-10	gene	taxon:6239			
+WB	WBGene00005007	spr-2		C27B7.1	gene	taxon:6239			
+WB	WBGene00005008	spr-3		C07A12.5	gene	taxon:6239			
+WB	WBGene00005009	spr-4		C09H6.1	gene	taxon:6239			
+WB	WBGene00005010	spr-5		Y40B1B.6	gene	taxon:6239			
+WB	WBGene00005013	jmjd-1.1		F43G6.6	gene	taxon:6239			
+WB	WBGene00005014	spt-4		F54C4.2	gene	taxon:6239			
+WB	WBGene00005015	spt-5		K08E4.1	gene	taxon:6239			
+WB	WBGene00005016	sqt-1		B0491.2|Rol|rol-5	gene	taxon:6239			
+WB	WBGene00005017	sqt-2		C01B12.1|col-67|Rol	gene	taxon:6239			
+WB	WBGene00005018	sqt-3		F23H12.4|col-1|dpy-15|Rol|rol-4	gene	taxon:6239			
+WB	WBGene00005019	sqv-1		D2096.4	gene	taxon:6239			
+WB	WBGene00005020	sqv-2		Y110A2AL.14	gene	taxon:6239			
+WB	WBGene00005021	sqv-3		R10E11.4|svh-10	gene	taxon:6239			
+WB	WBGene00005022	sqv-4		F29F11.1	gene	taxon:6239			
+WB	WBGene00005023	sqv-5		T24D1.1|ChSy-S	gene	taxon:6239			
+WB	WBGene00005024	sqv-6		Y50D4C.4|sqv6	gene	taxon:6239			
+WB	WBGene00005025	sqv-7		C52E12.3	gene	taxon:6239			
+WB	WBGene00005026	sqv-8		ZK1307.5|spe-2	gene	taxon:6239			
+WB	WBGene00005027	sra-1		AH6.4	gene	taxon:6239			
+WB	WBGene00005028	sra-2		AH6.6	gene	taxon:6239			
+WB	WBGene00005029	sra-3		AH6.7	gene	taxon:6239			
+WB	WBGene00005030	sra-4		AH6.8	gene	taxon:6239			
+WB	WBGene00005032	sra-6		AH6.10	gene	taxon:6239			
+WB	WBGene00005033	sra-7		AH6.11	gene	taxon:6239			
+WB	WBGene00005034	sra-8		AH6.12	gene	taxon:6239			
+WB	WBGene00005035	sra-9		AH6.14	gene	taxon:6239			
+WB	WBGene00005036	sra-10		F44F4.5	gene	taxon:6239			
+WB	WBGene00005037	sra-11		F44F4.13	gene	taxon:6239			
+WB	WBGene00005038	sra-12		F44F4.7	gene	taxon:6239			
+WB	WBGene00005039	sra-13		F49E12.5	gene	taxon:6239			
+WB	WBGene00005040	sra-14		F35C5.2	gene	taxon:6239			
+WB	WBGene00005043	sra-17		F28C12.1	gene	taxon:6239			
+WB	WBGene00005044	sra-18		F28C12.2	gene	taxon:6239			
+WB	WBGene00005046	sra-20		F28C12.4	gene	taxon:6239			
+WB	WBGene00005047	sra-21		F28C12.5	gene	taxon:6239			
+WB	WBGene00005048	sra-22		F28C12.7	gene	taxon:6239			
+WB	WBGene00005049	sra-23		T06G6.1	gene	taxon:6239			
+WB	WBGene00005050	sra-24		T06G6.2	gene	taxon:6239			
+WB	WBGene00005051	sra-25		T26E3.9	gene	taxon:6239			
+WB	WBGene00005052	sra-26		T19D12.8	gene	taxon:6239			
+WB	WBGene00005053	sra-27		F18C5.1	gene	taxon:6239			
+WB	WBGene00005054	sra-28		F18C5.6	gene	taxon:6239			
+WB	WBGene00005055	sra-29		F18C5.8	gene	taxon:6239			
+WB	WBGene00005056	sra-30		Y40H7A.6	gene	taxon:6239			
+WB	WBGene00005057	sra-31		C56C10.5	gene	taxon:6239			
+WB	WBGene00005058	sra-32		B0304.5	gene	taxon:6239			
+WB	WBGene00005059	sra-33		B0304.6	gene	taxon:6239			
+WB	WBGene00005060	sra-34		B0304.7	gene	taxon:6239			
+WB	WBGene00005061	sra-35		B0304.8	gene	taxon:6239			
+WB	WBGene00005062	sra-36		B0304.9	gene	taxon:6239			
+WB	WBGene00005063	sra-37		T21H8.2	gene	taxon:6239			
+WB	WBGene00005064	sra-38		T21H8.3	gene	taxon:6239			
+WB	WBGene00005065	sra-39		T21H8.4	gene	taxon:6239			
+WB	WBGene00005066	srb-1		C27D6.10	gene	taxon:6239			
+WB	WBGene00005068	srb-3		C27D6.8	gene	taxon:6239			
+WB	WBGene00005070	srb-5		C27D6.6	gene	taxon:6239			
+WB	WBGene00005071	srb-6		R05H5.6	gene	taxon:6239			
+WB	WBGene00005076	srb-11		F23F12.10	gene	taxon:6239			
+WB	WBGene00005077	src-1		Y92H12A.1	gene	taxon:6239			
+WB	WBGene00005078	src-2		F49B2.5|kin-22	gene	taxon:6239			
+WB	WBGene00005079	srd-1		F33H1.5	gene	taxon:6239			
+WB	WBGene00005080	srd-2		R05H5.1	gene	taxon:6239			
+WB	WBGene00005081	srd-3		K10B4.5	gene	taxon:6239			
+WB	WBGene00005082	srd-4		ZK863.5	gene	taxon:6239			
+WB	WBGene00005083	srd-5		T19E7.5	gene	taxon:6239			
+WB	WBGene00005085	srd-7		C06G8.4	gene	taxon:6239			
+WB	WBGene00005086	srd-8		B0547.4	gene	taxon:6239			
+WB	WBGene00005087	srd-9		T09D3.1	gene	taxon:6239			
+WB	WBGene00005088	srd-10		Y45F10B.14	gene	taxon:6239			
+WB	WBGene00005089	srd-11		F53F4.9	gene	taxon:6239			
+WB	WBGene00005090	srd-12		C39H7.6	gene	taxon:6239			
+WB	WBGene00005091	srd-13		C39H7.7	gene	taxon:6239			
+WB	WBGene00005093	srd-15		C04E6.10	gene	taxon:6239			
+WB	WBGene00005094	srd-16		C04E6.9	gene	taxon:6239			
+WB	WBGene00005095	srd-17		Y2H9A.2	gene	taxon:6239			
+WB	WBGene00005096	srd-18		F53F1.10	gene	taxon:6239			
+WB	WBGene00005097	srd-19		F53F1.11	gene	taxon:6239			
+WB	WBGene00005098	srd-20		Y38A10A.1	gene	taxon:6239			
+WB	WBGene00005099	srd-21		W06G6.3	gene	taxon:6239			
+WB	WBGene00005101	srd-23		Y40H7A.5	gene	taxon:6239			
+WB	WBGene00005103	srd-25		F07C4.4	gene	taxon:6239			
+WB	WBGene00005104	srd-26		T02B5.4	gene	taxon:6239			
+WB	WBGene00005105	srd-27		T26E4.12	gene	taxon:6239			
+WB	WBGene00005106	srd-28		M01B2.2	gene	taxon:6239			
+WB	WBGene00005107	srd-29		F07C4.3	gene	taxon:6239			
+WB	WBGene00005108	srd-30		F07C4.5	gene	taxon:6239			
+WB	WBGene00005109	srd-31		F07C4.8	gene	taxon:6239			
+WB	WBGene00005110	srd-32		T19H12.5	gene	taxon:6239			
+WB	WBGene00005111	srd-33		T19H12.4	gene	taxon:6239			
+WB	WBGene00005112	srd-34		F32G8.1	gene	taxon:6239			
+WB	WBGene00005113	srd-35		R186.2	gene	taxon:6239			
+WB	WBGene00005114	srd-36		R04D3.6	gene	taxon:6239			
+WB	WBGene00005116	srd-38		R04D3.12	gene	taxon:6239			
+WB	WBGene00005117	srd-39		R04D3.8	gene	taxon:6239			
+WB	WBGene00005118	srd-40		F17A2.12	gene	taxon:6239			
+WB	WBGene00005119	srd-41		F17A2.6	gene	taxon:6239			
+WB	WBGene00005120	srd-42		R04D3.7	gene	taxon:6239			
+WB	WBGene00005121	srd-43		R04D3.9	gene	taxon:6239			
+WB	WBGene00005122	srd-44		F17A2.8	gene	taxon:6239			
+WB	WBGene00005123	srd-45		F17A2.7	gene	taxon:6239			
+WB	WBGene00005124	srd-46		F17A2.10	gene	taxon:6239			
+WB	WBGene00005125	srd-47		F17A2.11	gene	taxon:6239			
+WB	WBGene00005126	srd-48		F17A2.9	gene	taxon:6239			
+WB	WBGene00005127	srd-49		R04B5.8	gene	taxon:6239			
+WB	WBGene00005128	srd-50		F15A2.4	gene	taxon:6239			
+WB	WBGene00005129	srd-51		F15A2.3	gene	taxon:6239			
+WB	WBGene00005131	srd-53		F13G3.2	gene	taxon:6239			
+WB	WBGene00005132	srd-54		K02A2.7	gene	taxon:6239			
+WB	WBGene00005133	srd-55		K02A2.2	gene	taxon:6239			
+WB	WBGene00005134	srd-56		E04F6.14	gene	taxon:6239			
+WB	WBGene00005135	srd-58		E04F6.13	gene	taxon:6239			
+WB	WBGene00005136	srd-59		E04F6.1	gene	taxon:6239			
+WB	WBGene00005137	srd-60		C13B7.3	gene	taxon:6239			
+WB	WBGene00005138	srd-61		C01B4.5	gene	taxon:6239			
+WB	WBGene00005140	srd-63		F13A7.2	gene	taxon:6239			
+WB	WBGene00005141	srd-64		Y22D7AR.8	gene	taxon:6239			
+WB	WBGene00005142	srd-65		C39B5.12	gene	taxon:6239			
+WB	WBGene00005143	srd-66		Y39A3B.4	gene	taxon:6239			
+WB	WBGene00005144	srd-67		C39B5.11	gene	taxon:6239			
+WB	WBGene00005145	srd-68		F09C6.7	gene	taxon:6239			
+WB	WBGene00005146	srd-69		H04J21.2	gene	taxon:6239			
+WB	WBGene00005147	srd-70		F48F5.4	gene	taxon:6239			
+WB	WBGene00005148	srd-71		C13B7.4	gene	taxon:6239			
+WB	WBGene00005149	sre-1		B0495.1	gene	taxon:6239			
+WB	WBGene00005150	sre-2		C41C4.2	gene	taxon:6239			
+WB	WBGene00005153	srf-3		M02B1.1	gene	taxon:6239			
+WB	WBGene00005159	srg-1		C18F10.4	gene	taxon:6239			
+WB	WBGene00005160	srg-2		C18F10.5	gene	taxon:6239			
+WB	WBGene00005161	srg-3		C18F10.6	gene	taxon:6239			
+WB	WBGene00005162	srg-4		T12A2.12	gene	taxon:6239			
+WB	WBGene00005163	srg-5		T12A2.11	gene	taxon:6239			
+WB	WBGene00005164	srg-6		T12A2.13	gene	taxon:6239			
+WB	WBGene00005165	srg-7		C18F10.8	gene	taxon:6239			
+WB	WBGene00005166	srg-8		T12A2.9	gene	taxon:6239			
+WB	WBGene00005167	srg-9		T12A2.10	gene	taxon:6239			
+WB	WBGene00005168	srg-10		T04A8.1	gene	taxon:6239			
+WB	WBGene00005169	srg-11		T04A8.2	gene	taxon:6239			
+WB	WBGene00005170	srg-13		T23F11.5	gene	taxon:6239			
+WB	WBGene00005171	srg-14		F26B1.6	gene	taxon:6239			
+WB	WBGene00005172	srg-15		C34C6.1	gene	taxon:6239			
+WB	WBGene00005173	srg-16		F15A4.4	gene	taxon:6239			
+WB	WBGene00005174	srg-17		F15A4.7	gene	taxon:6239			
+WB	WBGene00005177	srg-20		ZC204.4	gene	taxon:6239			
+WB	WBGene00005178	srg-21		Y25C1A.9	gene	taxon:6239			
+WB	WBGene00005179	srg-22		Y25C1A.10|Y25C1A.f	gene	taxon:6239			
+WB	WBGene00005180	srg-23		Y25C1A.11	gene	taxon:6239			
+WB	WBGene00005181	srg-24		Y25C1A.12	gene	taxon:6239			
+WB	WBGene00005182	srg-25		T09D3.5	gene	taxon:6239			
+WB	WBGene00005183	srg-26		C10G8.1	gene	taxon:6239			
+WB	WBGene00005184	srg-27		T09D3.7	gene	taxon:6239			
+WB	WBGene00005185	srg-28		T09D3.2	gene	taxon:6239			
+WB	WBGene00005186	srg-29		T09D3.6	gene	taxon:6239			
+WB	WBGene00005187	srg-30		W02F12.7	gene	taxon:6239			
+WB	WBGene00005188	srg-31		T07H8.5	gene	taxon:6239			
+WB	WBGene00005189	srg-32		T21C9.7	gene	taxon:6239			
+WB	WBGene00005190	srg-33		F21F8.1	gene	taxon:6239			
+WB	WBGene00005191	srg-34		Y51A2D.12	gene	taxon:6239			
+WB	WBGene00005193	srg-36		K04C1.6	gene	taxon:6239			
+WB	WBGene00005194	srg-37		K04C1.1	gene	taxon:6239			
+WB	WBGene00005195	srg-38		T19C4.8	gene	taxon:6239			
+WB	WBGene00005196	srg-39		T19C4.2	gene	taxon:6239			
+WB	WBGene00005197	srg-40		T19C4.4	gene	taxon:6239			
+WB	WBGene00005198	srg-41		T19C4.3	gene	taxon:6239			
+WB	WBGene00005199	srg-42		T19C4.9	gene	taxon:6239			
+WB	WBGene00005201	srg-44		F31E9.2	gene	taxon:6239			
+WB	WBGene00005202	srg-45		C51F7.2	gene	taxon:6239			
+WB	WBGene00005203	srg-46		F32H5.5	gene	taxon:6239			
+WB	WBGene00005204	srg-47		C53A5.8	gene	taxon:6239			
+WB	WBGene00005205	srg-48		Y43B11AR.5	gene	taxon:6239			
+WB	WBGene00005207	srg-50		Y43B11AR.2|Y43B11AR.d	gene	taxon:6239			
+WB	WBGene00005208	srg-51		Y40H7A.8	gene	taxon:6239			
+WB	WBGene00005210	srg-53		T02B11.1	gene	taxon:6239			
+WB	WBGene00005211	srg-54		W09D12.3	gene	taxon:6239			
+WB	WBGene00005212	srg-55		W09D12.2	gene	taxon:6239			
+WB	WBGene00005213	srg-56		C24B9.10	gene	taxon:6239			
+WB	WBGene00005214	srg-57		C24B9.14	gene	taxon:6239			
+WB	WBGene00005215	srg-58		R05D8.6	gene	taxon:6239			
+WB	WBGene00005216	srg-59		C24B9.7	gene	taxon:6239			
+WB	WBGene00005217	srg-60		C24B9.15	gene	taxon:6239			
+WB	WBGene00005218	srg-61		C24B9.11	gene	taxon:6239			
+WB	WBGene00005219	srg-62		C24B9.12	gene	taxon:6239			
+WB	WBGene00005221	srg-64		ZK678.6	gene	taxon:6239			
+WB	WBGene00005222	srg-65		T05C3.8	gene	taxon:6239			
+WB	WBGene00005223	srg-66		T05C3.7	gene	taxon:6239			
+WB	WBGene00005224	srg-67		ZC317.4	gene	taxon:6239			
+WB	WBGene00005225	srg-68		ZC317.5	gene	taxon:6239			
+WB	WBGene00005226	srg-69		F09E5.4	gene	taxon:6239			
+WB	WBGene00005227	srh-1		T11F9.18	gene	taxon:6239			
+WB	WBGene00005228	srh-2		C05E4.14	gene	taxon:6239			
+WB	WBGene00005229	srh-3		K04F1.5	gene	taxon:6239			
+WB	WBGene00005230	srh-4		K09D9.6	gene	taxon:6239			
+WB	WBGene00005231	srh-5		K04F1.16	gene	taxon:6239			
+WB	WBGene00005233	srh-7		K09D9.7	gene	taxon:6239			
+WB	WBGene00005234	srh-8		K09D9.8	gene	taxon:6239			
+WB	WBGene00005236	srh-10		Y38A10A.3	gene	taxon:6239			
+WB	WBGene00005237	srh-11		R09F10.6	gene	taxon:6239			
+WB	WBGene00005240	srh-15		C50B6.6	gene	taxon:6239			
+WB	WBGene00005241	srh-16		F55C5.9	gene	taxon:6239			
+WB	WBGene00005242	srh-17		C47E8.2	gene	taxon:6239			
+WB	WBGene00005243	srh-18		C50B6.5	gene	taxon:6239			
+WB	WBGene00005244	srh-19		F19G12.5	gene	taxon:6239			
+WB	WBGene00005245	srh-20		C02E7.3	gene	taxon:6239			
+WB	WBGene00005246	srh-21		C02E7.2	gene	taxon:6239			
+WB	WBGene00005247	srh-22		C02E7.4	gene	taxon:6239			
+WB	WBGene00005248	srh-23		C02E7.5	gene	taxon:6239			
+WB	WBGene00005249	srh-25		C54D10.6	gene	taxon:6239			
+WB	WBGene00005250	srh-27		W05H5.4	gene	taxon:6239			
+WB	WBGene00005251	srh-28		ZC404.5	gene	taxon:6239			
+WB	WBGene00005253	srh-30		ZC404.12	gene	taxon:6239			
+WB	WBGene00005254	srh-31		W06D12.7	gene	taxon:6239			
+WB	WBGene00005255	srh-32		Y26G10.2	gene	taxon:6239			
+WB	WBGene00005256	srh-33		M02H5.9|M02H5.b	gene	taxon:6239			
+WB	WBGene00005257	srh-34		M02H5.10	gene	taxon:6239			
+WB	WBGene00005258	srh-35		M02H5.11	gene	taxon:6239			
+WB	WBGene00005259	srh-36		T03D3.4	gene	taxon:6239			
+WB	WBGene00005260	srh-37		R11G11.9	gene	taxon:6239			
+WB	WBGene00005261	srh-38		C31B8.11	gene	taxon:6239			
+WB	WBGene00005262	srh-39		C06A8.7	gene	taxon:6239			
+WB	WBGene00005263	srh-40		Y40D12A.3	gene	taxon:6239			
+WB	WBGene00005264	srh-41		Y54G11A.12	gene	taxon:6239			
+WB	WBGene00005265	srh-42		Y54G11A.15	gene	taxon:6239			
+WB	WBGene00005267	srh-44		B0334.7	gene	taxon:6239			
+WB	WBGene00005268	srh-45		T03F7.2	gene	taxon:6239			
+WB	WBGene00005269	srh-46		T03F7.3	gene	taxon:6239			
+WB	WBGene00005270	srh-47		T03F7.4	gene	taxon:6239			
+WB	WBGene00005271	srh-48		C06C3.6	gene	taxon:6239			
+WB	WBGene00005272	srh-49		C10G11.4	gene	taxon:6239			
+WB	WBGene00005273	srh-50		C10G11.2	gene	taxon:6239			
+WB	WBGene00005274	srh-51		C10G11.3	gene	taxon:6239			
+WB	WBGene00005275	srh-52		R08H2.7	gene	taxon:6239			
+WB	WBGene00005278	srh-55		T09F5.5	gene	taxon:6239			
+WB	WBGene00005279	srh-56		R05D8.3	gene	taxon:6239			
+WB	WBGene00005280	srh-57		Y49F6A.2	gene	taxon:6239			
+WB	WBGene00005281	srh-59		W10G11.10	gene	taxon:6239			
+WB	WBGene00005282	srh-60		W10G11.9	gene	taxon:6239			
+WB	WBGene00005283	srh-61		T21B4.8	gene	taxon:6239			
+WB	WBGene00005284	srh-62		ZK6.9	gene	taxon:6239			
+WB	WBGene00005285	srh-63		T27E7.8	gene	taxon:6239			
+WB	WBGene00005288	srh-67		T21B4.6	gene	taxon:6239			
+WB	WBGene00005289	srh-68		T21B4.5	gene	taxon:6239			
+WB	WBGene00005290	srh-69		T21B4.7	gene	taxon:6239			
+WB	WBGene00005291	srh-70		T21B4.9	gene	taxon:6239			
+WB	WBGene00005292	srh-71		T10D4.5	gene	taxon:6239			
+WB	WBGene00005293	srh-72		ZC204.5	gene	taxon:6239			
+WB	WBGene00005294	srh-73		T21B4.14	gene	taxon:6239			
+WB	WBGene00005295	srh-74		C45B11.4	gene	taxon:6239			
+WB	WBGene00005296	srh-75		T04C12.2	gene	taxon:6239			
+WB	WBGene00005297	srh-76		F26F12.6	gene	taxon:6239			
+WB	WBGene00005299	srh-78		DC2.2	gene	taxon:6239			
+WB	WBGene00005300	srh-79		C04F2.1	gene	taxon:6239			
+WB	WBGene00005301	srh-80		DC2.1	gene	taxon:6239			
+WB	WBGene00005303	srh-82		W03F9.6	gene	taxon:6239			
+WB	WBGene00005304	srh-83		F09G2.7	gene	taxon:6239			
+WB	WBGene00005306	srh-85		C44C3.8	gene	taxon:6239			
+WB	WBGene00005308	srh-87		H27D07.6	gene	taxon:6239			
+WB	WBGene00005309	srh-88		C44C3.9	gene	taxon:6239			
+WB	WBGene00005310	srh-89		F25E5.14	gene	taxon:6239			
+WB	WBGene00005313	srh-92		F25E5.13	gene	taxon:6239			
+WB	WBGene00005315	srh-95		F21H7.11	gene	taxon:6239			
+WB	WBGene00005316	srh-97		F49H6.4	gene	taxon:6239			
+WB	WBGene00005317	srh-98		F21H7.14	gene	taxon:6239			
+WB	WBGene00005318	srh-99		C46E10.7	gene	taxon:6239			
+WB	WBGene00005319	srh-100		C46E10.10	gene	taxon:6239			
+WB	WBGene00005321	srh-102		F40D4.11	gene	taxon:6239			
+WB	WBGene00005323	srh-104		F21H7.7	gene	taxon:6239			
+WB	WBGene00005324	T27A1.1			gene	taxon:6239			
+WB	WBGene00005328	srh-109		T19C9.4	gene	taxon:6239			
+WB	WBGene00005330	srh-111		F08E10.6	gene	taxon:6239			
+WB	WBGene00005331	srh-112		T19C9.2	gene	taxon:6239			
+WB	WBGene00005332	srh-113		Y68A4A.7	gene	taxon:6239			
+WB	WBGene00005334	srh-115		Y61B8A.2	gene	taxon:6239			
+WB	WBGene00005335	srh-116		Y61B8A.1	gene	taxon:6239			
+WB	WBGene00005337	srh-118		K03D7.6	gene	taxon:6239			
+WB	WBGene00005338	srh-119		Y102A5C.21	gene	taxon:6239			
+WB	WBGene00005339	srh-120		T27C5.1	gene	taxon:6239			
+WB	WBGene00005340	srh-122		R08H2.5	gene	taxon:6239			
+WB	WBGene00005341	srh-123		F08E10.3	gene	taxon:6239			
+WB	WBGene00005342	srh-125		C18B10.8	gene	taxon:6239			
+WB	WBGene00005344	srh-127		F37B4.1	gene	taxon:6239			
+WB	WBGene00005345	srh-128		Y47G7B.1	gene	taxon:6239			
+WB	WBGene00005346	srh-129		F14F9.7	gene	taxon:6239			
+WB	WBGene00005347	srh-130		F14F9.1	gene	taxon:6239			
+WB	WBGene00005348	srh-131		Y102A5C.31	gene	taxon:6239			
+WB	WBGene00005349	srh-132		T27C5.5	gene	taxon:6239			
+WB	WBGene00005350	srh-133		Y59A8B.3|Y59A8B.n	gene	taxon:6239			
+WB	WBGene00005351	srh-134		Y59A8B.4	gene	taxon:6239			
+WB	WBGene00005352	srh-135		T01E8.7	gene	taxon:6239			
+WB	WBGene00005353	srh-136		F36D3.6	gene	taxon:6239			
+WB	WBGene00005354	srh-137		Y70C5C.4	gene	taxon:6239			
+WB	WBGene00005355	srh-138		T08G3.12	gene	taxon:6239			
+WB	WBGene00005356	srh-139		F57E7.3	gene	taxon:6239			
+WB	WBGene00005357	srh-140		Y6E2A.6	gene	taxon:6239			
+WB	WBGene00005358	srh-141		T08G3.5	gene	taxon:6239			
+WB	WBGene00005359	srh-142		T08G3.3	gene	taxon:6239			
+WB	WBGene00005361	srh-145		F26D2.4	gene	taxon:6239			
+WB	WBGene00005362	srh-146		C31B8.3	gene	taxon:6239			
+WB	WBGene00005363	srh-147		K08G2.12	gene	taxon:6239			
+WB	WBGene00005364	srh-148		K08G2.5	gene	taxon:6239			
+WB	WBGene00005365	srh-149		K08G2.13	gene	taxon:6239			
+WB	WBGene00005370	srh-154		F20E11.12	gene	taxon:6239			
+WB	WBGene00005375	srh-159		F40D4.3	gene	taxon:6239			
+WB	WBGene00005382	srh-166		Y38H6C.12	gene	taxon:6239			
+WB	WBGene00005383	srh-167		F57G8.3	gene	taxon:6239			
+WB	WBGene00005385	srh-169		C49G7.2	gene	taxon:6239			
+WB	WBGene00005386	srh-170		R08H2.3	gene	taxon:6239			
+WB	WBGene00005387	srh-171		Y60A3A.5	gene	taxon:6239			
+WB	WBGene00005388	srh-172		Y60A3A.6	gene	taxon:6239			
+WB	WBGene00005389	srh-173		Y60A3A.4	gene	taxon:6239			
+WB	WBGene00005390	srh-174		F40D4.1	gene	taxon:6239			
+WB	WBGene00005392	srh-177		K02E2.3	gene	taxon:6239			
+WB	WBGene00005393	srh-178		ZK228.8	gene	taxon:6239			
+WB	WBGene00005394	srh-179		ZK228.7	gene	taxon:6239			
+WB	WBGene00005395	srh-180		F57G8.1	gene	taxon:6239			
+WB	WBGene00005396	srh-181		ZK228.6	gene	taxon:6239			
+WB	WBGene00005397	srh-182		ZK228.5	gene	taxon:6239			
+WB	WBGene00005398	srh-183		Y60A3A.3	gene	taxon:6239			
+WB	WBGene00005399	srh-184		D1054.12	gene	taxon:6239			
+WB	WBGene00005400	srh-185		C50H11.7	gene	taxon:6239			
+WB	WBGene00005401	srh-186		F36G9.2	gene	taxon:6239			
+WB	WBGene00005402	srh-187		F10G2.8	gene	taxon:6239			
+WB	WBGene00005404	srh-190		C17E7.2	gene	taxon:6239			
+WB	WBGene00005405	srh-192		ZC132.7	gene	taxon:6239			
+WB	WBGene00005406	srh-193		F47D2.9	gene	taxon:6239			
+WB	WBGene00005407	srh-194		F47D2.10	gene	taxon:6239			
+WB	WBGene00005408	srh-195		R52.7	gene	taxon:6239			
+WB	WBGene00005410	srh-199		ZK697.11	gene	taxon:6239			
+WB	WBGene00005411	srh-200		F07C4.13	gene	taxon:6239			
+WB	WBGene00005412	srh-201		R03H4.9	gene	taxon:6239			
+WB	WBGene00005414	srh-203		F20E11.10	gene	taxon:6239			
+WB	WBGene00005415	srh-204		E03D2.3	gene	taxon:6239			
+WB	WBGene00005416	srh-206		Y102A5C.15	gene	taxon:6239			
+WB	WBGene00005417	srh-207		ZK262.1	gene	taxon:6239			
+WB	WBGene00005418	srh-208		C43D7.6	gene	taxon:6239			
+WB	WBGene00005419	srh-209		ZK262.11	gene	taxon:6239			
+WB	WBGene00005421	srh-211		D1065.5	gene	taxon:6239			
+WB	WBGene00005422	srh-212		T22F3.6	gene	taxon:6239			
+WB	WBGene00005423	srh-213		T22F3.5	gene	taxon:6239			
+WB	WBGene00005424	srh-214		T20B3.4	gene	taxon:6239			
+WB	WBGene00005425	srh-215		T20B3.3	gene	taxon:6239			
+WB	WBGene00005426	srh-216		T20B3.5	gene	taxon:6239			
+WB	WBGene00005427	srh-217		Y113G7B.2	gene	taxon:6239			
+WB	WBGene00005428	srh-218		C06B8.10	gene	taxon:6239			
+WB	WBGene00005429	srh-219		C06B8.6	gene	taxon:6239			
+WB	WBGene00005430	srh-220		F47C12.5	gene	taxon:6239			
+WB	WBGene00005432	srh-222		F47C12.10	gene	taxon:6239			
+WB	WBGene00005433	srh-223		F47C12.3	gene	taxon:6239			
+WB	WBGene00005435	srh-227		C35D6.2	gene	taxon:6239			
+WB	WBGene00005437	srh-229		C04F2.4	gene	taxon:6239			
+WB	WBGene00005439	srh-231		C03G6.11	gene	taxon:6239			
+WB	WBGene00005440	srh-233		Y113G7A.1	gene	taxon:6239			
+WB	WBGene00005441	srh-234		F07C4.14	gene	taxon:6239			
+WB	WBGene00005442	srh-235		F08E10.1	gene	taxon:6239			
+WB	WBGene00005443	srh-236		Y68A4A.9	gene	taxon:6239			
+WB	WBGene00005444	srh-237		T05E12.7	gene	taxon:6239			
+WB	WBGene00005446	srh-239		T26H5.3	gene	taxon:6239			
+WB	WBGene00005447	srh-240		F37B4.13	gene	taxon:6239			
+WB	WBGene00005448	srh-241		F37B4.6	gene	taxon:6239			
+WB	WBGene00005449	srh-243		F37B4.3	gene	taxon:6239			
+WB	WBGene00005450	srh-244		C03G6.9	gene	taxon:6239			
+WB	WBGene00005451	srh-245		F31F4.9	gene	taxon:6239			
+WB	WBGene00005452	srh-246		F31F4.18	gene	taxon:6239			
+WB	WBGene00005453	srh-247		C31B8.13	gene	taxon:6239			
+WB	WBGene00005454	srh-248		H05B21.2	gene	taxon:6239			
+WB	WBGene00005456	srh-250		C49D10.3	gene	taxon:6239			
+WB	WBGene00005457	srh-251		R08H2.4	gene	taxon:6239			
+WB	WBGene00005458	srh-252		T19C9.3	gene	taxon:6239			
+WB	WBGene00005461	srh-255		F28B1.8	gene	taxon:6239			
+WB	WBGene00005463	srh-257		T06E6.6	gene	taxon:6239			
+WB	WBGene00005464	srh-258		T06E6.7	gene	taxon:6239			
+WB	WBGene00005470	srh-264		T06E6.8	gene	taxon:6239			
+WB	WBGene00005471	srh-265		T06E6.9	gene	taxon:6239			
+WB	WBGene00005472	srh-266		F31F4.6	gene	taxon:6239			
+WB	WBGene00005474	srh-268		C54F6.1	gene	taxon:6239			
+WB	WBGene00005475	srh-269		T03E6.5	gene	taxon:6239			
+WB	WBGene00005476	srh-270		F37B4.5	gene	taxon:6239			
+WB	WBGene00005477	srh-271		W02H5.6|W02H5.c	gene	taxon:6239			
+WB	WBGene00005478	srh-272		F37B4.4	gene	taxon:6239			
+WB	WBGene00005479	srh-274		C32B5.2	gene	taxon:6239			
+WB	WBGene00005480	srh-275		C03G6.7	gene	taxon:6239			
+WB	WBGene00005481	srh-276		F21A3.1	gene	taxon:6239			
+WB	WBGene00005482	srh-277		K05D4.6	gene	taxon:6239			
+WB	WBGene00005484	srh-279		F11A5.2	gene	taxon:6239			
+WB	WBGene00005486	srh-281		F11A5.1	gene	taxon:6239			
+WB	WBGene00005487	srh-282		T21D12.5	gene	taxon:6239			
+WB	WBGene00005488	srh-283		C47A10.2	gene	taxon:6239			
+WB	WBGene00005489	srh-284		C47A10.3	gene	taxon:6239			
+WB	WBGene00005490	srh-286		Y59A8A.4	gene	taxon:6239			
+WB	WBGene00005491	srh-287		C47A10.9	gene	taxon:6239			
+WB	WBGene00005492	srh-288		C47A10.7	gene	taxon:6239			
+WB	WBGene00005493	srh-289		C47A10.10	gene	taxon:6239			
+WB	WBGene00005494	srh-290		C47A10.11	gene	taxon:6239			
+WB	WBGene00005495	srh-291		Y94A7B.3	gene	taxon:6239			
+WB	WBGene00005496	srh-292		Y94A7B.1	gene	taxon:6239			
+WB	WBGene00005497	srh-293		K08G2.8	gene	taxon:6239			
+WB	WBGene00005499	srh-295		ZK1037.8	gene	taxon:6239			
+WB	WBGene00005500	srh-296		Y94A7B.4	gene	taxon:6239			
+WB	WBGene00005501	srh-297		C17F4.4	gene	taxon:6239			
+WB	WBGene00005502	srh-298		Y94A7B.5	gene	taxon:6239			
+WB	WBGene00005503	srh-299		K08G2.9	gene	taxon:6239			
+WB	WBGene00005504	srh-300		Y94A7B.6	gene	taxon:6239			
+WB	WBGene00005505	srh-301		Y94A7B.8	gene	taxon:6239			
+WB	WBGene00005507	srh-303		Y94A7B.7	gene	taxon:6239			
+WB	WBGene00005508	srh-304		Y94A7B.9	gene	taxon:6239			
+WB	WBGene00005512	srh-105		T27A1.7	gene	taxon:6239			
+WB	WBGene00005513	sri-1		F36G9.8	gene	taxon:6239			
+WB	WBGene00005514	sri-2		F36G9.9	gene	taxon:6239			
+WB	WBGene00005516	sri-4		C05E4.4	gene	taxon:6239			
+WB	WBGene00005517	sri-5		F28D9.2	gene	taxon:6239			
+WB	WBGene00005518	sri-6		T09E8.5	gene	taxon:6239			
+WB	WBGene00005519	sri-7		T06E6.4	gene	taxon:6239			
+WB	WBGene00005521	sri-9		Y102A5C.29	gene	taxon:6239			
+WB	WBGene00005522	sri-10		C54E10.4	gene	taxon:6239			
+WB	WBGene00005523	sri-11		T22H2.3	gene	taxon:6239			
+WB	WBGene00005524	sri-12		T22H2.1	gene	taxon:6239			
+WB	WBGene00005525	sri-13		M01G12.13	gene	taxon:6239			
+WB	WBGene00005526	sri-14		M01G12.1	gene	taxon:6239			
+WB	WBGene00005527	sri-15		F15H9.2	gene	taxon:6239			
+WB	WBGene00005528	sri-16		F15H9.4	gene	taxon:6239			
+WB	WBGene00005529	sri-17		F15H9.3	gene	taxon:6239			
+WB	WBGene00005530	sri-18		Y22F5A.2	gene	taxon:6239			
+WB	WBGene00005531	sri-19		Y69E1A.6	gene	taxon:6239			
+WB	WBGene00005532	sri-20		AC3.1	gene	taxon:6239			
+WB	WBGene00005533	sri-21		T24A6.4	gene	taxon:6239			
+WB	WBGene00005536	sri-24		C41G6.11	gene	taxon:6239			
+WB	WBGene00005537	sri-25		C41G6.10	gene	taxon:6239			
+WB	WBGene00005538	sri-26		C41G6.14	gene	taxon:6239			
+WB	WBGene00005539	sri-27		ZK697.4	gene	taxon:6239			
+WB	WBGene00005540	sri-28		B0454.3	gene	taxon:6239			
+WB	WBGene00005541	sri-29		B0454.4	gene	taxon:6239			
+WB	WBGene00005542	sri-30		B0454.10	gene	taxon:6239			
+WB	WBGene00005543	sri-31		B0454.2	gene	taxon:6239			
+WB	WBGene00005544	sri-32		T10D4.12	gene	taxon:6239			
+WB	WBGene00005545	sri-33		Y27F2A.4|Y27F2A.g	gene	taxon:6239			
+WB	WBGene00005546	sri-34		Y27F2A.7	gene	taxon:6239			
+WB	WBGene00005548	sri-36		F33H12.5	gene	taxon:6239			
+WB	WBGene00005549	sri-37		D2062.2	gene	taxon:6239			
+WB	WBGene00005550	sri-38		D2062.8	gene	taxon:6239			
+WB	WBGene00005551	sri-39		F33H12.2	gene	taxon:6239			
+WB	WBGene00005552	sri-40		Y27F2A.3|Y27F2A.h	gene	taxon:6239			
+WB	WBGene00005554	sri-42		T10D4.9	gene	taxon:6239			
+WB	WBGene00005555	sri-43		T10D4.10	gene	taxon:6239			
+WB	WBGene00005557	sri-45		K07E8.9	gene	taxon:6239			
+WB	WBGene00005558	sri-46		K07E8.11	gene	taxon:6239			
+WB	WBGene00005559	sri-47		F22E5.4	gene	taxon:6239			
+WB	WBGene00005560	sri-48		ZC239.9	gene	taxon:6239			
+WB	WBGene00005562	sri-50		ZC239.19	gene	taxon:6239			
+WB	WBGene00005563	sri-51		ZC239.8	gene	taxon:6239			
+WB	WBGene00005565	sri-53		ZC239.10	gene	taxon:6239			
+WB	WBGene00005566	sri-54		T10D4.8	gene	taxon:6239			
+WB	WBGene00005569	sri-57		F22E5.16	gene	taxon:6239			
+WB	WBGene00005572	sri-60		Y47G7B.3	gene	taxon:6239			
+WB	WBGene00005573	sri-61		F34D6.6	gene	taxon:6239			
+WB	WBGene00005574	sri-62		F34D6.5	gene	taxon:6239			
+WB	WBGene00005575	sri-63		F39E9.3	gene	taxon:6239			
+WB	WBGene00005577	sri-65		F13A7.8	gene	taxon:6239			
+WB	WBGene00005578	sri-66		F28B1.6	gene	taxon:6239			
+WB	WBGene00005579	sri-67		Y60A3A.22	gene	taxon:6239			
+WB	WBGene00005581	sri-69		Y102A5C.32	gene	taxon:6239			
+WB	WBGene00005582	sri-70		Y61B8B.1	gene	taxon:6239			
+WB	WBGene00005583	sri-71		D2062.3	gene	taxon:6239			
+WB	WBGene00005584	sri-72		C14C6.11	gene	taxon:6239			
+WB	WBGene00005585	sri-73		C14C6.10	gene	taxon:6239			
+WB	WBGene00005586	sri-74		F33H12.4	gene	taxon:6239			
+WB	WBGene00005589	sri-77		D2062.9	gene	taxon:6239			
+WB	WBGene00005590	sri-78		Y27F2A.2|Y27F2A.i	gene	taxon:6239			
+WB	WBGene00005591	srj-1		ZK829.8	gene	taxon:6239			
+WB	WBGene00005592	srj-4		C27A7.7	gene	taxon:6239			
+WB	WBGene00005593	srj-5		F31F4.16	gene	taxon:6239			
+WB	WBGene00005594	srj-6		F31F4.8	gene	taxon:6239			
+WB	WBGene00005595	srj-7		T28A11.10	gene	taxon:6239			
+WB	WBGene00005596	srj-8		T28A11.9	gene	taxon:6239			
+WB	WBGene00005597	srj-9		T20C4.1	gene	taxon:6239			
+WB	WBGene00005598	srj-10		F14H3.1	gene	taxon:6239			
+WB	WBGene00005599	srj-11		T28A11.12	gene	taxon:6239			
+WB	WBGene00005601	srj-13		R13D7.3	gene	taxon:6239			
+WB	WBGene00005602	srj-14		C03G6.3	gene	taxon:6239			
+WB	WBGene00005603	srj-15		Y40B10B.2	gene	taxon:6239			
+WB	WBGene00005606	srj-18		R05D8.2	gene	taxon:6239			
+WB	WBGene00005607	srj-19		Y45G12C.14	gene	taxon:6239			
+WB	WBGene00005608	srj-20		Y45G12C.15	gene	taxon:6239			
+WB	WBGene00005609	srj-21		F28H7.11	gene	taxon:6239			
+WB	WBGene00005610	srj-22		F28H7.1	gene	taxon:6239			
+WB	WBGene00005611	srj-23		R09B5.7	gene	taxon:6239			
+WB	WBGene00005612	srj-24		C05E4.11	gene	taxon:6239			
+WB	WBGene00005613	srj-25		C05E4.10	gene	taxon:6239			
+WB	WBGene00005614	srj-26		ZK262.10	gene	taxon:6239			
+WB	WBGene00005615	srj-27		T01G5.3	gene	taxon:6239			
+WB	WBGene00005616	srj-29		F22B8.1	gene	taxon:6239			
+WB	WBGene00005617	srj-32		F07G11.5	gene	taxon:6239			
+WB	WBGene00005618	srj-33		T07C12.1	gene	taxon:6239			
+WB	WBGene00005621	srj-37		F48G7.1	gene	taxon:6239			
+WB	WBGene00005622	srj-38		T02B11.5	gene	taxon:6239			
+WB	WBGene00005623	srj-39		F38H12.1	gene	taxon:6239			
+WB	WBGene00005624	srj-40		F38H12.2	gene	taxon:6239			
+WB	WBGene00005625	srj-42		Y73F8A.3	gene	taxon:6239			
+WB	WBGene00005626	srj-44		T03D3.11	gene	taxon:6239			
+WB	WBGene00005627	srj-45		T03D3.6	gene	taxon:6239			
+WB	WBGene00005628	srj-49		T03D3.12	gene	taxon:6239			
+WB	WBGene00005629	srj-50		T03D3.2	gene	taxon:6239			
+WB	WBGene00005631	srj-52		Y49C4A.7|Y49C4A.b	gene	taxon:6239			
+WB	WBGene00005632	srj-53		Y49C4A.6	gene	taxon:6239			
+WB	WBGene00005633	srj-54		F37B4.11	gene	taxon:6239			
+WB	WBGene00005634	srj-55		Y45G12A.1	gene	taxon:6239			
+WB	WBGene00005635	srj-57		T03D3.14	gene	taxon:6239			
+WB	WBGene00005638	srm-1		T28H11.2	gene	taxon:6239			
+WB	WBGene00005639	srm-2		T28H11.3	gene	taxon:6239			
+WB	WBGene00005640	srn-1		K12B6.5	gene	taxon:6239			
+WB	WBGene00005641	sro-1		D1022.6	gene	taxon:6239			
+WB	WBGene00005642	srp-1		C05E4.3	gene	taxon:6239			
+WB	WBGene00005643	srp-2		C05E4.1|pes-21	gene	taxon:6239			
+WB	WBGene00005644	srp-3		Y32G9A.4|srp-4	gene	taxon:6239			
+WB	WBGene00005647	srp-6		C03G6.19	gene	taxon:6239			
+WB	WBGene00005648	srp-7		F20D6.4	gene	taxon:6239			
+WB	WBGene00005649	srp-8		F20D6.3	gene	taxon:6239			
+WB	WBGene00005652	srr-1		W07G4.6	gene	taxon:6239			
+WB	WBGene00005653	srr-2		T26H2.8	gene	taxon:6239			
+WB	WBGene00005654	srr-3		F36D3.3	gene	taxon:6239			
+WB	WBGene00005655	srr-4		K11D12.3	gene	taxon:6239			
+WB	WBGene00005657	srr-6		C13D9.1	gene	taxon:6239			
+WB	WBGene00005658	srr-7		T01G5.4	gene	taxon:6239			
+WB	WBGene00005659	srr-8		C13D9.3	gene	taxon:6239			
+WB	WBGene00005660	srr-9		T05B11.2	gene	taxon:6239			
+WB	WBGene00005661	srr-10		T05B11.6	gene	taxon:6239			
+WB	WBGene00005662	sars-2		W03B1.4|SerRS|srs-1	gene	taxon:6239			
+WB	WBGene00005663	sars-1		C47E12.1|srs-2	gene	taxon:6239			
+WB	WBGene00005664	sru-1		C33A12.14	gene	taxon:6239			
+WB	WBGene00005665	sru-2		C33A12.13	gene	taxon:6239			
+WB	WBGene00005666	sru-3		C33A12.11	gene	taxon:6239			
+WB	WBGene00005667	sru-4		C33A12.10	gene	taxon:6239			
+WB	WBGene00005669	sru-6		C33A12.8	gene	taxon:6239			
+WB	WBGene00005670	sru-7		C28C12.13	gene	taxon:6239			
+WB	WBGene00005671	sru-8		R07B5.7	gene	taxon:6239			
+WB	WBGene00005674	sru-11		Y45F10B.6	gene	taxon:6239			
+WB	WBGene00005675	sru-12		Y45F10B.5	gene	taxon:6239			
+WB	WBGene00005678	sru-15		T02D1.3	gene	taxon:6239			
+WB	WBGene00005679	sru-16		Y45F10B.4	gene	taxon:6239			
+WB	WBGene00005680	sru-17		T04A11.10	gene	taxon:6239			
+WB	WBGene00005681	sru-18		T04A11.9	gene	taxon:6239			
+WB	WBGene00005682	sru-19		T04A11.8	gene	taxon:6239			
+WB	WBGene00005683	sru-20		T04A11.7	gene	taxon:6239			
+WB	WBGene00005684	sru-21		C08F11.4	gene	taxon:6239			
+WB	WBGene00005685	sru-22		F36G9.5	gene	taxon:6239			
+WB	WBGene00005686	sru-23		F36G9.6	gene	taxon:6239			
+WB	WBGene00005687	sru-24		F31F4.13	gene	taxon:6239			
+WB	WBGene00005688	sru-25		F31F4.14	gene	taxon:6239			
+WB	WBGene00005689	sru-26		T04A11.12	gene	taxon:6239			
+WB	WBGene00005690	sru-27		C38C3.2	gene	taxon:6239			
+WB	WBGene00005691	sru-28		C38C3.1	gene	taxon:6239			
+WB	WBGene00005692	sru-29		C50C10.2	gene	taxon:6239			
+WB	WBGene00005693	sru-30		C50C10.3	gene	taxon:6239			
+WB	WBGene00005694	sru-31		C50C10.4	gene	taxon:6239			
+WB	WBGene00005698	sru-35		C33D9.4	gene	taxon:6239			
+WB	WBGene00005699	sru-36		R07B5.6	gene	taxon:6239			
+WB	WBGene00005700	sru-37		C50C10.1	gene	taxon:6239			
+WB	WBGene00005701	sru-38		R07B5.4	gene	taxon:6239			
+WB	WBGene00005702	sru-39		F46B6.11	gene	taxon:6239			
+WB	WBGene00005703	sru-40		R07B5.3	gene	taxon:6239			
+WB	WBGene00005705	sru-42		C55A1.8	gene	taxon:6239			
+WB	WBGene00005707	sru-44		T08G3.8	gene	taxon:6239			
+WB	WBGene00005708	sru-45		Y32B12B.7	gene	taxon:6239			
+WB	WBGene00005710	sru-47		F36D1.3	gene	taxon:6239			
+WB	WBGene00005711	sru-48		T03G11.2	gene	taxon:6239			
+WB	WBGene00005712	srv-1		R13F6.3|srg-12	gene	taxon:6239			
+WB	WBGene00005713	srv-2		C14A4.15	gene	taxon:6239			
+WB	WBGene00005714	srv-3		Y43F8C.19	gene	taxon:6239			
+WB	WBGene00005715	srv-4		F15E6.7	gene	taxon:6239			
+WB	WBGene00005716	srv-5		F48D6.2	gene	taxon:6239			
+WB	WBGene00005717	srv-6		C52B9.5	gene	taxon:6239			
+WB	WBGene00005718	srv-7		T22B7.5	gene	taxon:6239			
+WB	WBGene00005719	srv-8		F53F1.7	gene	taxon:6239			
+WB	WBGene00005720	srv-9		F53F1.8	gene	taxon:6239			
+WB	WBGene00005721	srv-10		F53F1.9	gene	taxon:6239			
+WB	WBGene00005722	srv-11		H25K10.3	gene	taxon:6239			
+WB	WBGene00005723	srv-12		T04B2.4	gene	taxon:6239			
+WB	WBGene00005724	srv-13		Y73B6BL.39	gene	taxon:6239			
+WB	WBGene00005725	srv-14		Y105C5B.4	gene	taxon:6239			
+WB	WBGene00005726	srv-15		Y105C5B.6	gene	taxon:6239			
+WB	WBGene00005727	srv-16		Y105C5B.10	gene	taxon:6239			
+WB	WBGene00005728	srv-17		C06E7.7	gene	taxon:6239			
+WB	WBGene00005730	srv-19		H04M03.6	gene	taxon:6239			
+WB	WBGene00005732	srv-21		H04M03.8	gene	taxon:6239			
+WB	WBGene00005733	srv-22		H04M03.9	gene	taxon:6239			
+WB	WBGene00005735	srv-24		Y73B6BL.10	gene	taxon:6239			
+WB	WBGene00005736	srv-25		Y73B6BL.11	gene	taxon:6239			
+WB	WBGene00005737	srv-26		Y73B6BL.40	gene	taxon:6239			
+WB	WBGene00005738	srv-27		Y73B6BL.41	gene	taxon:6239			
+WB	WBGene00005739	srv-28		T13A10.14	gene	taxon:6239			
+WB	WBGene00005740	srv-29		T13A10.6	gene	taxon:6239			
+WB	WBGene00005741	srv-30		T13A10.7	gene	taxon:6239			
+WB	WBGene00005742	srv-31		T13A10.9	gene	taxon:6239			
+WB	WBGene00005743	srv-32		T13A10.12	gene	taxon:6239			
+WB	WBGene00005744	ops-1		T13A10.13|RHO\/1|srv-33	gene	taxon:6239			
+WB	WBGene00005745	srv-34		F13A7.3	gene	taxon:6239			
+WB	WBGene00005748	srw-1		Y75B12B.7	gene	taxon:6239			
+WB	WBGene00005749	srw-2		T03D3.3	gene	taxon:6239			
+WB	WBGene00005750	srw-3		ZK105.2	gene	taxon:6239			
+WB	WBGene00005751	srw-4		F37B4.8	gene	taxon:6239			
+WB	WBGene00005753	srw-6		H10D18.3	gene	taxon:6239			
+WB	WBGene00005754	srw-7		R08F11.5	gene	taxon:6239			
+WB	WBGene00005755	srw-8		F59D6.5	gene	taxon:6239			
+WB	WBGene00005756	srw-9		ZC482.8	gene	taxon:6239			
+WB	WBGene00005757	srw-10		ZC482.6	gene	taxon:6239			
+WB	WBGene00005758	srw-11		M01B2.11	gene	taxon:6239			
+WB	WBGene00005759	srw-12		C41G6.2	gene	taxon:6239			
+WB	WBGene00005760	srw-13		C41G6.15	gene	taxon:6239			
+WB	WBGene00005761	srw-14		C41G6.8	gene	taxon:6239			
+WB	WBGene00005762	srw-15		C41G6.3	gene	taxon:6239			
+WB	WBGene00005763	srw-16		T10H4.5	gene	taxon:6239			
+WB	WBGene00005764	srw-17		T10H4.6	gene	taxon:6239			
+WB	WBGene00005766	srw-19		T10H4.8	gene	taxon:6239			
+WB	WBGene00005767	srw-20		T05E12.4	gene	taxon:6239			
+WB	WBGene00005768	srw-21		C06B8.9	gene	taxon:6239			
+WB	WBGene00005769	srw-22		T10H4.3	gene	taxon:6239			
+WB	WBGene00005770	srw-23		F49A5.8	gene	taxon:6239			
+WB	WBGene00005771	srw-24		C41G6.7	gene	taxon:6239			
+WB	WBGene00005773	srw-26		T05G11.3	gene	taxon:6239			
+WB	WBGene00005776	srw-29		F26D2.11	gene	taxon:6239			
+WB	WBGene00005778	srw-31		K03D7.2	gene	taxon:6239			
+WB	WBGene00005779	srw-32		K03D7.11	gene	taxon:6239			
+WB	WBGene00005780	srw-33		T26H5.5	gene	taxon:6239			
+WB	WBGene00005781	srw-34		F36D3.13	gene	taxon:6239			
+WB	WBGene00005782	srw-35		T08G3.10	gene	taxon:6239			
+WB	WBGene00005783	srw-36		F14F8.7	gene	taxon:6239			
+WB	WBGene00005785	srw-38		Y116F11B.5|Y116F11B.e	gene	taxon:6239			
+WB	WBGene00005786	srw-39		F19B2.3	gene	taxon:6239			
+WB	WBGene00005787	srw-40		Y52E8A.5|Y52E8A.a|Y52E8A.b	gene	taxon:6239			
+WB	WBGene00005788	srw-41		F14F8.10	gene	taxon:6239			
+WB	WBGene00005789	srw-42		F14F8.11	gene	taxon:6239			
+WB	WBGene00005790	srw-43		F14F8.5	gene	taxon:6239			
+WB	WBGene00005791	srw-44		F14F8.6	gene	taxon:6239			
+WB	WBGene00005795	srw-48		F26D2.9	gene	taxon:6239			
+WB	WBGene00005798	srw-51		F40D4.8	gene	taxon:6239			
+WB	WBGene00005800	srw-53		T05G11.7	gene	taxon:6239			
+WB	WBGene00005801	srw-54		Y32B12C.2	gene	taxon:6239			
+WB	WBGene00005802	srw-55		T05G11.6	gene	taxon:6239			
+WB	WBGene00005803	srw-56		F36G9.16	gene	taxon:6239			
+WB	WBGene00005804	srw-57		F36G9.1	gene	taxon:6239			
+WB	WBGene00005806	srw-59		H24D24.1	gene	taxon:6239			
+WB	WBGene00005807	srw-60		T11F1.1	gene	taxon:6239			
+WB	WBGene00005808	srw-61		H25K10.7	gene	taxon:6239			
+WB	WBGene00005809	srw-62		T05A6.6	gene	taxon:6239			
+WB	WBGene00005810	srw-63		Y37A1B.10	gene	taxon:6239			
+WB	WBGene00005813	srw-66		Y57G7A.4	gene	taxon:6239			
+WB	WBGene00005814	srw-67		F18E3.2	gene	taxon:6239			
+WB	WBGene00005815	srw-68		F18E3.4	gene	taxon:6239			
+WB	WBGene00005816	srw-69		F18E3.5	gene	taxon:6239			
+WB	WBGene00005818	srw-71		F18E3.6	gene	taxon:6239			
+WB	WBGene00005819	srw-72		F20E11.6	gene	taxon:6239			
+WB	WBGene00005820	srw-73		T03E6.6	gene	taxon:6239			
+WB	WBGene00005823	srw-76		W06G6.6	gene	taxon:6239			
+WB	WBGene00005824	srw-77		W06G6.8	gene	taxon:6239			
+WB	WBGene00005826	srw-79		T11F1.5	gene	taxon:6239			
+WB	WBGene00005829	srw-82		ZK262.7	gene	taxon:6239			
+WB	WBGene00005830	srw-83		ZK262.6	gene	taxon:6239			
+WB	WBGene00005831	srw-84		Y43F8A.4	gene	taxon:6239			
+WB	WBGene00005832	srw-85		C25F9.1	gene	taxon:6239			
+WB	WBGene00005834	srw-87		F57G8.4	gene	taxon:6239			
+WB	WBGene00005835	srw-88		T06G6.7	gene	taxon:6239			
+WB	WBGene00005836	srw-89		K09D9.13	gene	taxon:6239			
+WB	WBGene00005837	srw-90		Y46H3C.3	gene	taxon:6239			
+WB	WBGene00005838	srw-91		K04F1.4	gene	taxon:6239			
+WB	WBGene00005841	srw-94		H06H21.1	gene	taxon:6239			
+WB	WBGene00005842	srw-95		H06H21.2	gene	taxon:6239			
+WB	WBGene00005844	srw-97		ZC204.15	gene	taxon:6239			
+WB	WBGene00005845	srw-98		K04F1.3	gene	taxon:6239			
+WB	WBGene00005846	srw-99		Y46H3C.2	gene	taxon:6239			
+WB	WBGene00005847	srw-100		Y46H3C.1	gene	taxon:6239			
+WB	WBGene00005848	srw-101		ZK697.13	gene	taxon:6239			
+WB	WBGene00005849	srw-102		ZK697.12	gene	taxon:6239			
+WB	WBGene00005850	srw-103		ZK697.5	gene	taxon:6239			
+WB	WBGene00005854	srw-107		R11G11.13	gene	taxon:6239			
+WB	WBGene00005855	srw-108		R11G11.5	gene	taxon:6239			
+WB	WBGene00005856	srw-109		ZK488.9	gene	taxon:6239			
+WB	WBGene00005858	srw-111		M01G12.4	gene	taxon:6239			
+WB	WBGene00005859	srw-112		K12D9.9	gene	taxon:6239			
+WB	WBGene00005860	srw-113		ZK1037.9	gene	taxon:6239			
+WB	WBGene00005862	srw-115		K12D9.4	gene	taxon:6239			
+WB	WBGene00005864	srw-117		C44C3.6	gene	taxon:6239			
+WB	WBGene00005865	srw-118		C44C3.5	gene	taxon:6239			
+WB	WBGene00005866	srw-119		K12D9.7	gene	taxon:6239			
+WB	WBGene00005867	srw-120		K12D9.5	gene	taxon:6239			
+WB	WBGene00005868	srw-121		K12D9.3	gene	taxon:6239			
+WB	WBGene00005869	srw-122		H27D07.5	gene	taxon:6239			
+WB	WBGene00005870	srw-123		C44C3.11	gene	taxon:6239			
+WB	WBGene00005871	srw-124		C44C3.1	gene	taxon:6239			
+WB	WBGene00005874	srw-127		C33G8.1	gene	taxon:6239			
+WB	WBGene00005876	srw-129		C44C3.2	gene	taxon:6239			
+WB	WBGene00005877	srw-130		T24A6.14	gene	taxon:6239			
+WB	WBGene00005880	srw-133		T05B4.6	gene	taxon:6239			
+WB	WBGene00005881	srw-134		T05B4.7	gene	taxon:6239			
+WB	WBGene00005882	srw-135		K12D9.11	gene	taxon:6239			
+WB	WBGene00005883	srw-136		K12D9.10	gene	taxon:6239			
+WB	WBGene00005884	srw-137		H27D07.4	gene	taxon:6239			
+WB	WBGene00005885	srw-138		C44C3.3	gene	taxon:6239			
+WB	WBGene00005886	srw-139		C44C3.7	gene	taxon:6239			
+WB	WBGene00005887	srw-140		C03A7.3	gene	taxon:6239			
+WB	WBGene00005888	srw-141		H27D07.2	gene	taxon:6239			
+WB	WBGene00005889	srw-142		H05B21.3	gene	taxon:6239			
+WB	WBGene00005890	srw-143		H27D07.3	gene	taxon:6239			
+WB	WBGene00005891	srw-144		H05B21.4	gene	taxon:6239			
+WB	WBGene00005892	srx-1		F59E11.1	gene	taxon:6239			
+WB	WBGene00005893	srx-2		R03H4.2	gene	taxon:6239			
+WB	WBGene00005894	srx-3		R03H4.3	gene	taxon:6239			
+WB	WBGene00005895	srx-4		Y49C4A.5|Y49C4A.c	gene	taxon:6239			
+WB	WBGene00005896	srx-5		Y49C4A.4	gene	taxon:6239			
+WB	WBGene00005897	srx-6		F07G11.8	gene	taxon:6239			
+WB	WBGene00005898	srx-7		C14C6.1	gene	taxon:6239			
+WB	WBGene00005899	srx-8		C14C6.9	gene	taxon:6239			
+WB	WBGene00005900	srx-9		R13D7.6	gene	taxon:6239			
+WB	WBGene00005901	srx-10		R10D12.4	gene	taxon:6239			
+WB	WBGene00005903	srx-12		Y55F3AM.2	gene	taxon:6239			
+WB	WBGene00005904	srx-13		C44B12.4	gene	taxon:6239			
+WB	WBGene00005905	srx-14		C44B12.8	gene	taxon:6239			
+WB	WBGene00005907	srx-16		T07H8.1	gene	taxon:6239			
+WB	WBGene00005908	srx-17		F55B12.8	gene	taxon:6239			
+WB	WBGene00005909	srx-18		C47A10.8	gene	taxon:6239			
+WB	WBGene00005910	srx-19		T05A12.1	gene	taxon:6239			
+WB	WBGene00005911	srx-20		R13H7.1	gene	taxon:6239			
+WB	WBGene00005912	srx-21		F31F4.4	gene	taxon:6239			
+WB	WBGene00005913	srx-22		F31F4.3	gene	taxon:6239			
+WB	WBGene00005914	srx-23		F31F4.2	gene	taxon:6239			
+WB	WBGene00005915	srx-24		C24B9.16	gene	taxon:6239			
+WB	WBGene00005917	srx-26		R05D8.4	gene	taxon:6239			
+WB	WBGene00005919	srx-28		R05D8.5	gene	taxon:6239			
+WB	WBGene00005920	srx-29		K06B4.9	gene	taxon:6239			
+WB	WBGene00005922	srx-31		F41H8.4|F41H8.b	gene	taxon:6239			
+WB	WBGene00005923	srx-32		R13D11.9	gene	taxon:6239			
+WB	WBGene00005924	srx-33		T01C4.3	gene	taxon:6239			
+WB	WBGene00005925	srx-34		T01C4.4	gene	taxon:6239			
+WB	WBGene00005927	srx-36		T01C4.6	gene	taxon:6239			
+WB	WBGene00005929	srx-38		C03A7.5	gene	taxon:6239			
+WB	WBGene00005930	srx-39		C03A7.6	gene	taxon:6239			
+WB	WBGene00005931	fbxa-199		T06E6.3|srx-40	gene	taxon:6239			
+WB	WBGene00005932	srx-41		F59B1.7	gene	taxon:6239			
+WB	WBGene00005933	srx-42		C06B3.11	gene	taxon:6239			
+WB	WBGene00005934	srx-43		T10C6.3	gene	taxon:6239			
+WB	WBGene00005935	srx-44		T10C6.4	gene	taxon:6239			
+WB	WBGene00005936	srx-45		K01B6.2	gene	taxon:6239			
+WB	WBGene00005937	srx-46		E02C12.2	gene	taxon:6239			
+WB	WBGene00005938	srx-47		E02C12.3	gene	taxon:6239			
+WB	WBGene00005939	srx-48		T26H8.2	gene	taxon:6239			
+WB	WBGene00005941	srx-50		Y43B11AL.2	gene	taxon:6239			
+WB	WBGene00005942	srx-51		T10H4.9	gene	taxon:6239			
+WB	WBGene00005945	srx-54		Y102A5C.22	gene	taxon:6239			
+WB	WBGene00005947	srx-56		C03G6.2	gene	taxon:6239			
+WB	WBGene00005949	srx-58		C29F3.6	gene	taxon:6239			
+WB	WBGene00005950	srx-59		T07H8.3	gene	taxon:6239			
+WB	WBGene00005951	srx-60		R13D7.4	gene	taxon:6239			
+WB	WBGene00005953	srx-62		K09D9.10	gene	taxon:6239			
+WB	WBGene00005954	srx-63		K07C6.6	gene	taxon:6239			
+WB	WBGene00005955	srx-64		K07C6.7	gene	taxon:6239			
+WB	WBGene00005956	srx-65		K07C6.8	gene	taxon:6239			
+WB	WBGene00005957	srx-66		K07C6.9	gene	taxon:6239			
+WB	WBGene00005958	srx-67		K07C6.10	gene	taxon:6239			
+WB	WBGene00005959	srx-68		K07C6.11	gene	taxon:6239			
+WB	WBGene00005964	srx-73		F41F3.7	gene	taxon:6239			
+WB	WBGene00005967	srx-76		K12G11.5	gene	taxon:6239			
+WB	WBGene00005968	srx-77		K03B4.5	gene	taxon:6239			
+WB	WBGene00005969	srx-78		C01G10.3	gene	taxon:6239			
+WB	WBGene00005971	srx-80		F43A11.4	gene	taxon:6239			
+WB	WBGene00005973	srx-82		F43A11.6	gene	taxon:6239			
+WB	WBGene00005975	srx-84		F35B12.1	gene	taxon:6239			
+WB	WBGene00005976	srx-85		F38B7.4	gene	taxon:6239			
+WB	WBGene00005977	srx-86		F38B7.7	gene	taxon:6239			
+WB	WBGene00005978	srx-87		F38B7.8	gene	taxon:6239			
+WB	WBGene00005979	srx-88		F43A11.1	gene	taxon:6239			
+WB	WBGene00005981	srx-90		H12C20.5	gene	taxon:6239			
+WB	WBGene00005983	srx-92		F10G2.6	gene	taxon:6239			
+WB	WBGene00005984	srx-93		F59B1.3	gene	taxon:6239			
+WB	WBGene00005986	srx-95		F41G3.11	gene	taxon:6239			
+WB	WBGene00005987	srx-96		T01D3.4	gene	taxon:6239			
+WB	WBGene00005988	srx-97		F19B10.7	gene	taxon:6239			
+WB	WBGene00005989	srx-98		F19B10.8	gene	taxon:6239			
+WB	WBGene00005992	srx-101		F40H7.4	gene	taxon:6239			
+WB	WBGene00005993	srx-102		F40H7.5	gene	taxon:6239			
+WB	WBGene00005995	srx-104		F40H7.7	gene	taxon:6239			
+WB	WBGene00005996	srx-105		F40H7.8	gene	taxon:6239			
+WB	WBGene00005999	srx-108		F40H7.2	gene	taxon:6239			
+WB	WBGene00006001	srx-110		C46E10.6	gene	taxon:6239			
+WB	WBGene00006002	srx-111		T24E12.4	gene	taxon:6239			
+WB	WBGene00006003	srx-112		T24E12.8	gene	taxon:6239			
+WB	WBGene00006004	srx-113		F56H9.1	gene	taxon:6239			
+WB	WBGene00006005	srx-114		F07F6.9	gene	taxon:6239			
+WB	WBGene00006006	srx-115		B0507.11	gene	taxon:6239			
+WB	WBGene00006007	srx-116		W05B10.5	gene	taxon:6239			
+WB	WBGene00006008	srx-117		C14C11.5	gene	taxon:6239			
+WB	WBGene00006009	srx-118		T21B4.12	gene	taxon:6239			
+WB	WBGene00006010	srx-119		F49C5.1	gene	taxon:6239			
+WB	WBGene00006011	srx-120		F49C5.2	gene	taxon:6239			
+WB	WBGene00006012	srx-121		C04E12.8	gene	taxon:6239			
+WB	WBGene00006013	srx-122		F35F10.8	gene	taxon:6239			
+WB	WBGene00006016	srx-125		F32H5.6	gene	taxon:6239			
+WB	WBGene00006019	srx-128		F55B12.7	gene	taxon:6239			
+WB	WBGene00006020	srx-129		F55B12.9	gene	taxon:6239			
+WB	WBGene00006021	srx-130		F09F3.1	gene	taxon:6239			
+WB	WBGene00006022	srx-131		F09F3.2	gene	taxon:6239			
+WB	WBGene00006024	srx-133		F09F3.4	gene	taxon:6239			
+WB	WBGene00006025	srx-134		F09F3.7	gene	taxon:6239			
+WB	WBGene00006026	srx-135		F09F3.11	gene	taxon:6239			
+WB	WBGene00006027	srx-136		F09F3.12	gene	taxon:6239			
+WB	WBGene00006028	srx-137		F09F3.13	gene	taxon:6239			
+WB	WBGene00006047	ssp-19		C55C2.2	gene	taxon:6239			
+WB	WBGene00006048	ssp-31		ZK1225.6	gene	taxon:6239			
+WB	WBGene00006055	ssr-2		C14A11.7	gene	taxon:6239			
+WB	WBGene00006058	sst-20		F54C1.9	gene	taxon:6239			
+WB	WBGene00006059	stc-1		F54C9.2	gene	taxon:6239			
+WB	WBGene00006060	sth-1		ZC513.12	gene	taxon:6239			
+WB	WBGene00006061	stl-1		F30A10.5	gene	taxon:6239			
+WB	WBGene00006062	stn-1		F30A10.8	gene	taxon:6239			
+WB	WBGene00006063	sto-1		F08C6.4	gene	taxon:6239			
+WB	WBGene00006064	sto-2		F32A6.5	gene	taxon:6239			
+WB	WBGene00006065	sto-3		F52D10.5	gene	taxon:6239			
+WB	WBGene00006066	sto-4		Y71H9A.3	gene	taxon:6239			
+WB	WBGene00006067	sto-5		F41G4.3	gene	taxon:6239			
+WB	WBGene00006068	sto-6		Y71H9A.2	gene	taxon:6239			
+WB	WBGene00006069	str-1		C42D4.5	gene	taxon:6239			
+WB	WBGene00006070	str-2		C50C10.7	gene	taxon:6239			
+WB	WBGene00006071	str-3		M7.13	gene	taxon:6239			
+WB	WBGene00006072	str-4		C50B6.10	gene	taxon:6239			
+WB	WBGene00006073	str-5		T23D5.12	gene	taxon:6239			
+WB	WBGene00006074	str-6		T23D5.10	gene	taxon:6239			
+WB	WBGene00006075	str-7		F22B8.5	gene	taxon:6239			
+WB	WBGene00006076	str-8		T23D5.11	gene	taxon:6239			
+WB	WBGene00006077	str-9		F57A10.1	gene	taxon:6239			
+WB	WBGene00006078	str-10		R03G8.5	gene	taxon:6239			
+WB	WBGene00006080	str-12		B0391.4	gene	taxon:6239			
+WB	WBGene00006081	str-13		C24B9.8	gene	taxon:6239			
+WB	WBGene00006082	str-14		T08G3.2	gene	taxon:6239			
+WB	WBGene00006083	str-15		T08G3.1	gene	taxon:6239			
+WB	WBGene00006084	str-16		Y73C8A.1	gene	taxon:6239			
+WB	WBGene00006085	str-18		T23D5.6	gene	taxon:6239			
+WB	WBGene00006086	str-19		T23D5.7	gene	taxon:6239			
+WB	WBGene00006087	str-20		C05E4.2	gene	taxon:6239			
+WB	WBGene00006090	str-23		C55A1.5	gene	taxon:6239			
+WB	WBGene00006092	str-25		F44G3.11	gene	taxon:6239			
+WB	WBGene00006093	str-27		T23D5.1	gene	taxon:6239			
+WB	WBGene00006094	str-28		F25E5.12	gene	taxon:6239			
+WB	WBGene00006096	str-30		T27C4.3	gene	taxon:6239			
+WB	WBGene00006097	str-31		C54F6.10	gene	taxon:6239			
+WB	WBGene00006098	str-32		T19H12.7	gene	taxon:6239			
+WB	WBGene00006099	str-33		C24B9.1	gene	taxon:6239			
+WB	WBGene00006102	str-37		C50B6.12	gene	taxon:6239			
+WB	WBGene00006103	str-38		T23D5.2	gene	taxon:6239			
+WB	WBGene00006104	str-39		F37B4.12	gene	taxon:6239			
+WB	WBGene00006105	str-40		C50H11.12	gene	taxon:6239			
+WB	WBGene00006106	str-41		R13D7.1	gene	taxon:6239			
+WB	WBGene00006108	str-43		T23D5.9	gene	taxon:6239			
+WB	WBGene00006109	str-44		C42D4.4	gene	taxon:6239			
+WB	WBGene00006110	str-45		T09F5.3	gene	taxon:6239			
+WB	WBGene00006111	str-46		C31B8.6	gene	taxon:6239			
+WB	WBGene00006112	str-47		F07C4.1	gene	taxon:6239			
+WB	WBGene00006113	str-48		C34D4.8	gene	taxon:6239			
+WB	WBGene00006117	str-52		C45H4.12	gene	taxon:6239			
+WB	WBGene00006120	str-55		F26D2.7	gene	taxon:6239			
+WB	WBGene00006121	str-56		T06C12.3	gene	taxon:6239			
+WB	WBGene00006122	str-57		T06C12.2	gene	taxon:6239			
+WB	WBGene00006124	str-60		T06C12.1	gene	taxon:6239			
+WB	WBGene00006125	str-61		F14F8.1	gene	taxon:6239			
+WB	WBGene00006126	str-63		C17B7.1	gene	taxon:6239			
+WB	WBGene00006127	str-64		T28A11.1	gene	taxon:6239			
+WB	WBGene00006128	str-66		Y73C8C.5	gene	taxon:6239			
+WB	WBGene00006129	str-67		K10C9.6	gene	taxon:6239			
+WB	WBGene00006130	str-68		Y73C8C.6	gene	taxon:6239			
+WB	WBGene00006131	str-69		Y73C8C.11	gene	taxon:6239			
+WB	WBGene00006133	str-71		T23F1.4	gene	taxon:6239			
+WB	WBGene00006134	str-73		F26D2.1	gene	taxon:6239			
+WB	WBGene00006135	str-74		C14H10.4	gene	taxon:6239			
+WB	WBGene00006136	str-76		C01B4.10	gene	taxon:6239			
+WB	WBGene00006137	str-77		W06D12.4	gene	taxon:6239			
+WB	WBGene00006138	str-78		Y40H7A.1	gene	taxon:6239			
+WB	WBGene00006139	str-79		F52D2.9	gene	taxon:6239			
+WB	WBGene00006140	str-81		T26H2.6	gene	taxon:6239			
+WB	WBGene00006141	str-82		B0213.8	gene	taxon:6239			
+WB	WBGene00006142	str-83		B0213.7	gene	taxon:6239			
+WB	WBGene00006143	str-84		F59E11.13	gene	taxon:6239			
+WB	WBGene00006144	str-85		F59E11.15	gene	taxon:6239			
+WB	WBGene00006145	str-86		F59E11.14	gene	taxon:6239			
+WB	WBGene00006146	str-87		F59E11.16	gene	taxon:6239			
+WB	WBGene00006147	str-88		R08H2.2	gene	taxon:6239			
+WB	WBGene00006148	str-89		F59A1.4	gene	taxon:6239			
+WB	WBGene00006149	str-90		F58G4.2	gene	taxon:6239			
+WB	WBGene00006150	str-92		F59A1.3	gene	taxon:6239			
+WB	WBGene00006151	str-93		F59A1.14	gene	taxon:6239			
+WB	WBGene00006152	str-94		F07C3.8	gene	taxon:6239			
+WB	WBGene00006153	str-96		T10H4.2	gene	taxon:6239			
+WB	WBGene00006154	str-97		F10A3.8	gene	taxon:6239			
+WB	WBGene00006155	str-99		F10A3.6	gene	taxon:6239			
+WB	WBGene00006156	str-101		Y6E2A.2	gene	taxon:6239			
+WB	WBGene00006157	str-102		R08H2.13	gene	taxon:6239			
+WB	WBGene00006158	str-103		F44G3.1	gene	taxon:6239			
+WB	WBGene00006159	str-106		K05D4.2	gene	taxon:6239			
+WB	WBGene00006160	str-108		F10A3.13	gene	taxon:6239			
+WB	WBGene00006161	str-109		F10A3.5	gene	taxon:6239			
+WB	WBGene00006162	str-111		F10A3.15	gene	taxon:6239			
+WB	WBGene00006163	str-112		F10D2.4	gene	taxon:6239			
+WB	WBGene00006164	str-113		Y39H10B.1	gene	taxon:6239			
+WB	WBGene00006165	str-114		F59B1.1	gene	taxon:6239			
+WB	WBGene00006166	str-115		F07B10.3	gene	taxon:6239			
+WB	WBGene00006167	str-116		F07B10.2	gene	taxon:6239			
+WB	WBGene00006169	str-118		F57A8.3	gene	taxon:6239			
+WB	WBGene00006170	str-119		C13B7.5	gene	taxon:6239			
+WB	WBGene00006171	str-120		C13B7.2	gene	taxon:6239			
+WB	WBGene00006172	str-121		R02C2.5	gene	taxon:6239			
+WB	WBGene00006174	str-123		T22H6.4	gene	taxon:6239			
+WB	WBGene00006175	str-124		T22H6.3	gene	taxon:6239			
+WB	WBGene00006176	str-125		T05E12.1	gene	taxon:6239			
+WB	WBGene00006178	str-129		F58G4.5	gene	taxon:6239			
+WB	WBGene00006179	str-130		C09H5.9	gene	taxon:6239			
+WB	WBGene00006180	str-131		C09H5.6	gene	taxon:6239			
+WB	WBGene00006182	str-134		C05E4.6	gene	taxon:6239			
+WB	WBGene00006183	str-135		F21F8.10	gene	taxon:6239			
+WB	WBGene00006184	str-136		F21F8.9	gene	taxon:6239			
+WB	WBGene00006186	str-139		ZC513.9	gene	taxon:6239			
+WB	WBGene00006187	str-138		ZC513.11	gene	taxon:6239			
+WB	WBGene00006188	str-140		C09H5.3	gene	taxon:6239			
+WB	WBGene00006189	str-141		F47G9.2	gene	taxon:6239			
+WB	WBGene00006190	str-143		C09H5.4	gene	taxon:6239			
+WB	WBGene00006191	str-144		C09H5.5	gene	taxon:6239			
+WB	WBGene00006192	str-145		F58G4.7	gene	taxon:6239			
+WB	WBGene00006193	str-146		F58G4.6	gene	taxon:6239			
+WB	WBGene00006195	str-148		M01D1.1	gene	taxon:6239			
+WB	WBGene00006196	str-149		Y32B12B.5	gene	taxon:6239			
+WB	WBGene00006197	str-150		T03E6.4	gene	taxon:6239			
+WB	WBGene00006198	str-151		T03E6.1	gene	taxon:6239			
+WB	WBGene00006199	str-153		Y9C9A.7	gene	taxon:6239			
+WB	WBGene00006200	str-154		Y45G12C.12	gene	taxon:6239			
+WB	WBGene00006201	str-155		Y9C9A.10	gene	taxon:6239			
+WB	WBGene00006202	str-156		Y9C9A.11	gene	taxon:6239			
+WB	WBGene00006203	str-158		Y9C9A.9	gene	taxon:6239			
+WB	WBGene00006204	str-159		Y9C9A.18	gene	taxon:6239			
+WB	WBGene00006205	str-160		ZK697.10	gene	taxon:6239			
+WB	WBGene00006206	str-161		T08B6.3	gene	taxon:6239			
+WB	WBGene00006207	str-162		E03H12.1	gene	taxon:6239			
+WB	WBGene00006208	str-163		Y9C9A.3	gene	taxon:6239			
+WB	WBGene00006209	str-164		Y9C9A.2	gene	taxon:6239			
+WB	WBGene00006210	str-165		F55B12.6	gene	taxon:6239			
+WB	WBGene00006211	str-166		T08B6.6	gene	taxon:6239			
+WB	WBGene00006212	str-168		Y9C9A.6	gene	taxon:6239			
+WB	WBGene00006213	str-169		Y9C9A.4	gene	taxon:6239			
+WB	WBGene00006214	str-170		T08B6.7	gene	taxon:6239			
+WB	WBGene00006215	str-171		T01G5.5	gene	taxon:6239			
+WB	WBGene00006216	str-172		Y17G9A.5	gene	taxon:6239			
+WB	WBGene00006217	str-173		Y17G9A.1	gene	taxon:6239			
+WB	WBGene00006218	str-174		Y17G9A.7	gene	taxon:6239			
+WB	WBGene00006219	str-175		Y17G9A.6	gene	taxon:6239			
+WB	WBGene00006220	str-176		T01B11.5	gene	taxon:6239			
+WB	WBGene00006221	str-177		T18H9.4	gene	taxon:6239			
+WB	WBGene00006222	str-178		R11D1.5	gene	taxon:6239			
+WB	WBGene00006224	str-180		T10H9.6	gene	taxon:6239			
+WB	WBGene00006225	str-181		R11D1.6	gene	taxon:6239			
+WB	WBGene00006226	str-182		C12D8.12	gene	taxon:6239			
+WB	WBGene00006228	str-185		R08C7.7	gene	taxon:6239			
+WB	WBGene00006229	str-187		F26D10.8	gene	taxon:6239			
+WB	WBGene00006230	str-188		F40F9.4	gene	taxon:6239			
+WB	WBGene00006231	str-190		C18B10.7	gene	taxon:6239			
+WB	WBGene00006232	str-193		C50C10.6	gene	taxon:6239			
+WB	WBGene00006233	str-196		T01G6.3	gene	taxon:6239			
+WB	WBGene00006234	str-198		ZK285.1	gene	taxon:6239			
+WB	WBGene00006235	str-199		Y68A4A.3	gene	taxon:6239			
+WB	WBGene00006236	str-200		F20E11.4	gene	taxon:6239			
+WB	WBGene00006237	str-204		F10D2.1	gene	taxon:6239			
+WB	WBGene00006238	str-205		C02E7.9	gene	taxon:6239			
+WB	WBGene00006239	str-206		W06H8.7	gene	taxon:6239			
+WB	WBGene00006240	str-207		F26G5.4	gene	taxon:6239			
+WB	WBGene00006241	str-208		F26G5.2	gene	taxon:6239			
+WB	WBGene00006242	str-209		F26G5.5	gene	taxon:6239			
+WB	WBGene00006244	str-211		C02E7.13	gene	taxon:6239			
+WB	WBGene00006247	str-214		C31A11.9	gene	taxon:6239			
+WB	WBGene00006249	str-217		Y102A5C.28	gene	taxon:6239			
+WB	WBGene00006251	str-220		C42D4.9	gene	taxon:6239			
+WB	WBGene00006252	str-221		Y46H3D.2	gene	taxon:6239			
+WB	WBGene00006253	str-222		Y46H3D.3	gene	taxon:6239			
+WB	WBGene00006256	str-225		C07G3.6	gene	taxon:6239			
+WB	WBGene00006257	str-226		C07G3.4	gene	taxon:6239			
+WB	WBGene00006258	str-227		C07G3.3	gene	taxon:6239			
+WB	WBGene00006259	str-228		C07G3.5	gene	taxon:6239			
+WB	WBGene00006260	str-229		C17E7.11	gene	taxon:6239			
+WB	WBGene00006261	str-230		T16A9.2	gene	taxon:6239			
+WB	WBGene00006262	str-231		C06C6.3	gene	taxon:6239			
+WB	WBGene00006263	str-232		T10C6.1	gene	taxon:6239			
+WB	WBGene00006264	str-233		C06C6.2	gene	taxon:6239			
+WB	WBGene00006265	str-236		K02H11.3	gene	taxon:6239			
+WB	WBGene00006266	str-238		R09E12.4	gene	taxon:6239			
+WB	WBGene00006268	str-240		K02H11.2	gene	taxon:6239			
+WB	WBGene00006270	str-243		K02H11.7	gene	taxon:6239			
+WB	WBGene00006271	str-244		C50H11.9	gene	taxon:6239			
+WB	WBGene00006272	str-245		F32A7.7	gene	taxon:6239			
+WB	WBGene00006273	str-246		W09D6.3	gene	taxon:6239			
+WB	WBGene00006274	str-247		B0213.9	gene	taxon:6239			
+WB	WBGene00006275	str-248		C55A1.3	gene	taxon:6239			
+WB	WBGene00006276	str-249		C42D4.12	gene	taxon:6239			
+WB	WBGene00006277	str-250		C06B3.10	gene	taxon:6239			
+WB	WBGene00006278	str-252		C06B3.9	gene	taxon:6239			
+WB	WBGene00006279	str-253		F41B5.8	gene	taxon:6239			
+WB	WBGene00006280	str-254		F10A3.9	gene	taxon:6239			
+WB	WBGene00006281	str-255		C45H4.15	gene	taxon:6239			
+WB	WBGene00006282	str-256		T01G6.9	gene	taxon:6239			
+WB	WBGene00006283	str-257		C01B4.1	gene	taxon:6239			
+WB	WBGene00006284	str-258		C01B4.3	gene	taxon:6239			
+WB	WBGene00006286	str-260		T24A6.6	gene	taxon:6239			
+WB	WBGene00006287	str-261		W09D6.2	gene	taxon:6239			
+WB	WBGene00006288	str-262		C05E4.13	gene	taxon:6239			
+WB	WBGene00006289	str-263		B0391.12	gene	taxon:6239			
+WB	WBGene00006293	stu-8			gene	taxon:6239			
+WB	WBGene00006294	stu-9			gene	taxon:6239			
+WB	WBGene00006295	stu-10			gene	taxon:6239			
+WB	WBGene00006296	stu-11			gene	taxon:6239			
+WB	WBGene00006297	stu-12			gene	taxon:6239			
+WB	WBGene00006298	stu-13			gene	taxon:6239			
+WB	WBGene00006299	stu-14			gene	taxon:6239			
+WB	WBGene00006300	stu-15			gene	taxon:6239			
+WB	WBGene00006301	stu-16			gene	taxon:6239			
+WB	WBGene00006302	stu-17			gene	taxon:6239			
+WB	WBGene00006304	stu-19			gene	taxon:6239			
+WB	WBGene00006306	sue-1		F07A5.5	gene	taxon:6239			
+WB	WBGene00006307	suf-1		F28C6.6	gene	taxon:6239			
+WB	WBGene00006308	sul-1		K09C4.8|tag-37	gene	taxon:6239			
+WB	WBGene00006309	sul-2		D1014.1|tag-75	gene	taxon:6239			
+WB	WBGene00006310	sul-3		C54D2.4	gene	taxon:6239			
+WB	WBGene00006311	sun-1		F57B1.2|mtf-1	gene	taxon:6239			
+WB	WBGene00006318	sup-9		F34D6.3|twk-23|twk-38	gene	taxon:6239			
+WB	WBGene00006319	sup-10		R09G11.1	gene	taxon:6239			
+WB	WBGene00006321	sup-12		T22B2.4	gene	taxon:6239			
+WB	WBGene00006324	sup-17		DY3.7	gene	taxon:6239			
+WB	WBGene00006331	sup-26		R10E4.2|tag-310	gene	taxon:6239			
+WB	WBGene00006342	sup-37		C01B7.1|ztf-12	gene	taxon:6239			
+WB	WBGene00006349	sur-2		F39B2.4|mdt-23	gene	taxon:6239			
+WB	WBGene00006351	sur-5		K03A1.5	gene	taxon:6239			
+WB	WBGene00006352	sur-6		F26E4.1	gene	taxon:6239			
+WB	WBGene00006353	sur-7		F01G12.2	gene	taxon:6239			
+WB	WBGene00006359	swp-1		B0336.9|CeSWAP	gene	taxon:6239			
+WB	WBGene00006363	syd-1		F35D2.5	gene	taxon:6239			
+WB	WBGene00006364	syd-2		F59F5.6|sad-2	gene	taxon:6239			
+WB	WBGene00006365	syg-1		K02E10.8	gene	taxon:6239			
+WB	WBGene00006366	sym-1		C44H4.3	gene	taxon:6239			
+WB	WBGene00006367	sym-2		ZK1067.6	gene	taxon:6239			
+WB	WBGene00006371	syx-3		F35C8.4|syn-1	gene	taxon:6239			
+WB	WBGene00006372	syx-2		F48F7.2|syn-2	gene	taxon:6239			
+WB	WBGene00006373	syx-5		F55A11.2|syn-3	gene	taxon:6239			
+WB	WBGene00006374	syx-4		T01B11.3|syn-4	gene	taxon:6239			
+WB	WBGene00006375	syp-1		F26D2.2	gene	taxon:6239			
+WB	WBGene00006376	syp-2		C24G6.1	gene	taxon:6239			
+WB	WBGene00006377	syp-3		F39H2.4	gene	taxon:6239			
+WB	WBGene00006379	sys-1		T23D8.9	gene	taxon:6239			
+WB	WBGene00006380	tab-1		F31E8.3|ceh-29|mec-16	gene	taxon:6239			
+WB	WBGene00006381	tac-1		Y54E2A.3|2P40	gene	taxon:6239			
+WB	WBGene00006382	taf-1		W04A8.7|Y71A12B.b	gene	taxon:6239			
+WB	WBGene00006383	taf-2		Y37E11B.4	gene	taxon:6239			
+WB	WBGene00006384	taf-3		C11G6.1	gene	taxon:6239			
+WB	WBGene00006385	taf-4		R119.6	gene	taxon:6239			
+WB	WBGene00006386	taf-5		F30F8.8	gene	taxon:6239			
+WB	WBGene00006387	taf-6.1		W09B6.2	gene	taxon:6239			
+WB	WBGene00006388	taf-7.1		F54F7.1	gene	taxon:6239			
+WB	WBGene00006389	taf-7.2		Y111B2A.16	gene	taxon:6239			
+WB	WBGene00006390	taf-8		ZK1320.12	gene	taxon:6239			
+WB	WBGene00006391	taf-9		T12D8.7	gene	taxon:6239			
+WB	WBGene00006392	taf-10		K03B4.3	gene	taxon:6239			
+WB	WBGene00006393	taf-11.1		F48D6.1	gene	taxon:6239			
+WB	WBGene00006394	taf-11.2		K10D3.3	gene	taxon:6239			
+WB	WBGene00006395	taf-11.3		F43D9.5	gene	taxon:6239			
+WB	WBGene00006396	taf-12		Y56A3A.4	gene	taxon:6239			
+WB	WBGene00006397	taf-13		C14A4.10	gene	taxon:6239			
+WB	WBGene00006402	fut-3		F59E12.13|ceft-4|tag-8	gene	taxon:6239			
+WB	WBGene00006404	tag-10		C31C9.1	gene	taxon:6239			
+WB	WBGene00006405	itsn-1		Y116A8C.36|tag-11	gene	taxon:6239			
+WB	WBGene00006406	srgp-1		F12F6.5|tag-13	gene	taxon:6239			
+WB	WBGene00006407	lim-9		F25H5.1|tag-15	gene	taxon:6239			
+WB	WBGene00006409	hdl-2		C09G9.4|tag-19	gene	taxon:6239			
+WB	WBGene00006410	nck-1		ZK470.5|tag-22	gene	taxon:6239			
+WB	WBGene00006411	octr-1		F14D12.6|tag-24	gene	taxon:6239			
+WB	WBGene00006412	nlg-1		C40C9.5|cest-14|tag-27	gene	taxon:6239			
+WB	WBGene00006414	raga-1		T24F1.1|tag-29	gene	taxon:6239			
+WB	WBGene00006415	tag-30		F38H4.7	gene	taxon:6239			
+WB	WBGene00006416	sams-5		T13A10.11|tag-32	gene	taxon:6239			
+WB	WBGene00006418	spl-2		B0222.4|tag-38	gene	taxon:6239			
+WB	WBGene00006419	oac-39		R02C2.3|tag-40	gene	taxon:6239			
+WB	WBGene00006423	asd-2		T21G5.5|let-529|star-2|tag-44	gene	taxon:6239			
+WB	WBGene00006424	ctbp-1		F49E10.5|tag-45	gene	taxon:6239			
+WB	WBGene00006428	tkr-3		AC7.1|tag-49	gene	taxon:6239			
+WB	WBGene00006431	tag-52		C02F12.4	gene	taxon:6239			
+WB	WBGene00006432	atrn-1		F33C8.1|tag-53	gene	taxon:6239			
+WB	WBGene00006433	sdhb-1		F42A8.2|tag-55	gene	taxon:6239			
+WB	WBGene00006434	prdx-2		F09E5.15|ceprx2|tag-56	gene	taxon:6239			
+WB	WBGene00006435	stdh-4		F25G6.5|tag-57	gene	taxon:6239			
+WB	WBGene00006436	ttn-1		W06H8.8|tag-7|tag-58|tag-211|Y38B5A.a|Y38B5A.b	gene	taxon:6239			
+WB	WBGene00006437	mrck-1		K08B12.5|tag-59	gene	taxon:6239			
+WB	WBGene00006438	nrfl-1		C01F6.6|mpz-2|tag-60	gene	taxon:6239			
+WB	WBGene00006439	ant-1.1		T27E9.1|tag-61|wan-1	gene	taxon:6239			
+WB	WBGene00006442	tag-65		F58G11.5|scaf-6	gene	taxon:6239			
+WB	WBGene00006443	pak-2		C45B11.1|pak-4|tag-66	gene	taxon:6239			
+WB	WBGene00006444	shn-1		C33B4.3|tag-67	gene	taxon:6239			
+WB	WBGene00006445	tag-68		F37D6.6|F37D6.a	gene	taxon:6239			
+WB	WBGene00006446	atx-3		F28F8.6|tag-70	gene	taxon:6239			
+WB	WBGene00006447	tag-72		C25A1.3	gene	taxon:6239			
+WB	WBGene00006448	glod-4		C16C10.10|tag-73	gene	taxon:6239			
+WB	WBGene00006449	alg-4		ZK757.3|tag-76	gene	taxon:6239			
+WB	WBGene00006450	tag-77		C28C12.10	gene	taxon:6239			
+WB	WBGene00006452	heh-1		R148.6|tag-79	gene	taxon:6239			
+WB	WBGene00006454	aex-4		T14G12.2|tag-81	gene	taxon:6239			
+WB	WBGene00006459	tag-89		H02I12.3	gene	taxon:6239			
+WB	WBGene00006460	ppm-1.A		F25D1.1|ppm-1|tag-93	gene	taxon:6239			
+WB	WBGene00006461	tag-96		M01D7.4	gene	taxon:6239			
+WB	WBGene00006462	svh-5		C33A11.4	gene	taxon:6239			
+WB	WBGene00006463	nduf-2.2		T26A5.3|tag-99	gene	taxon:6239			
+WB	WBGene00006465	fntb-1		F23B12.6|nde-4|tag-114	gene	taxon:6239			
+WB	WBGene00006467	magu-2		C01B7.4	gene	taxon:6239			
+WB	WBGene00006468	rhgf-1		F13E6.6|tag-118	gene	taxon:6239			
+WB	WBGene00006470	tag-120		F40F9.2	gene	taxon:6239			
+WB	WBGene00006471	nhr-233		Y32B12B.6|tag-122	gene	taxon:6239			
+WB	WBGene00006472	tag-123		F08F1.7	gene	taxon:6239			
+WB	WBGene00006473	tag-124		E02H1.3	gene	taxon:6239			
+WB	WBGene00006474	wdr-5.1		C14B1.4|swd-3|swd-3.1|tag-125|wdr-5	gene	taxon:6239			
+WB	WBGene00006475	tyra-3		M03F4.3|tag-126	gene	taxon:6239			
+WB	WBGene00006476	rhgf-2		T08H4.1|tag-127	gene	taxon:6239			
+WB	WBGene00006477	chup-1		ZK721.1|tag-130	gene	taxon:6239			
+WB	WBGene00006478	tag-131		H38K22.3	gene	taxon:6239			
+WB	WBGene00006479	tmbi-4		B0563.4|tag-132	gene	taxon:6239			
+WB	WBGene00006483	dgk-4		F42A9.1|tag-137	gene	taxon:6239			
+WB	WBGene00006484	tag-138		F08A8.6	gene	taxon:6239			
+WB	WBGene00006486	zipt-16		T11F9.2|tag-140|zipt-21	gene	taxon:6239			
+WB	WBGene00006487	zipt-17		C30H6.2|tag-141|zipt-22	gene	taxon:6239			
+WB	WBGene00006488	F56D6.6		tag-142	gene	taxon:6239			
+WB	WBGene00006489	zhit-3		ZK856.9|tag-143	gene	taxon:6239			
+WB	WBGene00006490	kdin-1		F36H1.2|tag-144	gene	taxon:6239			
+WB	WBGene00006491	acl-3		ZK809.2|tag-145	gene	taxon:6239			
+WB	WBGene00006494	zipt-7.2		H13N06.5|hke-4.2|tag-148	gene	taxon:6239			
+WB	WBGene00006495	cpna-1		F31D5.3|tag-149	gene	taxon:6239			
+WB	WBGene00006496	cgef-1		C14A11.3|tag-150	gene	taxon:6239			
+WB	WBGene00006497	tag-151		F10G7.1	gene	taxon:6239			
+WB	WBGene00006498	ten-1		R13F6.4|mnm-5|tag-152	gene	taxon:6239			
+WB	WBGene00006499	tag-153		F44A2.1	gene	taxon:6239			
+WB	WBGene00006503	snx-3		W06D4.5|tag-157	gene	taxon:6239			
+WB	WBGene00006504	kcc-1		R13A1.2|tag-158	gene	taxon:6239			
+WB	WBGene00006505	lagr-1		Y6B3B.10	gene	taxon:6239			
+WB	WBGene00006508	tns-1		M01E11.7|tag-83|tag-163	gene	taxon:6239			
+WB	WBGene00006509	tag-164		Y76A2A.1	gene	taxon:6239			
+WB	WBGene00006510	mtrr-1		C01G6.6|tag-165	gene	taxon:6239			
+WB	WBGene00006512	abcf-1		F18E2.2|tag-167	gene	taxon:6239			
+WB	WBGene00006513	rimb-1		Y39A3CL.2|tag-168	gene	taxon:6239			
+WB	WBGene00006514	tdp-1		F44G4.4|tag-169	gene	taxon:6239			
+WB	WBGene00006515	txdc-9		C05D11.3|tag-170	gene	taxon:6239			
+WB	WBGene00006516	vps-16		C05D11.2|tag-171	gene	taxon:6239			
+WB	WBGene00006517	madd-3		E02H4.3|tag-172	gene	taxon:6239			
+WB	WBGene00006518	bckd-1B		F27D4.5|tag-173	gene	taxon:6239			
+WB	WBGene00006519	cox-6A		F54D8.2|tag-174	gene	taxon:6239			
+WB	WBGene00006520	egli-1		D2013.10|tag-175	gene	taxon:6239			
+WB	WBGene00006522	abcx-1		C56E6.1|tag-177	gene	taxon:6239			
+WB	WBGene00006523	tam-1		F26G5.9	gene	taxon:6239			
+WB	WBGene00006524	tap-1		C44H4.5	gene	taxon:6239			
+WB	WBGene00006525	tax-2		F36F2.5|nrf-7	gene	taxon:6239			
+WB	WBGene00006526	tax-4		ZC84.2	gene	taxon:6239			
+WB	WBGene00006527	tax-6		C02F4.2|cna-1|pph-3|pph2B-A	gene	taxon:6239			
+WB	WBGene00006528	tba-1		F26E4.8|TUBA3	gene	taxon:6239			
+WB	WBGene00006529	tba-2		C47B2.3|Alpha-tubulin|mel-45|TUBA4B	gene	taxon:6239			
+WB	WBGene00006530	tba-4		F44F4.11	gene	taxon:6239			
+WB	WBGene00006531	tba-5		F16D3.1|dyf-10	gene	taxon:6239			
+WB	WBGene00006532	tba-6		F32H2.9	gene	taxon:6239			
+WB	WBGene00006533	tba-7		T28D6.2	gene	taxon:6239			
+WB	WBGene00006534	tba-8		ZK899.4	gene	taxon:6239			
+WB	WBGene00006535	tba-9		F40F4.5	gene	taxon:6239			
+WB	WBGene00006536	tbb-1		K01G5.7|TUBB7	gene	taxon:6239			
+WB	WBGene00006537	tbb-2		C36E8.5|rot-2|TUBB8	gene	taxon:6239			
+WB	WBGene00006538	tbb-4		B0272.1	gene	taxon:6239			
+WB	WBGene00006539	tbb-6		T04H1.9	gene	taxon:6239			
+WB	WBGene00006540	tbg-1		F58A4.8|sas-3|TUBG	gene	taxon:6239			
+WB	WBGene00006541	tbh-1		H13N06.6	gene	taxon:6239			
+WB	WBGene00006542	tbp-1		T20B12.2|3H475|TBP	gene	taxon:6239			
+WB	WBGene00006543	tbx-2		F21H11.3|mab-22|sdf-13	gene	taxon:6239			
+WB	WBGene00006544	tbx-7		ZK328.8	gene	taxon:6239			
+WB	WBGene00006545	tbx-8		T07C4.2	gene	taxon:6239			
+WB	WBGene00006546	tbx-9		T07C4.6	gene	taxon:6239			
+WB	WBGene00006547	tbx-11		F40H6.4	gene	taxon:6239			
+WB	WBGene00006549	tbx-30		Y59E9AR.3	gene	taxon:6239			
+WB	WBGene00006550	tbx-31		C36C9.2	gene	taxon:6239			
+WB	WBGene00006551	tbx-32		ZK380.1	gene	taxon:6239			
+WB	WBGene00006552	tbx-33		Y66A7A.8	gene	taxon:6239			
+WB	WBGene00006553	tbx-34		Y47D3A.10	gene	taxon:6239			
+WB	WBGene00006554	tbx-35		ZK177.10	gene	taxon:6239			
+WB	WBGene00006555	tbx-36		ZK829.5	gene	taxon:6239			
+WB	WBGene00006556	tbx-37		Y47D3A.12	gene	taxon:6239			
+WB	WBGene00006557	tbx-38		C24H11.3	gene	taxon:6239			
+WB	WBGene00006558	tbx-39		Y73F8A.16	gene	taxon:6239			
+WB	WBGene00006559	tbx-40		Y73F8A.17	gene	taxon:6239			
+WB	WBGene00006560	tbx-41		T26C11.1	gene	taxon:6239			
+WB	WBGene00006561	tcl-2		Y38C1AA.4|Y38C1AA.g	gene	taxon:6239			
+WB	WBGene00006562	tdc-1		K01C8.3|adc-1	gene	taxon:6239			
+WB	WBGene00006563	teg-1		Y47D3A.27	gene	taxon:6239			
+WB	WBGene00006565	tfg-1		Y63D3A.5	gene	taxon:6239			
+WB	WBGene00006566	tgt-1		ZK829.6|tgt	gene	taxon:6239			
+WB	WBGene00006567	tgt-2		Y39B6A.35	gene	taxon:6239			
+WB	WBGene00006568	thk-1		Y43C5A.5	gene	taxon:6239			
+WB	WBGene00006570	tig-2		F39G3.8	gene	taxon:6239			
+WB	WBGene00006571	tim-1		Y75B8A.22|csg-5	gene	taxon:6239			
+WB	WBGene00006572	tin-9.1		C06G3.11|tim9a	gene	taxon:6239			
+WB	WBGene00006573	tin-10		Y66D12A.22|tim10	gene	taxon:6239			
+WB	WBGene00006574	tin-13		DY3.1|tim-13|tim13	gene	taxon:6239			
+WB	WBGene00006575	tir-1		F13B10.1|nsy-2	gene	taxon:6239			
+WB	WBGene00006576	tkr-1		C38C10.1	gene	taxon:6239			
+WB	WBGene00006577	tlf-1		F39H11.2	gene	taxon:6239			
+WB	WBGene00006578	tli-1		F25H2.1	gene	taxon:6239			
+WB	WBGene00006579	tlk-1		C07A9.3	gene	taxon:6239			
+WB	WBGene00006580	tlp-1		T23G4.1	gene	taxon:6239			
+WB	WBGene00006582	tmd-2		C08D8.2	gene	taxon:6239			
+WB	WBGene00006583	tnc-2		ZK673.7	gene	taxon:6239			
+WB	WBGene00006584	tni-1		F42E11.4	gene	taxon:6239			
+WB	WBGene00006585	tni-3		T20B3.2	gene	taxon:6239			
+WB	WBGene00006586	tni-4		W03F8.1|W03F8.b	gene	taxon:6239			
+WB	WBGene00006587	tnt-2		F53A9.10	gene	taxon:6239			
+WB	WBGene00006588	tnt-3		C14F5.3|esp-1	gene	taxon:6239			
+WB	WBGene00006589	tnt-4		T08B1.2	gene	taxon:6239			
+WB	WBGene00006590	toc-1		ZC395.3	gene	taxon:6239			
+WB	WBGene00006591	toh-1		T24A11.3|nas-26	gene	taxon:6239			
+WB	WBGene00006592	dpy-31		R151.5|nas-35|toh-2	gene	taxon:6239			
+WB	WBGene00006593	tol-1		C07F11.1|C07F11.a|C07F11.b	gene	taxon:6239			
+WB	WBGene00006594	tom-1		M01A10.2|tag-23|tomo-1	gene	taxon:6239			
+WB	WBGene00006595	top-1		M01E5.5|DNA topoisomerase I	gene	taxon:6239			
+WB	WBGene00006596	top-3		Y56A3A.27|TOP3|Y56A3A	gene	taxon:6239			
+WB	WBGene00006597	tor-1		Y37A1B.12|dyt-2	gene	taxon:6239			
+WB	WBGene00006598	tor-2		Y37A1B.13|dyt-1	gene	taxon:6239			
+WB	WBGene00006599	tpa-1		B0545.1|nipi-1|tpa-1A|tpa-1B	gene	taxon:6239			
+WB	WBGene00006600	tph-1		ZK1290.2	gene	taxon:6239			
+WB	WBGene00006601	tpi-1		Y17G7B.7|TPI	gene	taxon:6239			
+WB	WBGene00006602	tps-1		ZK54.2|tag-25	gene	taxon:6239			
+WB	WBGene00006603	tps-2		F19H8.1	gene	taxon:6239			
+WB	WBGene00006604	tra-1		Y47D3A.6|her-2	gene	taxon:6239			
+WB	WBGene00006605	tra-2		C15F1.3	gene	taxon:6239			
+WB	WBGene00006606	tra-3		LLC1.1|clp-5	gene	taxon:6239			
+WB	WBGene00006607	tre-1		F57B10.7|tag-36|tre1	gene	taxon:6239			
+WB	WBGene00006608	tre-2		T05A12.2|tre2	gene	taxon:6239			
+WB	WBGene00006609	tre-3		W05E10.4|tre3	gene	taxon:6239			
+WB	WBGene00006610	tre-4		F15A2.2	gene	taxon:6239			
+WB	WBGene00006611	tre-5		C23H3.7|tre5	gene	taxon:6239			
+WB	WBGene00006612	trf-1		F45G2.6	gene	taxon:6239			
+WB	WBGene00006613	trm-1		ZC376.5|Trm1	gene	taxon:6239			
+WB	WBGene00006614	trp-1		ZC21.2|strpc1	gene	taxon:6239			
+WB	WBGene00006615	trp-2		R06B10.4|strpc2	gene	taxon:6239			
+WB	WBGene00006616	trp-4		Y71A12B.4|Y71A12B.e	gene	taxon:6239			
+WB	WBGene00006617	tars-1		C47D12.6|trs-1	gene	taxon:6239			
+WB	WBGene00006618	trt-1		DY3.4	gene	taxon:6239			
+WB	WBGene00006619	try-1		ZK546.15	gene	taxon:6239			
+WB	WBGene00006620	svh-1		C07G1.1|try-2	gene	taxon:6239			
+WB	WBGene00006621	try-3		C43G2.5	gene	taxon:6239			
+WB	WBGene00006622	try-4		F31D4.6	gene	taxon:6239			
+WB	WBGene00006623	try-5		K07B1.1	gene	taxon:6239			
+WB	WBGene00006624	try-6		F48A9.3	gene	taxon:6239			
+WB	WBGene00006625	try-7		ZC581.6	gene	taxon:6239			
+WB	WBGene00006626	tsn-1		F10G7.2	gene	taxon:6239			
+WB	WBGene00006627	tsp-1		C02F5.8	gene	taxon:6239			
+WB	WBGene00006628	tsp-2		C02F5.11	gene	taxon:6239			
+WB	WBGene00006629	tsp-3		Y39E4B.4	gene	taxon:6239			
+WB	WBGene00006630	tsp-4		F53B2.2	gene	taxon:6239			
+WB	WBGene00006631	tsp-5		Y45F10B.1	gene	taxon:6239			
+WB	WBGene00006632	tsp-6		C14A11.1	gene	taxon:6239			
+WB	WBGene00006633	tsp-7		T23D8.2	gene	taxon:6239			
+WB	WBGene00006634	tsp-8		F33C8.3	gene	taxon:6239			
+WB	WBGene00006635	tsp-9		C25G6.2	gene	taxon:6239			
+WB	WBGene00006636	tsp-10		T14B4.4	gene	taxon:6239			
+WB	WBGene00006637	tsp-11		B0563.2	gene	taxon:6239			
+WB	WBGene00006638	tsp-12		T14G10.6	gene	taxon:6239			
+WB	WBGene00006639	tsp-13		Y39B6A.6	gene	taxon:6239			
+WB	WBGene00006640	tsp-14		F39C12.3	gene	taxon:6239			
+WB	WBGene00006641	tsp-15		F53B6.1	gene	taxon:6239			
+WB	WBGene00006642	tsp-16		F01E11.4	gene	taxon:6239			
+WB	WBGene00006643	tsp-17		C02F12.1	gene	taxon:6239			
+WB	WBGene00006644	tsp-18		F59G1.2	gene	taxon:6239			
+WB	WBGene00006645	tsp-19		D2092.7	gene	taxon:6239			
+WB	WBGene00006646	tsp-20		B0198.1	gene	taxon:6239			
+WB	WBGene00006648	ttb-1		W03F9.5	gene	taxon:6239			
+WB	WBGene00006649	tth-1		F08F1.8	gene	taxon:6239			
+WB	WBGene00006652	ttx-1		Y113G7A.6|EH67|PR767	gene	taxon:6239			
+WB	WBGene00006654	ttx-3		C40H5.5	gene	taxon:6239			
+WB	WBGene00006655	tub-1		F10B5.4	gene	taxon:6239			
+WB	WBGene00006656	twk-1		F21C3.1|twk-7	gene	taxon:6239			
+WB	WBGene00006657	twk-2		T12C9.3	gene	taxon:6239			
+WB	WBGene00006658	twk-3		M110.2|twk-14|twk-25	gene	taxon:6239			
+WB	WBGene00006659	twk-4		ZK1067.5|twk-20	gene	taxon:6239			
+WB	WBGene00006660	twk-5		B0334.2|twk-1	gene	taxon:6239			
+WB	WBGene00006661	twk-6		F17C8.5|twk-5	gene	taxon:6239			
+WB	WBGene00006662	twk-7		F22B7.7|twk-8	gene	taxon:6239			
+WB	WBGene00006663	twk-8		ZC410.4|twk-19	gene	taxon:6239			
+WB	WBGene00006664	twk-9		ZK1251.8|twk-21	gene	taxon:6239			
+WB	WBGene00006665	twk-10		K04A8.4|twk-24	gene	taxon:6239			
+WB	WBGene00006666	twk-11		F20A1.7	gene	taxon:6239			
+WB	WBGene00006667	twk-12		F29F11.4|twk-9	gene	taxon:6239			
+WB	WBGene00006668	twk-13		R04F11.4|twk-15	gene	taxon:6239			
+WB	WBGene00006669	twk-14		K01D12.4|twk-12	gene	taxon:6239			
+WB	WBGene00006670	twk-16		F52E4.4	gene	taxon:6239			
+WB	WBGene00006671	twk-17		C44E12.3	gene	taxon:6239			
+WB	WBGene00006672	twk-18		C24A3.6|mah-2|twk-2|unc-110	gene	taxon:6239			
+WB	WBGene00006673	twk-20		C40C9.1	gene	taxon:6239			
+WB	WBGene00006674	twk-21		T01B4.1|twk-16	gene	taxon:6239			
+WB	WBGene00006675	twk-22		T01B4.2|twk-17	gene	taxon:6239			
+WB	WBGene00006676	twk-23		F19D8.1|twk-6	gene	taxon:6239			
+WB	WBGene00006677	twk-24		F55C5.3|twk-11	gene	taxon:6239			
+WB	WBGene00006678	twk-25		M04B2.5|twk-13	gene	taxon:6239			
+WB	WBGene00006679	twk-26		C33D12.3|twk-3	gene	taxon:6239			
+WB	WBGene00006680	twk-28		C52B9.6	gene	taxon:6239			
+WB	WBGene00006681	twk-29		F46A9.3	gene	taxon:6239			
+WB	WBGene00006682	twk-30		F36A2.4	gene	taxon:6239			
+WB	WBGene00006683	twk-31		Y47D3B.5	gene	taxon:6239			
+WB	WBGene00006684	twk-32		F53C11.6|twk-10	gene	taxon:6239			
+WB	WBGene00006685	twk-33		W06D12.5	gene	taxon:6239			
+WB	WBGene00006686	twk-34		K06B4.12	gene	taxon:6239			
+WB	WBGene00006687	twk-35		F31D4.7	gene	taxon:6239			
+WB	WBGene00006688	twk-36		R12G8.2	gene	taxon:6239			
+WB	WBGene00006689	twk-37		C48E7.9	gene	taxon:6239			
+WB	WBGene00006690	twk-39		C24H11.8	gene	taxon:6239			
+WB	WBGene00006691	twk-40		T28A8.1	gene	taxon:6239			
+WB	WBGene00006692	twk-42		W06D12.2	gene	taxon:6239			
+WB	WBGene00006693	twk-43		F32H5.7	gene	taxon:6239			
+WB	WBGene00006694	twk-44		Y71H9A.1	gene	taxon:6239			
+WB	WBGene00006695	twk-45		Y71H2AM.22	gene	taxon:6239			
+WB	WBGene00006696	twk-46		Y39B6A.19	gene	taxon:6239			
+WB	WBGene00006697	uaf-1		Y92C3B.2|Y92C3B.a|Y92C3B.b	gene	taxon:6239			
+WB	WBGene00006698	uaf-2		Y116A8C.35	gene	taxon:6239			
+WB	WBGene00006699	uba-1		C47E12.5|spe-32	gene	taxon:6239			
+WB	WBGene00006700	uba-2		W02A11.4	gene	taxon:6239			
+WB	WBGene00006701	ubc-1		C35B1.1	gene	taxon:6239			
+WB	WBGene00006702	ubc-3		Y71G12B.15	gene	taxon:6239			
+WB	WBGene00006703	ubc-6		D1022.1	gene	taxon:6239			
+WB	WBGene00006704	ubc-7		F58A4.10	gene	taxon:6239			
+WB	WBGene00006705	ubc-8		Y94H6A.6|Y94H6A.e	gene	taxon:6239			
+WB	WBGene00006706	ubc-9		F29B9.6|UBC9	gene	taxon:6239			
+WB	WBGene00006707	ubc-12		R09B3.4	gene	taxon:6239			
+WB	WBGene00006708	ubc-13		Y54G2A.31	gene	taxon:6239			
+WB	WBGene00006709	ubc-14		Y87G2A.9	gene	taxon:6239			
+WB	WBGene00006710	ubc-15		Y110A2AR.2|Y110A2AM.a|Y110A2AM.b	gene	taxon:6239			
+WB	WBGene00006711	ubc-16		Y54E5B.4	gene	taxon:6239			
+WB	WBGene00006712	ubc-17		B0403.2	gene	taxon:6239			
+WB	WBGene00006713	ubc-18		R01H2.6	gene	taxon:6239			
+WB	WBGene00006715	ubc-20		F40G9.3	gene	taxon:6239			
+WB	WBGene00006716	ubc-21		C06E2.3	gene	taxon:6239			
+WB	WBGene00006720	ubc-25		F25H2.8	gene	taxon:6239			
+WB	WBGene00006721	ubh-1		F46E10.8|F46E10.f	gene	taxon:6239			
+WB	WBGene00006722	ubh-2		Y40G12A.2	gene	taxon:6239			
+WB	WBGene00006723	ubh-3		Y40G12A.1	gene	taxon:6239			
+WB	WBGene00006724	ubh-4		C08B11.7	gene	taxon:6239			
+WB	WBGene00006725	ubl-1		H06I04.4	gene	taxon:6239			
+WB	WBGene00006726	ubl-5		F46F11.4	gene	taxon:6239			
+WB	WBGene00006727	ubq-1		F25B5.4	gene	taxon:6239			
+WB	WBGene00006728	ubq-2		ZK1010.1|rpl-40|rpl-40.1|ubiB	gene	taxon:6239			
+WB	WBGene00006729	ucp-4		K07B1.3|slc-25A27	gene	taxon:6239			
+WB	WBGene00006730	uev-1		F39B2.2|mms-2	gene	taxon:6239			
+WB	WBGene00006731	uev-2		F56D2.4	gene	taxon:6239			
+WB	WBGene00006732	uev-3		F26H9.7	gene	taxon:6239			
+WB	WBGene00006733	ufd-1		F19B6.2	gene	taxon:6239			
+WB	WBGene00006734	ufd-2		T05H10.5	gene	taxon:6239			
+WB	WBGene00006735	ula-1		C26E6.8	gene	taxon:6239			
+WB	WBGene00006736	ulp-1		T10F2.3	gene	taxon:6239			
+WB	WBGene00006737	ulp-2		Y38A8.3	gene	taxon:6239			
+WB	WBGene00006738	ulp-3		Y48A5A.2	gene	taxon:6239			
+WB	WBGene00006739	ulp-4		C41C4.6	gene	taxon:6239			
+WB	WBGene00006740	ulp-5		K02F2.4|K02F2.d|tofu-3	gene	taxon:6239			
+WB	WBGene00006741	unc-1		K03E6.5|unc-102	gene	taxon:6239			
+WB	WBGene00006742	unc-2		T02C5.5	gene	taxon:6239			
+WB	WBGene00006743	unc-3		Y16B4A.1	gene	taxon:6239			
+WB	WBGene00006744	unc-4		F26C11.2|ceh-4	gene	taxon:6239			
+WB	WBGene00006745	unc-5		B0273.4	gene	taxon:6239			
+WB	WBGene00006746	unc-6		F41C6.1|unc-106	gene	taxon:6239			
+WB	WBGene00006747	unc-7		R07D5.1|unc-12|unc-124	gene	taxon:6239			
+WB	WBGene00006748	unc-8		R13A1.4|unc-28	gene	taxon:6239			
+WB	WBGene00006749	unc-9		R12H7.1	gene	taxon:6239			
+WB	WBGene00006750	unc-10		T10A3.1|Rim|rim-1	gene	taxon:6239			
+WB	WBGene00006751	unc-11		C32E8.10|let-581	gene	taxon:6239			
+WB	WBGene00006752	unc-13		ZK524.2	gene	taxon:6239			
+WB	WBGene00006753	unc-14		K10D3.2	gene	taxon:6239			
+WB	WBGene00006754	unc-15		F07A5.7	gene	taxon:6239			
+WB	WBGene00006755	unc-16		ZK1098.10|egl-39	gene	taxon:6239			
+WB	WBGene00006756	unc-17		ZC416.8	gene	taxon:6239			
+WB	WBGene00006757	unc-18		F27D9.1|lan-2|unc-19	gene	taxon:6239			
+WB	WBGene00006759	unc-22		ZK617.1|twitchin|twitchin kinase	gene	taxon:6239			
+WB	WBGene00006760	unc-23		H14N18.1|bag-2|vab-4	gene	taxon:6239			
+WB	WBGene00006761	unc-24		F57H12.2	gene	taxon:6239			
+WB	WBGene00006762	unc-25		Y37D8A.23	gene	taxon:6239			
+WB	WBGene00006763	unc-26		JC8.10|unc-48	gene	taxon:6239			
+WB	WBGene00006764	unc-27		ZK721.2|tni-2|unc-99	gene	taxon:6239			
+WB	WBGene00006765	unc-29		T08G11.5|tmr-4|unc-21|unc-56	gene	taxon:6239			
+WB	WBGene00006766	unc-30		B0564.10	gene	taxon:6239			
+WB	WBGene00006767	unc-31		ZK897.1|egl-22	gene	taxon:6239			
+WB	WBGene00006768	unc-32		ZK637.8	gene	taxon:6239			
+WB	WBGene00006769	unc-33		Y37E11C.1	gene	taxon:6239			
+WB	WBGene00006770	unc-34		Y50D4C.1	gene	taxon:6239			
+WB	WBGene00006771	tln-1		Y71G12B.11|Ce Talin|unc-35	gene	taxon:6239			
+WB	WBGene00006772	unc-36		C50C3.9|eT1|unc-72	gene	taxon:6239			
+WB	WBGene00006773	unc-37		W02D3.9|ESG|let-76	gene	taxon:6239			
+WB	WBGene00006774	unc-38		F21F3.5|tmr-2	gene	taxon:6239			
+WB	WBGene00006775	unc-39		F56A12.1|ceh-35|mig-3	gene	taxon:6239			
+WB	WBGene00006776	unc-40		T19B4.7|madd-1|madd-40|unc-91	gene	taxon:6239			
+WB	WBGene00006777	unc-41		C27H6.1|apt-10|tcf-1	gene	taxon:6239			
+WB	WBGene00006778	unc-42		F58E6.10	gene	taxon:6239			
+WB	WBGene00006779	unc-43		K11E8.1|dec-8	gene	taxon:6239			
+WB	WBGene00006780	unc-44		B0350.2	gene	taxon:6239			
+WB	WBGene00006781	unc-45		F30H5.1	gene	taxon:6239			
+WB	WBGene00006782	unc-46		C04F5.3	gene	taxon:6239			
+WB	WBGene00006783	unc-47		T20G5.6	gene	taxon:6239			
+WB	WBGene00006784	unc-49		T21C12.1|unc-49A|unc-49B|unc-49C	gene	taxon:6239			
+WB	WBGene00006785	unc-50		T07A5.2	gene	taxon:6239			
+WB	WBGene00006786	unc-51		Y60A3A.1|atg-1|frs-2	gene	taxon:6239			
+WB	WBGene00006787	unc-52		ZC101.2	gene	taxon:6239			
+WB	WBGene00006788	unc-53		F45E10.1	gene	taxon:6239			
+WB	WBGene00006789	unc-54		F11C3.3|myo-4	gene	taxon:6239			
+WB	WBGene00006790	unc-55		F55D12.4	gene	taxon:6239			
+WB	WBGene00006791	unc-57		T04D1.3	gene	taxon:6239			
+WB	WBGene00006792	unc-58		T06H11.1|twk-18	gene	taxon:6239			
+WB	WBGene00006793	unc-59		W09C5.2|unc-88	gene	taxon:6239			
+WB	WBGene00006794	unc-60		C38C3.5|C38C3.f|unc-66	gene	taxon:6239			
+WB	WBGene00006795	unc-61		Y50E8A.4|Y50E8A.d	gene	taxon:6239			
+WB	WBGene00006796	unc-62		T28F12.2|ceh-25|let-328|nob-5	gene	taxon:6239			
+WB	WBGene00006797	unc-63		Y110A7A.3|lev-7|tmr-3	gene	taxon:6239			
+WB	WBGene00006798	unc-64		F56A8.7|syx-1	gene	taxon:6239			
+WB	WBGene00006799	unc-65			gene	taxon:6239			
+WB	WBGene00006801	unc-68		K11C4.5|kra-1|ryr-1	gene	taxon:6239			
+WB	WBGene00006802	unc-69		T07A5.6	gene	taxon:6239			
+WB	WBGene00006803	unc-70		K11C4.3|bgs-1	gene	taxon:6239			
+WB	WBGene00006804	unc-71		Y37D8A.13|adm-1|max-3	gene	taxon:6239			
+WB	WBGene00006805	unc-73		F55C7.7|let-509	gene	taxon:6239			
+WB	WBGene00006806	unc-74			gene	taxon:6239			
+WB	WBGene00006807	unc-75		C17D12.2	gene	taxon:6239			
+WB	WBGene00006808	unc-76		C01G10.11	gene	taxon:6239			
+WB	WBGene00006809	unc-77		C11D2.6|nca-1	gene	taxon:6239			
+WB	WBGene00006810	unc-78		C04F6.4	gene	taxon:6239			
+WB	WBGene00006811	unc-79		E03A3.6	gene	taxon:6239			
+WB	WBGene00006812	unc-80		F25C8.3	gene	taxon:6239			
+WB	WBGene00006814	unc-82		B0496.3	gene	taxon:6239			
+WB	WBGene00006815	unc-83		W01A11.3|CeGrip	gene	taxon:6239			
+WB	WBGene00006816	unc-84		F54B11.3	gene	taxon:6239			
+WB	WBGene00006817	unc-85		F10G7.3|asf-1	gene	taxon:6239			
+WB	WBGene00006818	unc-86		C30A5.7	gene	taxon:6239			
+WB	WBGene00006819	unc-87		F08B6.4	gene	taxon:6239			
+WB	WBGene00006820	unc-89		C09D1.1|phm-1	gene	taxon:6239			
+WB	WBGene00006822	unc-93		C46F11.1	gene	taxon:6239			
+WB	WBGene00006823	unc-94		C06A5.7|tmd-1|tropomodulin	gene	taxon:6239			
+WB	WBGene00006824	unc-95		Y105E8A.6|Y105E8E.e	gene	taxon:6239			
+WB	WBGene00006825	unc-96		F13C5.6|gei-10	gene	taxon:6239			
+WB	WBGene00006826	unc-97		F14D12.2	gene	taxon:6239			
+WB	WBGene00006827	unc-98		F08C6.7	gene	taxon:6239			
+WB	WBGene00006829	unc-101		K11D2.3	gene	taxon:6239			
+WB	WBGene00006830	unc-103		C30D11.1	gene	taxon:6239			
+WB	WBGene00006831	unc-104		C52E12.2|klp-1	gene	taxon:6239			
+WB	WBGene00006832	unc-105		C41C4.5	gene	taxon:6239			
+WB	WBGene00006833	unc-108		F53F10.4|rab-2|unc-67	gene	taxon:6239			
+WB	WBGene00006836	unc-112		C47E8.7	gene	taxon:6239			
+WB	WBGene00006839	unc-115		F09B9.2	gene	taxon:6239			
+WB	WBGene00006840	unc-116		R05D3.7|khc-1	gene	taxon:6239			
+WB	WBGene00006843	unc-119		M142.1|3L997	gene	taxon:6239			
+WB	WBGene00006844	unc-120		D1081.2	gene	taxon:6239			
+WB	WBGene00006845	unc-122		F11C3.2|cof-1|ofm-1	gene	taxon:6239			
+WB	WBGene00006852	unc-129		C53D6.2	gene	taxon:6239			
+WB	WBGene00006853	unc-130		C47G2.2	gene	taxon:6239			
+WB	WBGene00006856	usp-14		C13B4.2	gene	taxon:6239			
+WB	WBGene00006861	cal-5		C24H10.5|uvt-2	gene	taxon:6239			
+WB	WBGene00006862	pnk-4		C42D8.3|uvt-3	gene	taxon:6239			
+WB	WBGene00006863	gyg-1		F56B6.4|uvt-5	gene	taxon:6239			
+WB	WBGene00006864	npr-16		F56B6.5|uvt-6	gene	taxon:6239			
+WB	WBGene00006865	slcf-2		ZK563.1|uvt-7	gene	taxon:6239			
+WB	WBGene00006868	vab-1		M03A1.1	gene	taxon:6239			
+WB	WBGene00006869	vab-2		Y37E11AR.6|efn-1|Y37E11AR.a|Y37E11AR.f	gene	taxon:6239			
+WB	WBGene00006870	vab-3		F14F3.1|lin-20|mab-18|pax-6|sax-4	gene	taxon:6239			
+WB	WBGene00006873	vab-7		M142.4	gene	taxon:6239			
+WB	WBGene00006874	vab-8		K12F2.2|klp-5|unc-107	gene	taxon:6239			
+WB	WBGene00006875	vab-9		T22C8.8	gene	taxon:6239			
+WB	WBGene00006876	vab-10		ZK1151.1|mig-31	gene	taxon:6239			
+WB	WBGene00006881	vab-15		R07B1.1	gene	taxon:6239			
+WB	WBGene00006882	vab-19		T22D2.1|T22D2.a	gene	taxon:6239			
+WB	WBGene00006887	vav-1		C35B8.2	gene	taxon:6239			
+WB	WBGene00006888	vbh-1		Y54E10A.9	gene	taxon:6239			
+WB	WBGene00006889	pfd-3		T06G6.9|vbp-1	gene	taxon:6239			
+WB	WBGene00006890	vem-1		K07E3.8	gene	taxon:6239			
+WB	WBGene00006893	spon-1		F10E7.4|vab-13|ven-3	gene	taxon:6239			
+WB	WBGene00006894	ver-1		T17A3.1	gene	taxon:6239			
+WB	WBGene00006896	ver-3		F59F3.1	gene	taxon:6239			
+WB	WBGene00006897	ver-4		F59F3.5	gene	taxon:6239			
+WB	WBGene00006902	vet-6		F44F1.7	gene	taxon:6239			
+WB	WBGene00006910	vha-1		R10E11.8	gene	taxon:6239			
+WB	WBGene00006911	vha-2		R10E11.2	gene	taxon:6239			
+WB	WBGene00006912	vha-3		Y38F2AL.4	gene	taxon:6239			
+WB	WBGene00006913	vha-4		T01H3.1	gene	taxon:6239			
+WB	WBGene00006914	vha-5		F35H10.4|rdy-1	gene	taxon:6239			
+WB	WBGene00006915	vha-6		VW02B12L.1	gene	taxon:6239			
+WB	WBGene00006916	vha-7		C26H9A.1	gene	taxon:6239			
+WB	WBGene00006917	vha-8		C17H12.14|pes-6	gene	taxon:6239			
+WB	WBGene00006918	vha-9		ZK970.4	gene	taxon:6239			
+WB	WBGene00006919	vha-10		F46F11.5	gene	taxon:6239			
+WB	WBGene00006920	vha-11		Y38F2AL.3	gene	taxon:6239			
+WB	WBGene00006921	vha-12		F20B6.2	gene	taxon:6239			
+WB	WBGene00006922	vhl-1		F08G12.4	gene	taxon:6239			
+WB	WBGene00006923	vhp-1		F08B1.1|F09E5.f|nrf-2	gene	taxon:6239			
+WB	WBGene00006924	vig-1		F56D12.5	gene	taxon:6239			
+WB	WBGene00006925	vit-1		K09F5.2	gene	taxon:6239			
+WB	WBGene00006926	vit-2		C42D8.2	gene	taxon:6239			
+WB	WBGene00006927	vit-3		F59D8.1|F59D8.e|F59D8.f	gene	taxon:6239			
+WB	WBGene00006928	vit-4		F59D8.2|F59D8.a|F59D8.b	gene	taxon:6239			
+WB	WBGene00006929	vit-5		C04F6.1	gene	taxon:6239			
+WB	WBGene00006930	vit-6		K07H8.6	gene	taxon:6239			
+WB	WBGene00006931	vps-26		T20D3.7	gene	taxon:6239			
+WB	WBGene00006932	vps-34		B0025.1|let-512	gene	taxon:6239			
+WB	WBGene00006933	vps-35		F59G1.3	gene	taxon:6239			
+WB	WBGene00006934	vps-54		T21C9.2	gene	taxon:6239			
+WB	WBGene00006935	vars-1		ZC513.4|vrs-1	gene	taxon:6239			
+WB	WBGene00006936	glp-4		Y87G2A.5|vars-2|vrs-2	gene	taxon:6239			
+WB	WBGene00006937	wah-1		Y56A3A.32	gene	taxon:6239			
+WB	WBGene00006938	wee-1.1		F35H8.7	gene	taxon:6239			
+WB	WBGene00006940	wee-1.3		Y53C12A.1|spe-37	gene	taxon:6239			
+WB	WBGene00006941	wnk-1		C46C2.1	gene	taxon:6239			
+WB	WBGene00006942	wrk-1		F41D9.3	gene	taxon:6239			
+WB	WBGene00006943	wrm-1		B0336.1	gene	taxon:6239			
+WB	WBGene00006944	wrn-1		F18C5.2	gene	taxon:6239			
+WB	WBGene00006945	wars-1		Y80D3A.1|wrs-1	gene	taxon:6239			
+WB	WBGene00006946	prx-10		C34E10.4|wars-2|wrs-2	gene	taxon:6239			
+WB	WBGene00006947	wrt-1		ZK1290.12|ZK1290.5	gene	taxon:6239			
+WB	WBGene00006949	wrt-3		F38E11.7	gene	taxon:6239			
+WB	WBGene00006950	wrt-4		ZK678.5|ZK678	gene	taxon:6239			
+WB	WBGene00006951	wrt-5		W03D2.5|F35F11|W03D2	gene	taxon:6239			
+WB	WBGene00006952	wrt-6		ZK377.1|ZK377	gene	taxon:6239			
+WB	WBGene00006953	wrt-7		ZK1037.10|T26H8|ZK1037	gene	taxon:6239			
+WB	WBGene00006954	wrt-8		C29F3.2|cm20F10	gene	taxon:6239			
+WB	WBGene00006955	wrt-9		B0344.2	gene	taxon:6239			
+WB	WBGene00006957	wsp-1		C07G1.4	gene	taxon:6239			
+WB	WBGene00006958	wve-1		R06C1.3|gex-1	gene	taxon:6239			
+WB	WBGene00006959	xbp-1		R74.3	gene	taxon:6239			
+WB	WBGene00006960	xbx-1		F02D8.3	gene	taxon:6239			
+WB	WBGene00006961	xnp-1		B0041.7|slr-8	gene	taxon:6239			
+WB	WBGene00006962	xol-1		C18A11.5	gene	taxon:6239			
+WB	WBGene00006963	xpa-1		K07G5.2|rad-3	gene	taxon:6239			
+WB	WBGene00006964	xrn-2		Y48B6A.3	gene	taxon:6239			
+WB	WBGene00006965	xtr-1		F54F7.4	gene	taxon:6239			
+WB	WBGene00006966	xtr-2		F17A2.1	gene	taxon:6239			
+WB	WBGene00006967	yrn-1		F55G1.16|ceY RNA|Y RNA	gene	taxon:6239			
+WB	WBGene00006968	yars-2		K08F11.4|yrs-2	gene	taxon:6239			
+WB	WBGene00006970	zag-1		F28F9.1|zfh-1	gene	taxon:6239			
+WB	WBGene00006971	zak-1		R13F6.6	gene	taxon:6239			
+WB	WBGene00006974	zen-4		M03D4.1|klp-9	gene	taxon:6239			
+WB	WBGene00006975	zfp-1		F54F2.2|zpf-1	gene	taxon:6239			
+WB	WBGene00006976	zhp-3		K02B12.8	gene	taxon:6239			
+WB	WBGene00006977	zif-1		F59B2.6|tag-6	gene	taxon:6239			
+WB	WBGene00006978	zig-1		K10C3.3	gene	taxon:6239			
+WB	WBGene00006979	zig-2		F42F12.2	gene	taxon:6239			
+WB	WBGene00006980	zig-3		C14F5.2	gene	taxon:6239			
+WB	WBGene00006981	zig-4		C09C7.1	gene	taxon:6239			
+WB	WBGene00006982	zig-5		Y48A6A.1	gene	taxon:6239			
+WB	WBGene00006983	zig-6		T03G11.8	gene	taxon:6239			
+WB	WBGene00006984	zig-7		F54D7.4	gene	taxon:6239			
+WB	WBGene00006985	zig-8		Y39E4B.8	gene	taxon:6239			
+WB	WBGene00006986	zip-1		Y75B8A.35	gene	taxon:6239			
+WB	WBGene00006987	zmp-1		EGAP1.3	gene	taxon:6239			
+WB	WBGene00006988	zyg-1		F59E12.2	gene	taxon:6239			
+WB	WBGene00006993	zyg-8		Y79H2A.11|apo-1	gene	taxon:6239			
+WB	WBGene00006994	zyg-9		F22B5.7	gene	taxon:6239			
+WB	WBGene00006996	zyg-11		C08B11.1	gene	taxon:6239			
+WB	WBGene00006997	zyg-12		ZK546.1|ber-1	gene	taxon:6239			
+WB	WBGene00006999	zyx-1		F42G4.3	gene	taxon:6239			
+WB	WBGene00007000	tufm-1		Y71H2AM.23|EF-Tu1|Y71H2_378.a	gene	taxon:6239			
+WB	WBGene00007001	tufm-2		C43E11.4|EF-Tu2	gene	taxon:6239			
+WB	WBGene00007002	pre-1			gene	taxon:6239			
+WB	WBGene00007003	pre-7			gene	taxon:6239			
+WB	WBGene00007004	pre-33			gene	taxon:6239			
+WB	WBGene00007006	npr-3		C10C6.2|flp15-R	gene	taxon:6239			
+WB	WBGene00007007	mak-2		C44C8.6	gene	taxon:6239			
+WB	WBGene00007008	rfp-1		R05D3.4|tag-84	gene	taxon:6239			
+WB	WBGene00007009	wwp-1		Y65B4BR.4|CeWWP1|Y65B4B_11.a	gene	taxon:6239			
+WB	WBGene00007010	alx-1		R10E12.1|pqn-58|YNK1	gene	taxon:6239			
+WB	WBGene00007011	mdt-1.2		T23C6.1	gene	taxon:6239			
+WB	WBGene00007012	mdt-4		ZK546.13	gene	taxon:6239			
+WB	WBGene00007013	mdt-8		Y62F5A.1	gene	taxon:6239			
+WB	WBGene00007014	mdt-10		T09A5.6	gene	taxon:6239			
+WB	WBGene00007015	mdt-11		R144.9	gene	taxon:6239			
+WB	WBGene00007016	mdt-15		R12B2.5	gene	taxon:6239			
+WB	WBGene00007017	mdt-17		Y113G7B.18	gene	taxon:6239			
+WB	WBGene00007018	mdt-18		C55B7.9|let-604	gene	taxon:6239			
+WB	WBGene00007019	mdt-19		Y71H2B.6	gene	taxon:6239			
+WB	WBGene00007020	mdt-20		Y104H12D.1	gene	taxon:6239			
+WB	WBGene00007021	immp-1		C24H11.6	gene	taxon:6239			
+WB	WBGene00007022	mdt-22		ZK970.3|Surf-5	gene	taxon:6239			
+WB	WBGene00007023	mdt-27		T18H9.6	gene	taxon:6239			
+WB	WBGene00007024	plin-1		W01A8.1|mdt-28	gene	taxon:6239			
+WB	WBGene00007025	mdt-29		K08E3.8	gene	taxon:6239			
+WB	WBGene00007026	mdt-31		F32H2.2	gene	taxon:6239			
+WB	WBGene00007027	ssl-1		Y111B2A.22|pqn-81|Y111B2C.a|Y111B2C.b|Y111B2E.c	gene	taxon:6239			
+WB	WBGene00007028	trr-1		C47D12.1	gene	taxon:6239			
+WB	WBGene00007029	mys-1		VC5.4	gene	taxon:6239			
+WB	WBGene00007030	epc-1		Y111B2A.11|Y111B2G.a	gene	taxon:6239			
+WB	WBGene00007031	erf-1			gene	taxon:6239			
+WB	WBGene00007032	erf-2			gene	taxon:6239			
+WB	WBGene00007036	sod-5		ZK430.3	gene	taxon:6239			
+WB	WBGene00007041	tag-180		T24F1.6	gene	taxon:6239			
+WB	WBGene00007042	pbrm-1		C26C6.1|tag-185	gene	taxon:6239			
+WB	WBGene00007043	algn-10		T24D1.4|tag-179	gene	taxon:6239			
+WB	WBGene00007044	cpna-5		B0495.10|tag-178	gene	taxon:6239			
+WB	WBGene00007045	pgap-2		T04A8.12|tag-189	gene	taxon:6239			
+WB	WBGene00007047	wts-1		T20F10.1|tag-181	gene	taxon:6239			
+WB	WBGene00007048	nfx-1		C16A3.7|tag-182	gene	taxon:6239			
+WB	WBGene00007049	tag-191		C53A5.4	gene	taxon:6239			
+WB	WBGene00007053	chd-7		T04D1.4|tag-192	gene	taxon:6239			
+WB	WBGene00007054	scpl-1		B0379.4|tag-188	gene	taxon:6239			
+WB	WBGene00007055	tag-196		F41E6.6	gene	taxon:6239			
+WB	WBGene00007056	crn-7		F09G8.2|tag-198	gene	taxon:6239			
+WB	WBGene00007057	ant-1.2		W02D3.6|tag-194|wan-2	gene	taxon:6239			
+WB	WBGene00007058	dmd-6		F13G11.1|tag-193	gene	taxon:6239			
+WB	WBGene00007059	vps-52		F08C6.3|tag-197	gene	taxon:6239			
+WB	WBGene00007060	wht-6		T26A5.1|tag-200	gene	taxon:6239			
+WB	WBGene00007062	ebp-3		Y59A8B.9|tag-201	gene	taxon:6239			
+WB	WBGene00007064	rga-9		2RSSE.1	gene	taxon:6239			
+WB	WBGene00007065	pot-3		3R5.1	gene	taxon:6239			
+WB	WBGene00007067	4R79.2			gene	taxon:6239			
+WB	WBGene00007068	cTel55X.1		6R55.1	gene	taxon:6239			
+WB	WBGene00007070	ugt-49		AC3.2	gene	taxon:6239			
+WB	WBGene00007071	AC3.5			gene	taxon:6239			
+WB	WBGene00007072	ugt-1		AC3.7|dod-15	gene	taxon:6239			
+WB	WBGene00007073	ugt-2		AC3.8	gene	taxon:6239			
+WB	WBGene00007080	sfxn-1.1		AH6.2	gene	taxon:6239			
+WB	WBGene00007081	AH6.3			gene	taxon:6239			
+WB	WBGene00007083	AH10.2			gene	taxon:6239			
+WB	WBGene00007089	B0001.4			gene	taxon:6239			
+WB	WBGene00007091	eri-12		B0001.6	gene	taxon:6239			
+WB	WBGene00007096	B0024.3			gene	taxon:6239			
+WB	WBGene00007097	B0024.4			gene	taxon:6239			
+WB	WBGene00007099	trx-2		B0024.9	gene	taxon:6239			
+WB	WBGene00007101	B0024.11			gene	taxon:6239			
+WB	WBGene00007102	B0024.13			gene	taxon:6239			
+WB	WBGene00007103	crm-1		B0024.14	gene	taxon:6239			
+WB	WBGene00007104	B0024.15			gene	taxon:6239			
+WB	WBGene00007105	znf-207		B0035.1|bugz-1	gene	taxon:6239			
+WB	WBGene00007107	pfd-4		B0035.4|4M79|tag-317	gene	taxon:6239			
+WB	WBGene00007108	gspd-1		B0035.5	gene	taxon:6239			
+WB	WBGene00007109	edg-1		B0035.6	gene	taxon:6239			
+WB	WBGene00007110	leo-1		B0035.11	gene	taxon:6239			
+WB	WBGene00007111	sart-3		B0035.12	gene	taxon:6239			
+WB	WBGene00007112	B0035.13			gene	taxon:6239			
+WB	WBGene00007113	B0035.15			gene	taxon:6239			
+WB	WBGene00007114	mttu-1		B0035.16	gene	taxon:6239			
+WB	WBGene00007115	B0198.2			gene	taxon:6239			
+WB	WBGene00007116	B0198.3			gene	taxon:6239			
+WB	WBGene00007117	spe-42		B0240.2	gene	taxon:6239			
+WB	WBGene00007118	npp-22		B0240.4|ndc-1|NDC1	gene	taxon:6239			
+WB	WBGene00007119	calf-1		B0250.2	gene	taxon:6239			
+WB	WBGene00007122	B0250.5			gene	taxon:6239			
+WB	WBGene00007123	srbc-79		B0250.6	gene	taxon:6239			
+WB	WBGene00007126	dhcr-7		B0250.9	gene	taxon:6239			
+WB	WBGene00007127	srbc-78		B0250.10	gene	taxon:6239			
+WB	WBGene00007128	memb-1		B0272.2|gosr-2.1	gene	taxon:6239			
+WB	WBGene00007129	B0272.3			gene	taxon:6239			
+WB	WBGene00007130	B0272.4			gene	taxon:6239			
+WB	WBGene00007133	B0284.3			gene	taxon:6239			
+WB	WBGene00007135	cdk-12		B0285.1|cdtl-7	gene	taxon:6239			
+WB	WBGene00007137	lcmt-1		B0285.4	gene	taxon:6239			
+WB	WBGene00007138	B0285.6			gene	taxon:6239			
+WB	WBGene00007140	cyp-29A4		B0331.1	gene	taxon:6239			
+WB	WBGene00007141	pitr-4		B0331.2	gene	taxon:6239			
+WB	WBGene00007142	ttr-18		B0334.1	gene	taxon:6239			
+WB	WBGene00007143	hacl-1		B0334.3	gene	taxon:6239			
+WB	WBGene00007144	B0334.4			gene	taxon:6239			
+WB	WBGene00007145	B0334.5			gene	taxon:6239			
+WB	WBGene00007146	B0334.6			gene	taxon:6239			
+WB	WBGene00007150	acly-2		B0365.1	gene	taxon:6239			
+WB	WBGene00007152	clec-225		B0365.5	gene	taxon:6239			
+WB	WBGene00007153	clec-41		B0365.6	gene	taxon:6239			
+WB	WBGene00007154	dhc-3		B0365.7	gene	taxon:6239			
+WB	WBGene00007156	B0379.2			gene	taxon:6239			
+WB	WBGene00007167	rbg-3		B0393.2|tbc-5	gene	taxon:6239			
+WB	WBGene00007169	B0393.4			gene	taxon:6239			
+WB	WBGene00007170	B0393.5			gene	taxon:6239			
+WB	WBGene00007171	B0393.6			gene	taxon:6239			
+WB	WBGene00007173	B0393.8			gene	taxon:6239			
+WB	WBGene00007174	mboa-1		B0395.2	gene	taxon:6239			
+WB	WBGene00007175	B0395.3			gene	taxon:6239			
+WB	WBGene00007176	kcnl-1		B0399.1	gene	taxon:6239			
+WB	WBGene00007177	oac-1		B0399.2	gene	taxon:6239			
+WB	WBGene00007184	ctr-9		B0464.2|tpr-3	gene	taxon:6239			
+WB	WBGene00007187	tag-342		B0464.8	gene	taxon:6239			
+WB	WBGene00007188	B0464.9			gene	taxon:6239			
+WB	WBGene00007189	pigm-1		B0491.1	gene	taxon:6239			
+WB	WBGene00007191	lgc-20		B0491.4	gene	taxon:6239			
+WB	WBGene00007194	dph-5		B0491.7	gene	taxon:6239			
+WB	WBGene00007195	thoc-7		B0513.2	gene	taxon:6239			
+WB	WBGene00007197	prdh-1		B0513.5|prodh	gene	taxon:6239			
+WB	WBGene00007200	vamp-8		B0513.9	gene	taxon:6239			
+WB	WBGene00007201	exos-4.1		B0564.1	gene	taxon:6239			
+WB	WBGene00007202	B0564.2			gene	taxon:6239			
+WB	WBGene00007203	best-1		B0564.3	gene	taxon:6239			
+WB	WBGene00007204	best-2		B0564.4	gene	taxon:6239			
+WB	WBGene00007207	fask-1		B0564.7	gene	taxon:6239			
+WB	WBGene00007210	agmo-1		BE10.2|subs-1	gene	taxon:6239			
+WB	WBGene00007211	BE10.3			gene	taxon:6239			
+WB	WBGene00007213	C01A2.1			gene	taxon:6239			
+WB	WBGene00007214	C01A2.2			gene	taxon:6239			
+WB	WBGene00007215	oxa-1		C01A2.3	gene	taxon:6239			
+WB	WBGene00007216	C01A2.4			gene	taxon:6239			
+WB	WBGene00007217	tads-1		C01A2.5	gene	taxon:6239			
+WB	WBGene00007219	nlp-38		C01A2.7|mip-1	gene	taxon:6239			
+WB	WBGene00007222	C01F6.2			gene	taxon:6239			
+WB	WBGene00007224	C01G6.2			gene	taxon:6239			
+WB	WBGene00007226	C01G6.4			gene	taxon:6239			
+WB	WBGene00007227	C01G6.5			gene	taxon:6239			
+WB	WBGene00007228	acs-7		C01G6.7	gene	taxon:6239			
+WB	WBGene00007230	C01G10.1			gene	taxon:6239			
+WB	WBGene00007234	C01G10.7			gene	taxon:6239			
+WB	WBGene00007235	ahsa-1		C01G10.8	gene	taxon:6239			
+WB	WBGene00007236	C01G10.9			gene	taxon:6239			
+WB	WBGene00007237	C01G10.10			gene	taxon:6239			
+WB	WBGene00007239	C01G10.14			gene	taxon:6239			
+WB	WBGene00007242	madf-5		C01G12.1	gene	taxon:6239			
+WB	WBGene00007245	C01G12.5			gene	taxon:6239			
+WB	WBGene00007247	C01G12.7			gene	taxon:6239			
+WB	WBGene00007248	catp-4		C01G12.8	gene	taxon:6239			
+WB	WBGene00007249	C01G12.9			gene	taxon:6239			
+WB	WBGene00007252	mlt-2		C01H6.2	gene	taxon:6239			
+WB	WBGene00007254	C01H6.4			gene	taxon:6239			
+WB	WBGene00007255	cnnm-4		C01H6.6	gene	taxon:6239			
+WB	WBGene00007257	C01H6.8			gene	taxon:6239			
+WB	WBGene00007258	hasp-1		C01H6.9	gene	taxon:6239			
+WB	WBGene00007260	olrn-1		C02C6.2|nsy-6	gene	taxon:6239			
+WB	WBGene00007261	lron-3		C02C6.3	gene	taxon:6239			
+WB	WBGene00007266	C03A3.1			gene	taxon:6239			
+WB	WBGene00007267	C03A3.2			gene	taxon:6239			
+WB	WBGene00007269	C03C10.2			gene	taxon:6239			
+WB	WBGene00007270	rei-1		C03C10.4	gene	taxon:6239			
+WB	WBGene00007275	C03D6.1			gene	taxon:6239			
+WB	WBGene00007277	asfl-1		C03D6.5	gene	taxon:6239			
+WB	WBGene00007278	lab-1		C03D6.6	gene	taxon:6239			
+WB	WBGene00007279	C03E10.1			gene	taxon:6239			
+WB	WBGene00007281	C03E10.3			gene	taxon:6239			
+WB	WBGene00007282	clec-223		C03E10.5	gene	taxon:6239			
+WB	WBGene00007283	clec-222		C03E10.6	gene	taxon:6239			
+WB	WBGene00007284	C03H12.1			gene	taxon:6239			
+WB	WBGene00007285	C04A11.1			gene	taxon:6239			
+WB	WBGene00007287	gck-4		C04A11.3|tag-334	gene	taxon:6239			
+WB	WBGene00007291	lips-2		C04B4.3	gene	taxon:6239			
+WB	WBGene00007297	C04F12.1			gene	taxon:6239			
+WB	WBGene00007301	C04F12.7			gene	taxon:6239			
+WB	WBGene00007302	C04F12.8			gene	taxon:6239			
+WB	WBGene00007303	rnh-1.3		C04F12.9	gene	taxon:6239			
+WB	WBGene00007304	ttr-39		C04G2.1	gene	taxon:6239			
+WB	WBGene00007305	ttbk-5		C04G2.2	gene	taxon:6239			
+WB	WBGene00007307	spch-1		C04G2.8	gene	taxon:6239			
+WB	WBGene00007309	C04G2.10			gene	taxon:6239			
+WB	WBGene00007312	C04H5.1			gene	taxon:6239			
+WB	WBGene00007313	clec-147		C04H5.2	gene	taxon:6239			
+WB	WBGene00007314	gcy-29		C04H5.3	gene	taxon:6239			
+WB	WBGene00007316	nlp-41		C04H5.8	gene	taxon:6239			
+WB	WBGene00007317	C05A9.2			gene	taxon:6239			
+WB	WBGene00007320	C05B5.2			gene	taxon:6239			
+WB	WBGene00007324	C05B5.8			gene	taxon:6239			
+WB	WBGene00007325	C05C9.1			gene	taxon:6239			
+WB	WBGene00007328	pho-10		C05C10.1	gene	taxon:6239			
+WB	WBGene00007329	C05C10.2			gene	taxon:6239			
+WB	WBGene00007330	C05C10.3			gene	taxon:6239			
+WB	WBGene00007331	pho-11		C05C10.4	gene	taxon:6239			
+WB	WBGene00007332	C05C10.5			gene	taxon:6239			
+WB	WBGene00007333	ufd-3		C05C10.6	gene	taxon:6239			
+WB	WBGene00007334	C05C10.7			gene	taxon:6239			
+WB	WBGene00007335	C05C12.1			gene	taxon:6239			
+WB	WBGene00007336	C05C12.4			gene	taxon:6239			
+WB	WBGene00007338	C05C12.6			gene	taxon:6239			
+WB	WBGene00007339	C05D12.1			gene	taxon:6239			
+WB	WBGene00007346	frpr-2		C05E7.4	gene	taxon:6239			
+WB	WBGene00007347	C05G5.1			gene	taxon:6239			
+WB	WBGene00007349	C05G5.3			gene	taxon:6239			
+WB	WBGene00007350	sucl-1		C05G5.4	gene	taxon:6239			
+WB	WBGene00007351	C05G5.5			gene	taxon:6239			
+WB	WBGene00007352	cdc-48.1		C06A1.1|phi-31	gene	taxon:6239			
+WB	WBGene00007353	txt-13		C06A1.2	gene	taxon:6239			
+WB	WBGene00007354	C06A1.3			gene	taxon:6239			
+WB	WBGene00007355	rpb-6		C06A1.5	gene	taxon:6239			
+WB	WBGene00007357	C06A12.3			gene	taxon:6239			
+WB	WBGene00007360	C06B3.1			gene	taxon:6239			
+WB	WBGene00007361	oac-3		C06B3.2	gene	taxon:6239			
+WB	WBGene00007362	cyp-35C1		C06B3.3	gene	taxon:6239			
+WB	WBGene00007363	stdh-1		C06B3.4|dod-8	gene	taxon:6239			
+WB	WBGene00007364	stdh-3		C06B3.5	gene	taxon:6239			
+WB	WBGene00007367	nhr-150		C06B8.1	gene	taxon:6239			
+WB	WBGene00007369	C06B8.3			gene	taxon:6239			
+WB	WBGene00007370	str-264		C06B8.4	gene	taxon:6239			
+WB	WBGene00007372	C06B8.7			gene	taxon:6239			
+WB	WBGene00007374	C06C3.3			gene	taxon:6239			
+WB	WBGene00007378	lido-17		C06C3.8	gene	taxon:6239			
+WB	WBGene00007381	C06C6.7			gene	taxon:6239			
+WB	WBGene00007382	C06C6.8			gene	taxon:6239			
+WB	WBGene00007383	C06C6.9			gene	taxon:6239			
+WB	WBGene00007384	swt-3		C06G8.1	gene	taxon:6239			
+WB	WBGene00007385	atp-5		C06H2.1|phi-39	gene	taxon:6239			
+WB	WBGene00007386	C06H2.2			gene	taxon:6239			
+WB	WBGene00007387	jmjd-5		C06H2.3	gene	taxon:6239			
+WB	WBGene00007388	folt-1		C06H2.4|tag-330	gene	taxon:6239			
+WB	WBGene00007389	glb-3		C06H2.5	gene	taxon:6239			
+WB	WBGene00007390	lmtr-3		C06H2.6	gene	taxon:6239			
+WB	WBGene00007394	C06H5.6			gene	taxon:6239			
+WB	WBGene00007395	dcar-1		C06H5.7	gene	taxon:6239			
+WB	WBGene00007396	rnp-9		C07A4.1|tiar-3	gene	taxon:6239			
+WB	WBGene00007399	clec-162		C07A9.1	gene	taxon:6239			
+WB	WBGene00007400	bud-31		C07A9.2|3J784	gene	taxon:6239			
+WB	WBGene00007401	C07A9.5			gene	taxon:6239			
+WB	WBGene00007402	ugt-60		C07A9.6	gene	taxon:6239			
+WB	WBGene00007403	set-3		C07A9.7	gene	taxon:6239			
+WB	WBGene00007404	best-5		C07A9.8	gene	taxon:6239			
+WB	WBGene00007411	C07C7.1			gene	taxon:6239			
+WB	WBGene00007412	stip-1		C07E3.1	gene	taxon:6239			
+WB	WBGene00007413	pro-2		C07E3.2	gene	taxon:6239			
+WB	WBGene00007414	C07E3.3			gene	taxon:6239			
+WB	WBGene00007415	C07E3.4			gene	taxon:6239			
+WB	WBGene00007416	ceh-57		C07E3.5|ceh-52	gene	taxon:6239			
+WB	WBGene00007417	ceh-58		C07E3.6	gene	taxon:6239			
+WB	WBGene00007418	C07E3.8			gene	taxon:6239			
+WB	WBGene00007419	C07E3.9			gene	taxon:6239			
+WB	WBGene00007420	C07E3.10			gene	taxon:6239			
+WB	WBGene00007421	C07H4.1			gene	taxon:6239			
+WB	WBGene00007422	ugt-17		C08B6.1	gene	taxon:6239			
+WB	WBGene00007424	C08B6.3			gene	taxon:6239			
+WB	WBGene00007425	C08B6.4			gene	taxon:6239			
+WB	WBGene00007426	C08B6.5			gene	taxon:6239			
+WB	WBGene00007428	wdr-20		C08B6.7|hpo-22	gene	taxon:6239			
+WB	WBGene00007429	C08B6.8			gene	taxon:6239			
+WB	WBGene00007431	C08B6.11			gene	taxon:6239			
+WB	WBGene00007432	srxa-18		C08B6.12	gene	taxon:6239			
+WB	WBGene00007433	swsn-7		C08B11.3	gene	taxon:6239			
+WB	WBGene00007434	arp-6		C08B11.6	gene	taxon:6239			
+WB	WBGene00007435	algn-6		C08B11.8	gene	taxon:6239			
+WB	WBGene00007437	C08E8.1			gene	taxon:6239			
+WB	WBGene00007438	C08E8.2			gene	taxon:6239			
+WB	WBGene00007440	C08E8.4			gene	taxon:6239			
+WB	WBGene00007443	pfd-1		C08F8.1	gene	taxon:6239			
+WB	WBGene00007444	C08F8.2			gene	taxon:6239			
+WB	WBGene00007446	mboa-4		C08F8.4	gene	taxon:6239			
+WB	WBGene00007448	C08F8.6			gene	taxon:6239			
+WB	WBGene00007452	C08F11.3			gene	taxon:6239			
+WB	WBGene00007455	ugt-22		C08F11.8	gene	taxon:6239			
+WB	WBGene00007456	srz-29		C08F11.9	gene	taxon:6239			
+WB	WBGene00007458	ule-4		C08F11.11	gene	taxon:6239			
+WB	WBGene00007459	C08F11.12			gene	taxon:6239			
+WB	WBGene00007460	C08F11.13			gene	taxon:6239			
+WB	WBGene00007462	ctsa-3.2		C08H9.1	gene	taxon:6239			
+WB	WBGene00007463	vgln-1		C08H9.2	gene	taxon:6239			
+WB	WBGene00007464	algn-8		C08H9.3	gene	taxon:6239			
+WB	WBGene00007465	chil-1		C08H9.4	gene	taxon:6239			
+WB	WBGene00007466	chil-2		C08H9.6	gene	taxon:6239			
+WB	WBGene00007467	chil-3		C08H9.7	gene	taxon:6239			
+WB	WBGene00007469	chil-4		C08H9.10	gene	taxon:6239			
+WB	WBGene00007470	chil-5		C08H9.11	gene	taxon:6239			
+WB	WBGene00007471	chil-6		C08H9.12	gene	taxon:6239			
+WB	WBGene00007472	chil-7		C08H9.13	gene	taxon:6239			
+WB	WBGene00007473	chil-8		C08H9.14	gene	taxon:6239			
+WB	WBGene00007474	C08H9.15			gene	taxon:6239			
+WB	WBGene00007478	C09F9.1			gene	taxon:6239			
+WB	WBGene00007479	C09F9.2			gene	taxon:6239			
+WB	WBGene00007480	glna-1		C09F9.3	gene	taxon:6239			
+WB	WBGene00007482	C09F12.2			gene	taxon:6239			
+WB	WBGene00007483	C09F12.3			gene	taxon:6239			
+WB	WBGene00007486	C09G1.4			gene	taxon:6239			
+WB	WBGene00007488	dph-2		C09G5.2	gene	taxon:6239			
+WB	WBGene00007490	mks-5		C09G5.8|nphp-8	gene	taxon:6239			
+WB	WBGene00007493	npp-23		C09G9.2	gene	taxon:6239			
+WB	WBGene00007495	C09G9.5			gene	taxon:6239			
+WB	WBGene00007496	npax-4		C09G9.7	gene	taxon:6239			
+WB	WBGene00007500	nasp-1		C09H10.6|btr-1	gene	taxon:6239			
+WB	WBGene00007502	glb-4		C09H10.8	gene	taxon:6239			
+WB	WBGene00007505	pezo-1		C10C5.1|PIEZO	gene	taxon:6239			
+WB	WBGene00007506	fbxc-58		C10C5.2	gene	taxon:6239			
+WB	WBGene00007507	C10C5.3			gene	taxon:6239			
+WB	WBGene00007508	C10C5.4			gene	taxon:6239			
+WB	WBGene00007509	C10C5.5			gene	taxon:6239			
+WB	WBGene00007513	wht-2		C10C6.5	gene	taxon:6239			
+WB	WBGene00007514	catp-8		C10C6.6	gene	taxon:6239			
+WB	WBGene00007515	C10C6.7			gene	taxon:6239			
+WB	WBGene00007516	gpx-5		C11E4.1	gene	taxon:6239			
+WB	WBGene00007517	gpx-3		C11E4.2	gene	taxon:6239			
+WB	WBGene00007518	del-8		C11E4.3|tag-263	gene	taxon:6239			
+WB	WBGene00007520	C11E4.6			gene	taxon:6239			
+WB	WBGene00007522	C11E4.8			gene	taxon:6239			
+WB	WBGene00007523	C11G6.2			gene	taxon:6239			
+WB	WBGene00007525	C11G10.1			gene	taxon:6239			
+WB	WBGene00007528	C11H1.2			gene	taxon:6239			
+WB	WBGene00007529	C11H1.3			gene	taxon:6239			
+WB	WBGene00007533	cbl-1		C12C8.2	gene	taxon:6239			
+WB	WBGene00007534	fubl-1		C12D8.1|fubp-3.1	gene	taxon:6239			
+WB	WBGene00007535	ttr-19		C12D8.4	gene	taxon:6239			
+WB	WBGene00007536	daf-36		C12D8.5	gene	taxon:6239			
+WB	WBGene00007540	C12D8.13			gene	taxon:6239			
+WB	WBGene00007542	C12D8.15			gene	taxon:6239			
+WB	WBGene00007545	C13B4.1			gene	taxon:6239			
+WB	WBGene00007546	nhr-153		C13C4.1	gene	taxon:6239			
+WB	WBGene00007547	nhr-154		C13C4.2	gene	taxon:6239			
+WB	WBGene00007548	C13C4.4			gene	taxon:6239			
+WB	WBGene00007549	spin-1		C13C4.5	gene	taxon:6239			
+WB	WBGene00007550	C13C4.6			gene	taxon:6239			
+WB	WBGene00007554	pptr-2		C13G3.3	gene	taxon:6239			
+WB	WBGene00007555	dohh-1		C14A4.1|tag-242	gene	taxon:6239			
+WB	WBGene00007556	algn-9		C14A4.3	gene	taxon:6239			
+WB	WBGene00007557	C14A4.6			gene	taxon:6239			
+WB	WBGene00007558	C14A4.7			gene	taxon:6239			
+WB	WBGene00007559	C14A4.8			gene	taxon:6239			
+WB	WBGene00007561	ccm-3		C14A4.11	gene	taxon:6239			
+WB	WBGene00007562	C14A4.12			gene	taxon:6239			
+WB	WBGene00007563	C14A4.13			gene	taxon:6239			
+WB	WBGene00007564	mrps-22		C14A4.14	gene	taxon:6239			
+WB	WBGene00007565	clec-48		C14A6.1	gene	taxon:6239			
+WB	WBGene00007567	C14A6.3			gene	taxon:6239			
+WB	WBGene00007570	C14A6.6			gene	taxon:6239			
+WB	WBGene00007571	C14A6.7			gene	taxon:6239			
+WB	WBGene00007572	C14A6.8			gene	taxon:6239			
+WB	WBGene00007573	C14B1.2			gene	taxon:6239			
+WB	WBGene00007574	C14B1.3			gene	taxon:6239			
+WB	WBGene00007576	dph-1		C14B1.5	gene	taxon:6239			
+WB	WBGene00007577	nrde-1		C14B1.6	gene	taxon:6239			
+WB	WBGene00007581	alkb-8		C14B1.10	gene	taxon:6239			
+WB	WBGene00007584	C14C10.1			gene	taxon:6239			
+WB	WBGene00007586	ril-2		C14C10.3	gene	taxon:6239			
+WB	WBGene00007588	C14C10.5			gene	taxon:6239			
+WB	WBGene00007589	erg-28		C14C10.6	gene	taxon:6239			
+WB	WBGene00007590	ttr-43		C14C10.7	gene	taxon:6239			
+WB	WBGene00007591	zipt-13		C14H10.1	gene	taxon:6239			
+WB	WBGene00007593	C14H10.3			gene	taxon:6239			
+WB	WBGene00007594	lgc-23		C15A7.1	gene	taxon:6239			
+WB	WBGene00007595	C15A7.2			gene	taxon:6239			
+WB	WBGene00007598	C15A11.4			gene	taxon:6239			
+WB	WBGene00007599	C15A11.7			gene	taxon:6239			
+WB	WBGene00007600	C15C6.1			gene	taxon:6239			
+WB	WBGene00007603	popl-4		C15C6.4	gene	taxon:6239			
+WB	WBGene00007604	xbx-9		C15C8.1	gene	taxon:6239			
+WB	WBGene00007605	hrg-7		C15C8.3|asp-10	gene	taxon:6239			
+WB	WBGene00007606	C15C8.4			gene	taxon:6239			
+WB	WBGene00007607	C15C8.5			gene	taxon:6239			
+WB	WBGene00007608	C15C8.6			gene	taxon:6239			
+WB	WBGene00007610	C15H7.3			gene	taxon:6239			
+WB	WBGene00007613	C15H11.1			gene	taxon:6239			
+WB	WBGene00007614	gnrr-2		C15H11.2	gene	taxon:6239			
+WB	WBGene00007615	set-31		C15H11.5|tag-338	gene	taxon:6239			
+WB	WBGene00007616	rpoa-12		C15H11.8	gene	taxon:6239			
+WB	WBGene00007617	rrbs-1		C15H11.9	gene	taxon:6239			
+WB	WBGene00007618	C15H11.10			gene	taxon:6239			
+WB	WBGene00007619	C15H11.11			gene	taxon:6239			
+WB	WBGene00007620	ocrl-1		C16C2.3	gene	taxon:6239			
+WB	WBGene00007622	C16C10.1			gene	taxon:6239			
+WB	WBGene00007623	C16C10.2			gene	taxon:6239			
+WB	WBGene00007624	hrde-1		C16C10.3|wago-9	gene	taxon:6239			
+WB	WBGene00007626	rnf-121		C16C10.5	gene	taxon:6239			
+WB	WBGene00007627	ccdc-55		C16C10.6	gene	taxon:6239			
+WB	WBGene00007628	C16C10.8			gene	taxon:6239			
+WB	WBGene00007630	har-1		C16C10.11	gene	taxon:6239			
+WB	WBGene00007631	wht-3		C16C10.12	gene	taxon:6239			
+WB	WBGene00007633	C16D2.1			gene	taxon:6239			
+WB	WBGene00007635	npr-4		C16D6.2	gene	taxon:6239			
+WB	WBGene00007637	dhhc-7		C17D12.1	gene	taxon:6239			
+WB	WBGene00007638	C17D12.3			gene	taxon:6239			
+WB	WBGene00007643	marc-3		C17E4.3	gene	taxon:6239			
+WB	WBGene00007644	mjl-1		C17E4.4	gene	taxon:6239			
+WB	WBGene00007645	C17E4.6			gene	taxon:6239			
+WB	WBGene00007646	nkb-1		C17E4.9	gene	taxon:6239			
+WB	WBGene00007647	C17E4.10			gene	taxon:6239			
+WB	WBGene00007648	folr-1		C17G1.1	gene	taxon:6239			
+WB	WBGene00007649	C17G1.2			gene	taxon:6239			
+WB	WBGene00007650	ugt-23		C17G1.3	gene	taxon:6239			
+WB	WBGene00007651	nra-3		C17G1.4	gene	taxon:6239			
+WB	WBGene00007653	cysl-1		C17G1.7	gene	taxon:6239			
+WB	WBGene00007659	pals-5		C17H1.6	gene	taxon:6239			
+WB	WBGene00007664	seb-3		C18B12.2|secr-2	gene	taxon:6239			
+WB	WBGene00007666	C18B12.4			gene	taxon:6239			
+WB	WBGene00007668	C18B12.6			gene	taxon:6239			
+WB	WBGene00007669	C18D1.2			gene	taxon:6239			
+WB	WBGene00007670	stg-1		C18D1.4	gene	taxon:6239			
+WB	WBGene00007678	srz-90		C18D4.9	gene	taxon:6239			
+WB	WBGene00007679	C18D11.1			gene	taxon:6239			
+WB	WBGene00007680	maa-1		C18D11.2	gene	taxon:6239			
+WB	WBGene00007683	C18E9.2			gene	taxon:6239			
+WB	WBGene00007684	C18E9.4			gene	taxon:6239			
+WB	WBGene00007685	C18E9.5			gene	taxon:6239			
+WB	WBGene00007686	tomm-40		C18E9.6	gene	taxon:6239			
+WB	WBGene00007687	C18E9.7			gene	taxon:6239			
+WB	WBGene00007688	C18E9.8			gene	taxon:6239			
+WB	WBGene00007689	C18E9.9			gene	taxon:6239			
+WB	WBGene00007690	sftd-3		C18E9.10	gene	taxon:6239			
+WB	WBGene00007691	cest-8		C23H4.2	gene	taxon:6239			
+WB	WBGene00007692	cest-9.1		C23H4.3	gene	taxon:6239			
+WB	WBGene00007693	cest-7		C23H4.4	gene	taxon:6239			
+WB	WBGene00007694	C23H4.6			gene	taxon:6239			
+WB	WBGene00007695	cest-9.2		C23H4.7	gene	taxon:6239			
+WB	WBGene00007696	tram-1		C24F3.1	gene	taxon:6239			
+WB	WBGene00007697	C24F3.2			gene	taxon:6239			
+WB	WBGene00007698	qns-1		C24F3.4	gene	taxon:6239			
+WB	WBGene00007699	C24H11.1			gene	taxon:6239			
+WB	WBGene00007700	C24H11.2			gene	taxon:6239			
+WB	WBGene00007701	srd-74		C24H11.4	gene	taxon:6239			
+WB	WBGene00007702	C24H11.5			gene	taxon:6239			
+WB	WBGene00007703	gbf-1		C24H11.7|phi-34	gene	taxon:6239			
+WB	WBGene00007704	mdt-21		C24H11.9|CeSrb7	gene	taxon:6239			
+WB	WBGene00007705	C25A1.1			gene	taxon:6239			
+WB	WBGene00007707	fath-1		C25A1.5	gene	taxon:6239			
+WB	WBGene00007708	nola-3		C25A1.6	gene	taxon:6239			
+WB	WBGene00007709	clec-87		C25A1.8|cpg-5	gene	taxon:6239			
+WB	WBGene00007710	rsa-1		C25A1.9	gene	taxon:6239			
+WB	WBGene00007711	lid-1		C25A1.12	gene	taxon:6239			
+WB	WBGene00007712	mrpl-34		C25A1.13	gene	taxon:6239			
+WB	WBGene00007714	C25D7.1			gene	taxon:6239			
+WB	WBGene00007717	C25D7.5			gene	taxon:6239			
+WB	WBGene00007718	otub-1		C25D7.8	gene	taxon:6239			
+WB	WBGene00007720	C25D7.10			gene	taxon:6239			
+WB	WBGene00007722	C25D7.15			gene	taxon:6239			
+WB	WBGene00007723	C25F9.2			gene	taxon:6239			
+WB	WBGene00007724	C25F9.4			gene	taxon:6239			
+WB	WBGene00007725	C25F9.5			gene	taxon:6239			
+WB	WBGene00007729	clec-185		C25G4.1	gene	taxon:6239			
+WB	WBGene00007730	C25G4.2			gene	taxon:6239			
+WB	WBGene00007731	C25G4.3			gene	taxon:6239			
+WB	WBGene00007732	spe-44		C25G4.4|gmeb-4|tag-347	gene	taxon:6239			
+WB	WBGene00007733	smz-1		C25G4.6	gene	taxon:6239			
+WB	WBGene00007736	igdb-2		C25G4.10	gene	taxon:6239			
+WB	WBGene00007739	C26C6.4			gene	taxon:6239			
+WB	WBGene00007740	C26C6.6			gene	taxon:6239			
+WB	WBGene00007741	glb-8		C26C6.7	gene	taxon:6239			
+WB	WBGene00007743	C26C6.9			gene	taxon:6239			
+WB	WBGene00007744	C26D10.3			gene	taxon:6239			
+WB	WBGene00007745	C26D10.4			gene	taxon:6239			
+WB	WBGene00007749	ceh-79		C26E1.3	gene	taxon:6239			
+WB	WBGene00007750	syg-2		C26G2.1	gene	taxon:6239			
+WB	WBGene00007751	C26G2.2			gene	taxon:6239			
+WB	WBGene00007752	wdfy-3		C26H9A.2	gene	taxon:6239			
+WB	WBGene00007753	C27A7.1			gene	taxon:6239			
+WB	WBGene00007755	C27A7.3			gene	taxon:6239			
+WB	WBGene00007756	C27A7.5			gene	taxon:6239			
+WB	WBGene00007757	C27A7.6			gene	taxon:6239			
+WB	WBGene00007760	C27B7.2			gene	taxon:6239			
+WB	WBGene00007761	rad-26		C27B7.4	gene	taxon:6239			
+WB	WBGene00007762	C27B7.5			gene	taxon:6239			
+WB	WBGene00007763	C27B7.6			gene	taxon:6239			
+WB	WBGene00007764	C27B7.7			gene	taxon:6239			
+WB	WBGene00007768	C27C7.5			gene	taxon:6239			
+WB	WBGene00007770	nhr-259		C27C7.8	gene	taxon:6239			
+WB	WBGene00007772	egrh-1		C27C12.2	gene	taxon:6239			
+WB	WBGene00007774	C27C12.4			gene	taxon:6239			
+WB	WBGene00007775	acd-3		C27C12.5|tag-324	gene	taxon:6239			
+WB	WBGene00007776	dmd-4		C27C12.6|tag-248	gene	taxon:6239			
+WB	WBGene00007777	C27D8.1			gene	taxon:6239			
+WB	WBGene00007780	C27D8.4			gene	taxon:6239			
+WB	WBGene00007784	ruvb-1		C27H6.2	gene	taxon:6239			
+WB	WBGene00007785	tofu-1		C27H6.3	gene	taxon:6239			
+WB	WBGene00007786	rmd-2		C27H6.4	gene	taxon:6239			
+WB	WBGene00007791	C28A5.6			gene	taxon:6239			
+WB	WBGene00007799	nrx-1		C29A12.4	gene	taxon:6239			
+WB	WBGene00007801	trpa-1		C29E6.2	gene	taxon:6239			
+WB	WBGene00007802	cutl-27		C29E6.4	gene	taxon:6239			
+WB	WBGene00007805	clec-231		C29F3.4	gene	taxon:6239			
+WB	WBGene00007806	clec-230		C29F3.5	gene	taxon:6239			
+WB	WBGene00007807	C29F3.7			gene	taxon:6239			
+WB	WBGene00007808	best-7		C29F4.2	gene	taxon:6239			
+WB	WBGene00007809	C29F4.3			gene	taxon:6239			
+WB	WBGene00007812	C29F7.3			gene	taxon:6239			
+WB	WBGene00007813	jmjd-3.3		C29F7.6	gene	taxon:6239			
+WB	WBGene00007816	C30F2.2			gene	taxon:6239			
+WB	WBGene00007819	C30F2.5			gene	taxon:6239			
+WB	WBGene00007820	clec-199		C30H6.1|clec-200	gene	taxon:6239			
+WB	WBGene00007822	clec-202		C30H6.4	gene	taxon:6239			
+WB	WBGene00007824	dlat-2		C30H6.7	gene	taxon:6239			
+WB	WBGene00007826	C30H6.9			gene	taxon:6239			
+WB	WBGene00007829	oac-5		C31A11.1	gene	taxon:6239			
+WB	WBGene00007831	srbc-83		C31A11.3	gene	taxon:6239			
+WB	WBGene00007832	srbc-82		C31A11.4	gene	taxon:6239			
+WB	WBGene00007833	oac-6		C31A11.5	gene	taxon:6239			
+WB	WBGene00007834	srxa-7		C31A11.6	gene	taxon:6239			
+WB	WBGene00007835	oac-7		C31A11.7	gene	taxon:6239			
+WB	WBGene00007836	C31C9.2			gene	taxon:6239			
+WB	WBGene00007837	fbxa-167		C31C9.3	gene	taxon:6239			
+WB	WBGene00007847	C31E10.6			gene	taxon:6239			
+WB	WBGene00007848	cytb-5.1		C31E10.7|cytochrome b5	gene	taxon:6239			
+WB	WBGene00007849	tbc-19		C31E10.8	gene	taxon:6239			
+WB	WBGene00007850	C31G12.1			gene	taxon:6239			
+WB	WBGene00007851	clec-245		C31G12.2	gene	taxon:6239			
+WB	WBGene00007857	C31H5.6			gene	taxon:6239			
+WB	WBGene00007859	mrps-31		C32A3.2	gene	taxon:6239			
+WB	WBGene00007860	rilp-1		C32A3.3	gene	taxon:6239			
+WB	WBGene00007861	C32A9.1			gene	taxon:6239			
+WB	WBGene00007862	kvs-2		C32C4.1	gene	taxon:6239			
+WB	WBGene00007863	C32C4.3			gene	taxon:6239			
+WB	WBGene00007864	irg-6		C32H11.1	gene	taxon:6239			
+WB	WBGene00007865	srz-15		C32H11.2	gene	taxon:6239			
+WB	WBGene00007867	C32H11.4			gene	taxon:6239			
+WB	WBGene00007868	C32H11.5			gene	taxon:6239			
+WB	WBGene00007875	dod-24		C32H11.12	gene	taxon:6239			
+WB	WBGene00007877	nfki-1		C33A11.1|nbid-1	gene	taxon:6239			
+WB	WBGene00007878	C33A11.2			gene	taxon:6239			
+WB	WBGene00007880	C33A12.1			gene	taxon:6239			
+WB	WBGene00007881	nlp-35		C33A12.2	gene	taxon:6239			
+WB	WBGene00007885	ugt-21		C33A12.6	gene	taxon:6239			
+WB	WBGene00007888	ttr-9		C33A12.15	gene	taxon:6239			
+WB	WBGene00007897	clec-182		C33D9.2	gene	taxon:6239			
+WB	WBGene00007903	lgc-21		C33G3.3	gene	taxon:6239			
+WB	WBGene00007904	C33G3.4			gene	taxon:6239			
+WB	WBGene00007907	C34B4.2			gene	taxon:6239			
+WB	WBGene00007908	C34B4.3			gene	taxon:6239			
+WB	WBGene00007910	C34B4.5			gene	taxon:6239			
+WB	WBGene00007912	figo-1		C34B7.2	gene	taxon:6239			
+WB	WBGene00007913	cyp-36A1		C34B7.3	gene	taxon:6239			
+WB	WBGene00007914	mys-4		C34B7.4	gene	taxon:6239			
+WB	WBGene00007917	chdh-1		C34C6.4	gene	taxon:6239			
+WB	WBGene00007918	sphk-1		C34C6.5|tag-274	gene	taxon:6239			
+WB	WBGene00007919	cup-16		C34C6.7	gene	taxon:6239			
+WB	WBGene00007922	pph-6		C34C12.3	gene	taxon:6239			
+WB	WBGene00007924	rsu-1		C34C12.5	gene	taxon:6239			
+WB	WBGene00007926	C34C12.7			gene	taxon:6239			
+WB	WBGene00007927	C34C12.8			gene	taxon:6239			
+WB	WBGene00007929	dmd-10		C34D1.1|dmd-11	gene	taxon:6239			
+WB	WBGene00007931	C34D1.4			gene	taxon:6239			
+WB	WBGene00007932	zip-5		C34D1.5	gene	taxon:6239			
+WB	WBGene00007935	C34E11.2			gene	taxon:6239			
+WB	WBGene00007938	C34F6.1			gene	taxon:6239			
+WB	WBGene00007941	C34F6.7			gene	taxon:6239			
+WB	WBGene00007942	idh-2		C34F6.8	gene	taxon:6239			
+WB	WBGene00007944	C34F6.10			gene	taxon:6239			
+WB	WBGene00007945	C34F6.11			gene	taxon:6239			
+WB	WBGene00007946	ugt-33		C35A5.2	gene	taxon:6239			
+WB	WBGene00007947	C35A5.3			gene	taxon:6239			
+WB	WBGene00007948	C35A5.4			gene	taxon:6239			
+WB	WBGene00007949	C35A5.5			gene	taxon:6239			
+WB	WBGene00007950	C35A5.6			gene	taxon:6239			
+WB	WBGene00007951	dmsr-8		C35A5.7	gene	taxon:6239			
+WB	WBGene00007952	C35A5.8			gene	taxon:6239			
+WB	WBGene00007953	hda-11		C35A5.9|hdac-11	gene	taxon:6239			
+WB	WBGene00007954	gcp-2.2		C35C5.2	gene	taxon:6239			
+WB	WBGene00007955	selt-1.1		C35C5.3	gene	taxon:6239			
+WB	WBGene00007956	trpp-9		C35C5.6	gene	taxon:6239			
+WB	WBGene00007959	C35C5.10			gene	taxon:6239			
+WB	WBGene00007961	C35D6.4			gene	taxon:6239			
+WB	WBGene00007963	cyp-25A1		C36A4.1	gene	taxon:6239			
+WB	WBGene00007964	cyp-25A2		C36A4.2	gene	taxon:6239			
+WB	WBGene00007965	C36A4.4			gene	taxon:6239			
+WB	WBGene00007966	maph-1.3		C36A4.5	gene	taxon:6239			
+WB	WBGene00007967	cyp-25A4		C36A4.6	gene	taxon:6239			
+WB	WBGene00007969	acs-19		C36A4.9	gene	taxon:6239			
+WB	WBGene00007971	rpb-3		C36B1.3	gene	taxon:6239			
+WB	WBGene00007972	prp-4		C36B1.5	gene	taxon:6239			
+WB	WBGene00007973	C36B1.6			gene	taxon:6239			
+WB	WBGene00007974	dhfr-1		C36B1.7	gene	taxon:6239			
+WB	WBGene00007975	gls-1		C36B1.8	gene	taxon:6239			
+WB	WBGene00007976	C36B1.9			gene	taxon:6239			
+WB	WBGene00007977	gska-3		C36B1.10	gene	taxon:6239			
+WB	WBGene00007978	C36B1.11			gene	taxon:6239			
+WB	WBGene00007979	imp-1		C36B1.12	gene	taxon:6239			
+WB	WBGene00007981	glb-11		C36E8.2	gene	taxon:6239			
+WB	WBGene00007982	pxd-1		C36E8.3	gene	taxon:6239			
+WB	WBGene00007984	irx-1		C36F7.1	gene	taxon:6239			
+WB	WBGene00007986	C36F7.5			gene	taxon:6239			
+WB	WBGene00007987	C36H8.1			gene	taxon:6239			
+WB	WBGene00007988	best-8		C37A5.1	gene	taxon:6239			
+WB	WBGene00007991	C37A5.7			gene	taxon:6239			
+WB	WBGene00007992	fipr-24		C37A5.8	gene	taxon:6239			
+WB	WBGene00007993	idhb-1		C37E2.1	gene	taxon:6239			
+WB	WBGene00007994	C37E2.2			gene	taxon:6239			
+WB	WBGene00007995	C37E2.3			gene	taxon:6239			
+WB	WBGene00007997	sre-13		C38C6.4	gene	taxon:6239			
+WB	WBGene00008000	slc-17.2		C38C10.2	gene	taxon:6239			
+WB	WBGene00008002	nlp-48		C38C10.6	gene	taxon:6239			
+WB	WBGene00008003	enu-3.2		C38D4.1	gene	taxon:6239			
+WB	WBGene00008006	tag-325		C38D4.5	gene	taxon:6239			
+WB	WBGene00008008	metl-5		C38D4.9	gene	taxon:6239			
+WB	WBGene00008018	tbc-8		C38H2.1	gene	taxon:6239			
+WB	WBGene00008019	C38H2.2			gene	taxon:6239			
+WB	WBGene00008020	C38H2.3			gene	taxon:6239			
+WB	WBGene00008021	C39B10.1			gene	taxon:6239			
+WB	WBGene00008022	lgc-41		C39B10.2	gene	taxon:6239			
+WB	WBGene00008027	scl-5		C39E9.2	gene	taxon:6239			
+WB	WBGene00008031	C39E9.7			gene	taxon:6239			
+WB	WBGene00008033	spin-2		C39E9.10	gene	taxon:6239			
+WB	WBGene00008040	ttr-5		C40H1.5	gene	taxon:6239			
+WB	WBGene00008041	ufc-1		C40H1.6	gene	taxon:6239			
+WB	WBGene00008042	C40H1.7			gene	taxon:6239			
+WB	WBGene00008043	C40H1.8			gene	taxon:6239			
+WB	WBGene00008044	C40H1.9			gene	taxon:6239			
+WB	WBGene00008045	C40H5.2			gene	taxon:6239			
+WB	WBGene00008050	chst-1		C41C4.1	gene	taxon:6239			
+WB	WBGene00008052	ctns-1		C41C4.7|cup-17	gene	taxon:6239			
+WB	WBGene00008053	cdc-48.2		C41C4.8	gene	taxon:6239			
+WB	WBGene00008056	nhr-164		C41G6.5	gene	taxon:6239			
+WB	WBGene00008058	C41G6.12			gene	taxon:6239			
+WB	WBGene00008061	mina-1		C41G7.3	gene	taxon:6239			
+WB	WBGene00008065	npr-18		C43C3.2	gene	taxon:6239			
+WB	WBGene00008068	sdz-6		C43D7.5	gene	taxon:6239			
+WB	WBGene00008072	C43F9.4			gene	taxon:6239			
+WB	WBGene00008074	nkb-2		C43F9.6	gene	taxon:6239			
+WB	WBGene00008076	lgc-43		C43F9.9	gene	taxon:6239			
+WB	WBGene00008077	oac-8		C43F9.10	gene	taxon:6239			
+WB	WBGene00008078	vps-50		C44B9.1|vesa-1	gene	taxon:6239			
+WB	WBGene00008080	C44B9.3			gene	taxon:6239			
+WB	WBGene00008081	athp-1		C44B9.4	gene	taxon:6239			
+WB	WBGene00008084	C44C10.3			gene	taxon:6239			
+WB	WBGene00008085	smcl-1		C44C10.4	gene	taxon:6239			
+WB	WBGene00008088	C44C10.7			gene	taxon:6239			
+WB	WBGene00008089	C44C10.9			gene	taxon:6239			
+WB	WBGene00008090	C44C10.10			gene	taxon:6239			
+WB	WBGene00008092	gmeb-3		C44F1.2|attf-1	gene	taxon:6239			
+WB	WBGene00008093	lron-1		C44H4.1	gene	taxon:6239			
+WB	WBGene00008095	C44H4.6			gene	taxon:6239			
+WB	WBGene00008096	C44H4.8			gene	taxon:6239			
+WB	WBGene00008097	ugt-15		C44H9.1	gene	taxon:6239			
+WB	WBGene00008099	C44H9.4			gene	taxon:6239			
+WB	WBGene00008100	C44H9.5			gene	taxon:6239			
+WB	WBGene00008101	C44H9.6			gene	taxon:6239			
+WB	WBGene00008102	C44H9.7			gene	taxon:6239			
+WB	WBGene00008106	C45B11.5			gene	taxon:6239			
+WB	WBGene00008107	aspm-1		C45G3.1|tag-255	gene	taxon:6239			
+WB	WBGene00008110	C46C2.2			gene	taxon:6239			
+WB	WBGene00008117	gsr-1		C46F11.2	gene	taxon:6239			
+WB	WBGene00008119	C46F11.4			gene	taxon:6239			
+WB	WBGene00008120	C46F11.5			gene	taxon:6239			
+WB	WBGene00008121	C46F11.6			gene	taxon:6239			
+WB	WBGene00008122	C47A4.1			gene	taxon:6239			
+WB	WBGene00008123	ent-4		C47A4.2|ent-6	gene	taxon:6239			
+WB	WBGene00008124	C47A4.3			gene	taxon:6239			
+WB	WBGene00008126	sre-21		C47A10.4	gene	taxon:6239			
+WB	WBGene00008127	ddo-1		C47A10.5	gene	taxon:6239			
+WB	WBGene00008128	srab-12		C47A10.6	gene	taxon:6239			
+WB	WBGene00008131	C47B2.2			gene	taxon:6239			
+WB	WBGene00008132	gale-1		C47B2.6	gene	taxon:6239			
+WB	WBGene00008133	efsc-1		C47B2.7|selb-1	gene	taxon:6239			
+WB	WBGene00008134	C47B2.9			gene	taxon:6239			
+WB	WBGene00008136	C47D12.2			gene	taxon:6239			
+WB	WBGene00008137	sfxn-1.4		C47D12.3	gene	taxon:6239			
+WB	WBGene00008139	C47D12.5			gene	taxon:6239			
+WB	WBGene00008140	xpf-1		C47D12.8|him-9	gene	taxon:6239			
+WB	WBGene00008142	C47E8.3			gene	taxon:6239			
+WB	WBGene00008143	C47E8.4			gene	taxon:6239			
+WB	WBGene00008144	gasr-8		C47E8.6|xbx-10	gene	taxon:6239			
+WB	WBGene00008147	C47E12.2			gene	taxon:6239			
+WB	WBGene00008148	C47E12.3			gene	taxon:6239			
+WB	WBGene00008149	pyp-1		C47E12.4	gene	taxon:6239			
+WB	WBGene00008150	mam-2		C47E12.6	gene	taxon:6239			
+WB	WBGene00008151	rrp-1		C47E12.7	gene	taxon:6239			
+WB	WBGene00008153	C47E12.10			gene	taxon:6239			
+WB	WBGene00008155	C47E12.12			gene	taxon:6239			
+WB	WBGene00008158	nhr-165		C47F8.2	gene	taxon:6239			
+WB	WBGene00008159	C47F8.3			gene	taxon:6239			
+WB	WBGene00008160	glct-4		C47F8.4	gene	taxon:6239			
+WB	WBGene00008161	C47F8.5			gene	taxon:6239			
+WB	WBGene00008162	C47F8.6			gene	taxon:6239			
+WB	WBGene00008164	C47G2.3			gene	taxon:6239			
+WB	WBGene00008165	C47G2.4			gene	taxon:6239			
+WB	WBGene00008166	saps-1		C47G2.5	gene	taxon:6239			
+WB	WBGene00008167	acox-1.5		C48B4.1|acox-5|drd-51	gene	taxon:6239			
+WB	WBGene00008171	C48B4.8			gene	taxon:6239			
+WB	WBGene00008173	C48B4.10			gene	taxon:6239			
+WB	WBGene00008178	C48D1.5			gene	taxon:6239			
+WB	WBGene00008183	rin-1		C48G7.3|tag-333	gene	taxon:6239			
+WB	WBGene00008184	C49A1.1			gene	taxon:6239			
+WB	WBGene00008185	best-10		C49A1.2	gene	taxon:6239			
+WB	WBGene00008186	best-11		C49A1.3	gene	taxon:6239			
+WB	WBGene00008187	C49A1.5			gene	taxon:6239			
+WB	WBGene00008191	C49A1.10			gene	taxon:6239			
+WB	WBGene00008195	ceh-88		C49C3.5	gene	taxon:6239			
+WB	WBGene00008199	C49C3.9			gene	taxon:6239			
+WB	WBGene00008200	C49C3.10			gene	taxon:6239			
+WB	WBGene00008201	C49C3.11			gene	taxon:6239			
+WB	WBGene00008202	clec-197		C49C3.12	gene	taxon:6239			
+WB	WBGene00008203	clec-198		C49C3.13	gene	taxon:6239			
+WB	WBGene00008205	sams-1		C49F5.1|drop-4	gene	taxon:6239			
+WB	WBGene00008206	set-6		C49F5.2	gene	taxon:6239			
+WB	WBGene00008207	C49F5.3			gene	taxon:6239			
+WB	WBGene00008208	nhr-167		C49F5.4	gene	taxon:6239			
+WB	WBGene00008209	C49F5.5			gene	taxon:6239			
+WB	WBGene00008214	gem-1		C49F8.2	gene	taxon:6239			
+WB	WBGene00008216	mec-19		C49G9.1	gene	taxon:6239			
+WB	WBGene00008218	nasp-2		C50B6.2	gene	taxon:6239			
+WB	WBGene00008220	C50B6.7			gene	taxon:6239			
+WB	WBGene00008221	nhr-168		C50B6.8	gene	taxon:6239			
+WB	WBGene00008222	C50B6.9			gene	taxon:6239			
+WB	WBGene00008223	lgc-48		C50B6.11	gene	taxon:6239			
+WB	WBGene00008224	slrp-1		C50B8.1	gene	taxon:6239			
+WB	WBGene00008225	nuaf-1		C50B8.3	gene	taxon:6239			
+WB	WBGene00008226	C50B8.4			gene	taxon:6239			
+WB	WBGene00008227	C50B8.5			gene	taxon:6239			
+WB	WBGene00008228	C50B8.6			gene	taxon:6239			
+WB	WBGene00008230	pfk-1.2		C50F4.2|pfk-2	gene	taxon:6239			
+WB	WBGene00008231	tag-329		C50F4.3	gene	taxon:6239			
+WB	WBGene00008233	C50F4.8			gene	taxon:6239			
+WB	WBGene00008234	C50F4.9			gene	taxon:6239			
+WB	WBGene00008235	C50F4.10			gene	taxon:6239			
+WB	WBGene00008236	C50F4.12			gene	taxon:6239			
+WB	WBGene00008237	nstp-10		C50F4.14	gene	taxon:6239			
+WB	WBGene00008238	C50F4.16			gene	taxon:6239			
+WB	WBGene00008239	fshr-1		C50H2.1|lgr	gene	taxon:6239			
+WB	WBGene00008242	ceh-75		C50H2.6	gene	taxon:6239			
+WB	WBGene00008243	C50H2.7			gene	taxon:6239			
+WB	WBGene00008246	C50H2.13			gene	taxon:6239			
+WB	WBGene00008247	srsx-26		C51E3.1	gene	taxon:6239			
+WB	WBGene00008248	srsx-27		C51E3.2	gene	taxon:6239			
+WB	WBGene00008249	srsx-28		C51E3.3	gene	taxon:6239			
+WB	WBGene00008250	srsx-29		C51E3.4	gene	taxon:6239			
+WB	WBGene00008251	srsx-30		C51E3.5	gene	taxon:6239			
+WB	WBGene00008252	C51E3.6			gene	taxon:6239			
+WB	WBGene00008255	C51E3.10			gene	taxon:6239			
+WB	WBGene00008256	glb-12		C52A11.2	gene	taxon:6239			
+WB	WBGene00008258	mans-2		C52E4.5	gene	taxon:6239			
+WB	WBGene00008262	ril-1		C53A5.1|phi-60	gene	taxon:6239			
+WB	WBGene00008265	kcnl-4		C53A5.5	gene	taxon:6239			
+WB	WBGene00008266	C53A5.6			gene	taxon:6239			
+WB	WBGene00008268	srt-32		C53A5.10	gene	taxon:6239			
+WB	WBGene00008270	C53A5.13			gene	taxon:6239			
+WB	WBGene00008271	suex-2		C53B4.1	gene	taxon:6239			
+WB	WBGene00008273	C53B4.3			gene	taxon:6239			
+WB	WBGene00008274	pdzd-8		C53B4.4|txt-15	gene	taxon:6239			
+WB	WBGene00008275	nstp-1		C53B4.6|svh-9	gene	taxon:6239			
+WB	WBGene00008278	npr-10		C53C7.1	gene	taxon:6239			
+WB	WBGene00008279	C53C7.3			gene	taxon:6239			
+WB	WBGene00008280	acc-2		C53D6.3	gene	taxon:6239			
+WB	WBGene00008281	C53D6.4			gene	taxon:6239			
+WB	WBGene00008283	C53D6.6			gene	taxon:6239			
+WB	WBGene00008284	C53D6.7			gene	taxon:6239			
+WB	WBGene00008286	C54C6.4			gene	taxon:6239			
+WB	WBGene00008288	C54C6.6			gene	taxon:6239			
+WB	WBGene00008289	nhr-169		C54C8.1	gene	taxon:6239			
+WB	WBGene00008290	bgnt-1.8		C54C8.2	gene	taxon:6239			
+WB	WBGene00008291	C54C8.3			gene	taxon:6239			
+WB	WBGene00008292	C54C8.4			gene	taxon:6239			
+WB	WBGene00008293	glct-5		C54C8.5	gene	taxon:6239			
+WB	WBGene00008294	clec-11		C54C8.7	gene	taxon:6239			
+WB	WBGene00008295	nlp-39		C54C8.9	gene	taxon:6239			
+WB	WBGene00008296	cdr-2		C54D10.1	gene	taxon:6239			
+WB	WBGene00008297	cdr-3		C54D10.2|tag-183	gene	taxon:6239			
+WB	WBGene00008299	C54D10.4			gene	taxon:6239			
+WB	WBGene00008300	C54D10.5			gene	taxon:6239			
+WB	WBGene00008304	C54D10.10			gene	taxon:6239			
+WB	WBGene00008307	ncs-5		C54E10.2	gene	taxon:6239			
+WB	WBGene00008308	C54E10.3			gene	taxon:6239			
+WB	WBGene00008309	nhr-170		C54E10.5	gene	taxon:6239			
+WB	WBGene00008311	rskn-2		C54G4.1	gene	taxon:6239			
+WB	WBGene00008315	C54G4.5			gene	taxon:6239			
+WB	WBGene00008316	dod-18		C54G4.6	gene	taxon:6239			
+WB	WBGene00008320	slc-25A29		C54G10.4	gene	taxon:6239			
+WB	WBGene00008321	C55A1.1			gene	taxon:6239			
+WB	WBGene00008327	srz-44		C55A1.12	gene	taxon:6239			
+WB	WBGene00008330	C55A6.1			gene	taxon:6239			
+WB	WBGene00008331	ttll-5		C55A6.2	gene	taxon:6239			
+WB	WBGene00008332	C55A6.3			gene	taxon:6239			
+WB	WBGene00008333	C55A6.4			gene	taxon:6239			
+WB	WBGene00008334	sdz-8		C55A6.5	gene	taxon:6239			
+WB	WBGene00008335	C55A6.6			gene	taxon:6239			
+WB	WBGene00008336	C55A6.7			gene	taxon:6239			
+WB	WBGene00008338	pafo-1		C55A6.9	gene	taxon:6239			
+WB	WBGene00008339	C55A6.10			gene	taxon:6239			
+WB	WBGene00008340	C55A6.11			gene	taxon:6239			
+WB	WBGene00008341	ttr-44		C56A3.2	gene	taxon:6239			
+WB	WBGene00008342	frpr-5		C56A3.3	gene	taxon:6239			
+WB	WBGene00008343	C56A3.4			gene	taxon:6239			
+WB	WBGene00008345	C56A3.6			gene	taxon:6239			
+WB	WBGene00008346	C56A3.8			gene	taxon:6239			
+WB	WBGene00008348	C56G7.3			gene	taxon:6239			
+WB	WBGene00008354	gcsh-1		D1025.2	gene	taxon:6239			
+WB	WBGene00008361	ints-7		D1043.1	gene	taxon:6239			
+WB	WBGene00008362	cfim-2		D1046.1	gene	taxon:6239			
+WB	WBGene00008364	slc-25A26		D1046.3	gene	taxon:6239			
+WB	WBGene00008365	D1046.4			gene	taxon:6239			
+WB	WBGene00008366	tpra-1		D1046.5	gene	taxon:6239			
+WB	WBGene00008367	D1053.2			gene	taxon:6239			
+WB	WBGene00008369	D1053.4			gene	taxon:6239			
+WB	WBGene00008370	D1054.1			gene	taxon:6239			
+WB	WBGene00008371	D1054.3			gene	taxon:6239			
+WB	WBGene00008375	D1054.8			gene	taxon:6239			
+WB	WBGene00008378	ule-3		D1054.11	gene	taxon:6239			
+WB	WBGene00008379	secs-1		D1054.13	gene	taxon:6239			
+WB	WBGene00008380	prp-38		D1054.14	gene	taxon:6239			
+WB	WBGene00008382	D1081.4			gene	taxon:6239			
+WB	WBGene00008386	cdc-5L		D1081.8|phi-7	gene	taxon:6239			
+WB	WBGene00008387	zhp-2		D1081.9	gene	taxon:6239			
+WB	WBGene00008394	D1086.7			gene	taxon:6239			
+WB	WBGene00008397	D2005.1			gene	taxon:6239			
+WB	WBGene00008398	D2005.3			gene	taxon:6239			
+WB	WBGene00008400	drh-3		D2005.5|ekl-3	gene	taxon:6239			
+WB	WBGene00008401	D2005.6			gene	taxon:6239			
+WB	WBGene00008402	wdfy-2		D2013.2	gene	taxon:6239			
+WB	WBGene00008403	csa-1		D2013.3	gene	taxon:6239			
+WB	WBGene00008404	wbp-2		D2013.6	gene	taxon:6239			
+WB	WBGene00008405	ttll-12		D2013.9|set-7	gene	taxon:6239			
+WB	WBGene00008408	D2023.4			gene	taxon:6239			
+WB	WBGene00008409	mpst-1		D2023.5	gene	taxon:6239			
+WB	WBGene00008411	mans-1		D2030.1	gene	taxon:6239			
+WB	WBGene00008412	D2030.2			gene	taxon:6239			
+WB	WBGene00008413	D2030.3			gene	taxon:6239			
+WB	WBGene00008414	D2030.4			gene	taxon:6239			
+WB	WBGene00008415	mce-1		D2030.5	gene	taxon:6239			
+WB	WBGene00008419	wdr-23		D2030.9|xrep-1	gene	taxon:6239			
+WB	WBGene00008421	D2030.12			gene	taxon:6239			
+WB	WBGene00008422	ecps-1		D2045.2	gene	taxon:6239			
+WB	WBGene00008423	D2045.5			gene	taxon:6239			
+WB	WBGene00008424	D2045.7			gene	taxon:6239			
+WB	WBGene00008425	D2045.8			gene	taxon:6239			
+WB	WBGene00008427	atg-10		D2085.2	gene	taxon:6239			
+WB	WBGene00008428	eif-2Bepsilon		D2085.3	gene	taxon:6239			
+WB	WBGene00008429	etc-1		D2085.4	gene	taxon:6239			
+WB	WBGene00008430	hgap-2		D2085.5	gene	taxon:6239			
+WB	WBGene00008431	piga-1		D2085.6	gene	taxon:6239			
+WB	WBGene00008433	marc-2		D2089.2	gene	taxon:6239			
+WB	WBGene00008435	glna-2		DH11.1	gene	taxon:6239			
+WB	WBGene00008438	DH11.5			gene	taxon:6239			
+WB	WBGene00008439	mfb-1		DY3.6|tag-220	gene	taxon:6239			
+WB	WBGene00008440	DY3.8			gene	taxon:6239			
+WB	WBGene00008441	usp-50		E01B7.1|phi-33|Y59A8B.a|Y59A8B.b	gene	taxon:6239			
+WB	WBGene00008442	E01B7.2			gene	taxon:6239			
+WB	WBGene00008443	pde-3		E01F3.1	gene	taxon:6239			
+WB	WBGene00008449	E01G6.1			gene	taxon:6239			
+WB	WBGene00008451	cest-3		E01G6.3	gene	taxon:6239			
+WB	WBGene00008452	mrps-5		E02A10.1	gene	taxon:6239			
+WB	WBGene00008453	E02A10.3			gene	taxon:6239			
+WB	WBGene00008455	E02H1.1			gene	taxon:6239			
+WB	WBGene00008456	eral-1		E02H1.2	gene	taxon:6239			
+WB	WBGene00008458	E02H1.6			gene	taxon:6239			
+WB	WBGene00008459	mrpl-53		E02H1.8	gene	taxon:6239			
+WB	WBGene00008462	E02H4.4			gene	taxon:6239			
+WB	WBGene00008464	E02H4.6			gene	taxon:6239			
+WB	WBGene00008470	E03H4.2			gene	taxon:6239			
+WB	WBGene00008471	E03H4.3			gene	taxon:6239			
+WB	WBGene00008472	E03H4.4			gene	taxon:6239			
+WB	WBGene00008473	E03H4.5			gene	taxon:6239			
+WB	WBGene00008474	nhr-174		E03H4.6	gene	taxon:6239			
+WB	WBGene00008475	oac-13		E03H4.7	gene	taxon:6239			
+WB	WBGene00008476	E03H4.8			gene	taxon:6239			
+WB	WBGene00008477	clec-17		E03H4.10	gene	taxon:6239			
+WB	WBGene00008478	E03H4.11			gene	taxon:6239			
+WB	WBGene00008479	glct-2		E03H4.12	gene	taxon:6239			
+WB	WBGene00008480	eif-2A		E04D5.1|eIF2alpha	gene	taxon:6239			
+WB	WBGene00008481	E04D5.2			gene	taxon:6239			
+WB	WBGene00008482	cut-4		E04D5.3	gene	taxon:6239			
+WB	WBGene00008485	ugt-43		F01D4.1	gene	taxon:6239			
+WB	WBGene00008486	ugt-44		F01D4.2	gene	taxon:6239			
+WB	WBGene00008488	F01D4.5			gene	taxon:6239			
+WB	WBGene00008489	srb-17		F01D4.7	gene	taxon:6239			
+WB	WBGene00008491	bgnt-1.1		F01D4.9	gene	taxon:6239			
+WB	WBGene00008492	F01D5.1			gene	taxon:6239			
+WB	WBGene00008494	F01D5.3			gene	taxon:6239			
+WB	WBGene00008495	F01D5.5			gene	taxon:6239			
+WB	WBGene00008496	F01D5.6			gene	taxon:6239			
+WB	WBGene00008497	F01D5.7			gene	taxon:6239			
+WB	WBGene00008498	F01D5.8			gene	taxon:6239			
+WB	WBGene00008499	cyp-37A1		F01D5.9|drop-1	gene	taxon:6239			
+WB	WBGene00008500	F01D5.10			gene	taxon:6239			
+WB	WBGene00008502	skih-2		F01G4.3	gene	taxon:6239			
+WB	WBGene00008504	pigq-1		F01G4.5	gene	taxon:6239			
+WB	WBGene00008505	F01G4.6			gene	taxon:6239			
+WB	WBGene00008506	tkt-1		F01G10.1	gene	taxon:6239			
+WB	WBGene00008510	lipl-7		F01G10.7	gene	taxon:6239			
+WB	WBGene00008512	F01G10.10			gene	taxon:6239			
+WB	WBGene00008513	F02A9.1			gene	taxon:6239			
+WB	WBGene00008514	mrpl-44		F02A9.4	gene	taxon:6239			
+WB	WBGene00008515	F02C12.1			gene	taxon:6239			
+WB	WBGene00008516	F02C12.2			gene	taxon:6239			
+WB	WBGene00008519	cyp-13B1		F02C12.5	gene	taxon:6239			
+WB	WBGene00008521	F02D8.4			gene	taxon:6239			
+WB	WBGene00008522	nlp-59		F02D8.5	gene	taxon:6239			
+WB	WBGene00008526	F02D10.6			gene	taxon:6239			
+WB	WBGene00008527	set-8		F02D10.7	gene	taxon:6239			
+WB	WBGene00008528	F02E9.1			gene	taxon:6239			
+WB	WBGene00008531	F02E9.7			gene	taxon:6239			
+WB	WBGene00008532	dpt-1		F02E9.9	gene	taxon:6239			
+WB	WBGene00008538	sqrd-1		F02H6.5	gene	taxon:6239			
+WB	WBGene00008542	scav-6		F07A5.3	gene	taxon:6239			
+WB	WBGene00008546	gfat-1		F07A11.2	gene	taxon:6239			
+WB	WBGene00008547	F07A11.4			gene	taxon:6239			
+WB	WBGene00008548	F07A11.5			gene	taxon:6239			
+WB	WBGene00008549	din-1		F07A11.6	gene	taxon:6239			
+WB	WBGene00008550	F07B10.4			gene	taxon:6239			
+WB	WBGene00008551	lgc-36		F07B10.5	gene	taxon:6239			
+WB	WBGene00008552	srsx-31		F07B10.6	gene	taxon:6239			
+WB	WBGene00008553	F07C6.2			gene	taxon:6239			
+WB	WBGene00008555	F07C6.4			gene	taxon:6239			
+WB	WBGene00008556	F07D3.3			gene	taxon:6239			
+WB	WBGene00008558	F07H5.7			gene	taxon:6239			
+WB	WBGene00008561	F07H5.10			gene	taxon:6239			
+WB	WBGene00008564	acox-1.1		F08A8.1|acox-1	gene	taxon:6239			
+WB	WBGene00008565	acox-1.2		F08A8.2|acox-2|drd-100	gene	taxon:6239			
+WB	WBGene00008566	acox-1.3		F08A8.3|acox-3	gene	taxon:6239			
+WB	WBGene00008567	acox-1.4		F08A8.4|acox-4	gene	taxon:6239			
+WB	WBGene00008568	F08A8.5		CE2FT-2	gene	taxon:6239			
+WB	WBGene00008569	fbxa-101		F08A8.7	gene	taxon:6239			
+WB	WBGene00008570	kcnl-2		F08A10.1	gene	taxon:6239			
+WB	WBGene00008571	prmn-1		F08B12.1	gene	taxon:6239			
+WB	WBGene00008572	F08B12.4		XM26	gene	taxon:6239			
+WB	WBGene00008574	srbc-61		F08E10.2	gene	taxon:6239			
+WB	WBGene00008577	F08G2.5			gene	taxon:6239			
+WB	WBGene00008580	dsb-1		F08G5.1	gene	taxon:6239			
+WB	WBGene00008581	acl-13		F08G5.2	gene	taxon:6239			
+WB	WBGene00008583	ugt-65		F08G5.5	gene	taxon:6239			
+WB	WBGene00008584	irg-4		F08G5.6	gene	taxon:6239			
+WB	WBGene00008585	F08G12.1			gene	taxon:6239			
+WB	WBGene00008588	F08G12.5			gene	taxon:6239			
+WB	WBGene00008589	nlp-57		F08G12.8	gene	taxon:6239			
+WB	WBGene00008592	F08H9.4			gene	taxon:6239			
+WB	WBGene00008593	clec-227		F08H9.5	gene	taxon:6239			
+WB	WBGene00008594	clec-57		F08H9.6	gene	taxon:6239			
+WB	WBGene00008595	clec-56		F08H9.7	gene	taxon:6239			
+WB	WBGene00008596	clec-54		F08H9.8	gene	taxon:6239			
+WB	WBGene00008597	clec-55		F08H9.9	gene	taxon:6239			
+WB	WBGene00008598	spin-3		F09A5.1	gene	taxon:6239			
+WB	WBGene00008599	F09A5.2			gene	taxon:6239			
+WB	WBGene00008602	oac-14		F09B9.1	gene	taxon:6239			
+WB	WBGene00008606	dhhc-1		F09B12.2	gene	taxon:6239			
+WB	WBGene00008607	F09B12.3			gene	taxon:6239			
+WB	WBGene00008615	ifas-2		F09C6.1	gene	taxon:6239			
+WB	WBGene00008619	nhr-262		F09C6.8	gene	taxon:6239			
+WB	WBGene00008621	F09C8.1			gene	taxon:6239			
+WB	WBGene00008622	F09C8.2			gene	taxon:6239			
+WB	WBGene00008623	spe-43		F09E8.1	gene	taxon:6239			
+WB	WBGene00008624	crld-1		F09E8.2	gene	taxon:6239			
+WB	WBGene00008626	nlp-79		F09E8.8	gene	taxon:6239			
+WB	WBGene00008627	hpx-2		F09F3.5	gene	taxon:6239			
+WB	WBGene00008628	ttr-21		F09F3.6	gene	taxon:6239			
+WB	WBGene00008629	cpt-5		F09F3.9	gene	taxon:6239			
+WB	WBGene00008630	nhr-175		F09F3.10	gene	taxon:6239			
+WB	WBGene00008631	F10A3.1			gene	taxon:6239			
+WB	WBGene00008637	F10A3.12			gene	taxon:6239			
+WB	WBGene00008641	pch-2		F10B5.5	gene	taxon:6239			
+WB	WBGene00008642	ints-11		F10B5.8	gene	taxon:6239			
+WB	WBGene00008643	tmem-138		F10B5.9	gene	taxon:6239			
+WB	WBGene00008644	F10C2.3			gene	taxon:6239			
+WB	WBGene00008645	F10C2.4			gene	taxon:6239			
+WB	WBGene00008646	F10C2.5			gene	taxon:6239			
+WB	WBGene00008647	F10C2.7			gene	taxon:6239			
+WB	WBGene00008652	F10D11.6			gene	taxon:6239			
+WB	WBGene00008654	pfas-1		F10F2.2	gene	taxon:6239			
+WB	WBGene00008655	lips-3		F10F2.3	gene	taxon:6239			
+WB	WBGene00008656	lron-5		F10F2.4	gene	taxon:6239			
+WB	WBGene00008659	clec-151		F10F2.7	gene	taxon:6239			
+WB	WBGene00008660	clec-153		F10F2.8	gene	taxon:6239			
+WB	WBGene00008661	F10G8.1			gene	taxon:6239			
+WB	WBGene00008663	eak-6		F10G8.4	gene	taxon:6239			
+WB	WBGene00008664	nubp-1		F10G8.6	gene	taxon:6239			
+WB	WBGene00008665	ercc-1		F10G8.7	gene	taxon:6239			
+WB	WBGene00008667	F10G8.9			gene	taxon:6239			
+WB	WBGene00008670	eif-2Bdelta		F11A3.2	gene	taxon:6239			
+WB	WBGene00008671	F11A5.3			gene	taxon:6239			
+WB	WBGene00008672	F11A5.4			gene	taxon:6239			
+WB	WBGene00008673	F11A5.5			gene	taxon:6239			
+WB	WBGene00008676	oac-15		F11A5.8	gene	taxon:6239			
+WB	WBGene00008677	F11A5.9			gene	taxon:6239			
+WB	WBGene00008678	stdh-2		F11A5.12|dod-10	gene	taxon:6239			
+WB	WBGene00008679	F11A5.13			gene	taxon:6239			
+WB	WBGene00008680	F11A5.15			gene	taxon:6239			
+WB	WBGene00008681	scrm-4		F11A6.2|plsc-4	gene	taxon:6239			
+WB	WBGene00008682	lex-1		F11A10.1	gene	taxon:6239			
+WB	WBGene00008683	repo-1		F11A10.2	gene	taxon:6239			
+WB	WBGene00008684	mig-32		F11A10.3|tag-288	gene	taxon:6239			
+WB	WBGene00008685	mon-2		F11A10.4	gene	taxon:6239			
+WB	WBGene00008686	F11A10.5			gene	taxon:6239			
+WB	WBGene00008687	F11A10.6			gene	taxon:6239			
+WB	WBGene00008688	rbm-34		F11A10.7	gene	taxon:6239			
+WB	WBGene00008690	F11C1.1			gene	taxon:6239			
+WB	WBGene00008691	mff-1		F11C1.2	gene	taxon:6239			
+WB	WBGene00008692	scav-4		F11C1.3	gene	taxon:6239			
+WB	WBGene00008693	F11C1.4			gene	taxon:6239			
+WB	WBGene00008694	vwa-8		F11C1.5	gene	taxon:6239			
+WB	WBGene00008695	F11C3.1			gene	taxon:6239			
+WB	WBGene00008696	clec-255		F11D11.1	gene	taxon:6239			
+WB	WBGene00008698	F11D11.3			gene	taxon:6239			
+WB	WBGene00008700	clec-254		F11D11.5	gene	taxon:6239			
+WB	WBGene00008706	gba-3		F11E6.1	gene	taxon:6239			
+WB	WBGene00008709	F11E6.6			gene	taxon:6239			
+WB	WBGene00008711	F11E6.8			gene	taxon:6239			
+WB	WBGene00008713	F11E6.10			gene	taxon:6239			
+WB	WBGene00008714	F11F1.1			gene	taxon:6239			
+WB	WBGene00008719	ttr-52		F11F1.7	gene	taxon:6239			
+WB	WBGene00008722	F12F6.7			gene	taxon:6239			
+WB	WBGene00008724	F13A7.1			gene	taxon:6239			
+WB	WBGene00008726	F13A7.11			gene	taxon:6239			
+WB	WBGene00008727	F13A7.12			gene	taxon:6239			
+WB	WBGene00008728	sre-36		F13A7.13	gene	taxon:6239			
+WB	WBGene00008729	F13B12.1			gene	taxon:6239			
+WB	WBGene00008730	F13B12.2			gene	taxon:6239			
+WB	WBGene00008731	F13B12.3			gene	taxon:6239			
+WB	WBGene00008734	F13B12.7			gene	taxon:6239			
+WB	WBGene00008735	F13D2.1			gene	taxon:6239			
+WB	WBGene00008736	gnrr-6		F13D2.2	gene	taxon:6239			
+WB	WBGene00008737	gnrr-7		F13D2.3	gene	taxon:6239			
+WB	WBGene00008740	F13D12.5			gene	taxon:6239			
+WB	WBGene00008741	ctsa-1.2		F13D12.6	gene	taxon:6239			
+WB	WBGene00008742	F13D12.8			gene	taxon:6239			
+WB	WBGene00008743	F13D12.9			gene	taxon:6239			
+WB	WBGene00008744	F13D12.10			gene	taxon:6239			
+WB	WBGene00008746	F13E6.2			gene	taxon:6239			
+WB	WBGene00008747	phf-31		F13E6.3	gene	taxon:6239			
+WB	WBGene00008748	yap-1		F13E6.4	gene	taxon:6239			
+WB	WBGene00008749	plpp-1.3		F13E6.5	gene	taxon:6239			
+WB	WBGene00008750	nish-1		F13E9.1	gene	taxon:6239			
+WB	WBGene00008752	fipr-15		F13E9.3	gene	taxon:6239			
+WB	WBGene00008760	F13E9.11			gene	taxon:6239			
+WB	WBGene00008762	ztf-2		F13G3.1	gene	taxon:6239			
+WB	WBGene00008763	F13G3.3			gene	taxon:6239			
+WB	WBGene00008765	ttx-7		F13G3.5	gene	taxon:6239			
+WB	WBGene00008767	F13G3.7			gene	taxon:6239			
+WB	WBGene00008769	mrpl-13		F13G3.11	gene	taxon:6239			
+WB	WBGene00008772	irld-4		F13G11.2	gene	taxon:6239			
+WB	WBGene00008774	F13H10.3			gene	taxon:6239			
+WB	WBGene00008775	mogs-1		F13H10.4|agl-1	gene	taxon:6239			
+WB	WBGene00008776	F13H10.5			gene	taxon:6239			
+WB	WBGene00008777	F13H10.6			gene	taxon:6239			
+WB	WBGene00008778	nhr-264		F14A5.1	gene	taxon:6239			
+WB	WBGene00008779	F14B4.1			gene	taxon:6239			
+WB	WBGene00008780	hxk-1		F14B4.2	gene	taxon:6239			
+WB	WBGene00008781	rpoa-2		F14B4.3	gene	taxon:6239			
+WB	WBGene00008783	F14B6.2			gene	taxon:6239			
+WB	WBGene00008785	F14B6.4			gene	taxon:6239			
+WB	WBGene00008786	oac-16		F14B6.5	gene	taxon:6239			
+WB	WBGene00008787	F14B6.6			gene	taxon:6239			
+WB	WBGene00008793	F14D7.6			gene	taxon:6239			
+WB	WBGene00008795	F14D7.8			gene	taxon:6239			
+WB	WBGene00008796	F14D7.9			gene	taxon:6239			
+WB	WBGene00008799	F14E5.1			gene	taxon:6239			
+WB	WBGene00008800	F14E5.2			gene	taxon:6239			
+WB	WBGene00008801	acp-3		F14E5.3	gene	taxon:6239			
+WB	WBGene00008803	lips-10		F14E5.5	gene	taxon:6239			
+WB	WBGene00008804	acp-4		F14E5.6	gene	taxon:6239			
+WB	WBGene00008805	git-1		F14F3.2	gene	taxon:6239			
+WB	WBGene00008806	mboa-7		F14F3.3|tag-289	gene	taxon:6239			
+WB	WBGene00008808	ntr-2		F14F4.1	gene	taxon:6239			
+WB	WBGene00008809	cyp-13A11		F14F7.2	gene	taxon:6239			
+WB	WBGene00008810	cyp-13A12		F14F7.3	gene	taxon:6239			
+WB	WBGene00008811	F14F7.4			gene	taxon:6239			
+WB	WBGene00008812	F14F7.5			gene	taxon:6239			
+WB	WBGene00008814	srz-1		F14F8.3	gene	taxon:6239			
+WB	WBGene00008815	srz-103		F14F8.4	gene	taxon:6239			
+WB	WBGene00008818	srz-101		F14F8.12	gene	taxon:6239			
+WB	WBGene00008819	shw-1		F14F11.1	gene	taxon:6239			
+WB	WBGene00008820	nlp-55		F14F11.2	gene	taxon:6239			
+WB	WBGene00008821	best-12		F14H3.2	gene	taxon:6239			
+WB	WBGene00008829	cyp-35D1		F14H3.10	gene	taxon:6239			
+WB	WBGene00008830	nhr-176		F14H3.11	gene	taxon:6239			
+WB	WBGene00008831	F14H3.12			gene	taxon:6239			
+WB	WBGene00008832	obr-2		F14H8.1	gene	taxon:6239			
+WB	WBGene00008837	sre-38		F15A4.1|2M776	gene	taxon:6239			
+WB	WBGene00008839	sre-37		F15A4.3	gene	taxon:6239			
+WB	WBGene00008840	F15A4.5			gene	taxon:6239			
+WB	WBGene00008849	try-10		F15B9.5	gene	taxon:6239			
+WB	WBGene00008850	F15B9.6			gene	taxon:6239			
+WB	WBGene00008852	ubql-1		F15C11.2	gene	taxon:6239			
+WB	WBGene00008853	clec-101		F15D3.2	gene	taxon:6239			
+WB	WBGene00008854	F15D3.4			gene	taxon:6239			
+WB	WBGene00008856	F15D3.6			gene	taxon:6239			
+WB	WBGene00008857	timm-23		F15D3.7|tim-23|TIM23	gene	taxon:6239			
+WB	WBGene00008859	F15D4.2			gene	taxon:6239			
+WB	WBGene00008860	romo-1		F15D4.3|rmo-1	gene	taxon:6239			
+WB	WBGene00008861	F15D4.4			gene	taxon:6239			
+WB	WBGene00008865	F15G9.1			gene	taxon:6239			
+WB	WBGene00008868	F15G9.5			gene	taxon:6239			
+WB	WBGene00008871	tag-314		F15H10.4	gene	taxon:6239			
+WB	WBGene00008874	F15H10.7			gene	taxon:6239			
+WB	WBGene00008875	F15H10.8			gene	taxon:6239			
+WB	WBGene00008876	F16A11.1			gene	taxon:6239			
+WB	WBGene00008877	rtcb-1		F16A11.2	gene	taxon:6239			
+WB	WBGene00008878	ppfr-1		F16A11.3	gene	taxon:6239			
+WB	WBGene00008879	F16B12.1			gene	taxon:6239			
+WB	WBGene00008883	F16B12.7			gene	taxon:6239			
+WB	WBGene00008884	nhr-281		F16B12.8	gene	taxon:6239			
+WB	WBGene00008885	F16C3.1			gene	taxon:6239			
+WB	WBGene00008887	tbcd-1		F16D3.4	gene	taxon:6239			
+WB	WBGene00008889	F16D3.6			gene	taxon:6239			
+WB	WBGene00008890	ser-5		F16D3.7	gene	taxon:6239			
+WB	WBGene00008891	clec-42		F16H6.1	gene	taxon:6239			
+WB	WBGene00008892	clec-246		F16H6.2	gene	taxon:6239			
+WB	WBGene00008894	F16H6.4			gene	taxon:6239			
+WB	WBGene00008900	F16H6.10			gene	taxon:6239			
+WB	WBGene00008901	nhr-27		F16H9.2	gene	taxon:6239			
+WB	WBGene00008902	phf-32		F17A2.3	gene	taxon:6239			
+WB	WBGene00008906	oac-17		F17B5.2	gene	taxon:6239			
+WB	WBGene00008907	clec-109		F17B5.3	gene	taxon:6239			
+WB	WBGene00008908	F17B5.4			gene	taxon:6239			
+WB	WBGene00008909	clec-110		F17B5.5	gene	taxon:6239			
+WB	WBGene00008911	F17C8.6			gene	taxon:6239			
+WB	WBGene00008916	clec-221		F17C11.5	gene	taxon:6239			
+WB	WBGene00008917	F17C11.6			gene	taxon:6239			
+WB	WBGene00008918	pigt-1		F17C11.7	gene	taxon:6239			
+WB	WBGene00008919	vps-36		F17C11.8|tag-318	gene	taxon:6239			
+WB	WBGene00008920	eef-1G		F17C11.9	gene	taxon:6239			
+WB	WBGene00008921	ctf-4		F17C11.10	gene	taxon:6239			
+WB	WBGene00008923	F17C11.12			gene	taxon:6239			
+WB	WBGene00008924	F17E5.2			gene	taxon:6239			
+WB	WBGene00008926	F17H10.2			gene	taxon:6239			
+WB	WBGene00008927	snx-17		F17H10.3	gene	taxon:6239			
+WB	WBGene00008928	F17H10.4			gene	taxon:6239			
+WB	WBGene00008932	F18A11.5			gene	taxon:6239			
+WB	WBGene00008935	F18C12.4			gene	taxon:6239			
+WB	WBGene00008936	papl-1		F18E2.1|drd-9	gene	taxon:6239			
+WB	WBGene00008937	srt-43		F18E2.4	gene	taxon:6239			
+WB	WBGene00008940	F18H3.4			gene	taxon:6239			
+WB	WBGene00008944	F19B2.5			gene	taxon:6239			
+WB	WBGene00008946	F19B2.7			gene	taxon:6239			
+WB	WBGene00008947	srz-16		F19B2.8	gene	taxon:6239			
+WB	WBGene00008948	F19B6.1			gene	taxon:6239			
+WB	WBGene00008950	wht-5		F19B6.4	gene	taxon:6239			
+WB	WBGene00008952	F19C6.3			gene	taxon:6239			
+WB	WBGene00008954	F19C6.5			gene	taxon:6239			
+WB	WBGene00008956	nekl-3		F19H6.1|mlt-1	gene	taxon:6239			
+WB	WBGene00008957	glb-13		F19H6.2	gene	taxon:6239			
+WB	WBGene00008959	F19H6.4			gene	taxon:6239			
+WB	WBGene00008965	mltn-10		F19H8.5	gene	taxon:6239			
+WB	WBGene00008967	F20B10.3			gene	taxon:6239			
+WB	WBGene00008968	elli-1		F20C5.3	gene	taxon:6239			
+WB	WBGene00008969	cdc-50.B		F20C5.4	gene	taxon:6239			
+WB	WBGene00008971	F20C5.6			gene	taxon:6239			
+WB	WBGene00008972	F20C5.7			gene	taxon:6239			
+WB	WBGene00008973	flwr-1		F20D1.1	gene	taxon:6239			
+WB	WBGene00008974	tbc-1		F20D1.2	gene	taxon:6239			
+WB	WBGene00008976	plp-2		F20D1.4	gene	taxon:6239			
+WB	WBGene00008977	iglr-1		F20D1.7	gene	taxon:6239			
+WB	WBGene00008978	cutl-3		F20D1.8	gene	taxon:6239			
+WB	WBGene00008979	slc-25A18.1		F20D1.9	gene	taxon:6239			
+WB	WBGene00008980	emre-1		F20D1.10|tag-299	gene	taxon:6239			
+WB	WBGene00008981	srz-48		F20E11.1	gene	taxon:6239			
+WB	WBGene00008982	srsx-2		F20E11.2	gene	taxon:6239			
+WB	WBGene00008985	F20G2.1			gene	taxon:6239			
+WB	WBGene00008986	F20G2.2			gene	taxon:6239			
+WB	WBGene00008988	F20G2.5			gene	taxon:6239			
+WB	WBGene00008989	F20G2.6			gene	taxon:6239			
+WB	WBGene00008990	smgl-1		F20G4.1	gene	taxon:6239			
+WB	WBGene00008992	F21A3.2			gene	taxon:6239			
+WB	WBGene00008995	prde-1		F21A3.5	gene	taxon:6239			
+WB	WBGene00008996	glb-14		F21A3.6	gene	taxon:6239			
+WB	WBGene00008997	lgc-31		F21A3.7	gene	taxon:6239			
+WB	WBGene00008998	ncs-4		F21A10.1	gene	taxon:6239			
+WB	WBGene00008999	myrf-2		F21A10.2	gene	taxon:6239			
+WB	WBGene00009001	tyr-3		F21C3.2	gene	taxon:6239			
+WB	WBGene00009004	pfd-6		F21C3.5	gene	taxon:6239			
+WB	WBGene00009006	F21D5.1			gene	taxon:6239			
+WB	WBGene00009008	F21D5.3			gene	taxon:6239			
+WB	WBGene00009009	F21D5.4			gene	taxon:6239			
+WB	WBGene00009010	F21D5.5		4J500	gene	taxon:6239			
+WB	WBGene00009011	F21D5.6			gene	taxon:6239			
+WB	WBGene00009012	F21D5.7			gene	taxon:6239			
+WB	WBGene00009013	mrps-33		F21D5.8	gene	taxon:6239			
+WB	WBGene00009016	F21D9.2			gene	taxon:6239			
+WB	WBGene00009023	F21G4.1			gene	taxon:6239			
+WB	WBGene00009025	phf-34		F21G4.4	gene	taxon:6239			
+WB	WBGene00009027	F21G4.6			gene	taxon:6239			
+WB	WBGene00009029	F21H7.3			gene	taxon:6239			
+WB	WBGene00009030	clec-233		F21H7.4	gene	taxon:6239			
+WB	WBGene00009031	F21H7.5			gene	taxon:6239			
+WB	WBGene00009032	bgnt-1.3		F21H7.10	gene	taxon:6239			
+WB	WBGene00009033	F21H7.12			gene	taxon:6239			
+WB	WBGene00009035	gfat-2		F22B3.4	gene	taxon:6239			
+WB	WBGene00009036	F22B3.5			gene	taxon:6239			
+WB	WBGene00009039	F22B3.8			gene	taxon:6239			
+WB	WBGene00009041	cut-3		F22B5.3	gene	taxon:6239			
+WB	WBGene00009042	F22B5.4			gene	taxon:6239			
+WB	WBGene00009044	F22B5.6			gene	taxon:6239			
+WB	WBGene00009045	F22B5.10			gene	taxon:6239			
+WB	WBGene00009046	F22B8.3			gene	taxon:6239			
+WB	WBGene00009048	cth-1		F22B8.6	gene	taxon:6239			
+WB	WBGene00009049	F22B8.7			gene	taxon:6239			
+WB	WBGene00009050	F22D6.2			gene	taxon:6239			
+WB	WBGene00009051	nduf-6		F22D6.4	gene	taxon:6239			
+WB	WBGene00009052	ekl-1		F22D6.6	gene	taxon:6239			
+WB	WBGene00009054	F22D6.9			gene	taxon:6239			
+WB	WBGene00009057	cept-1		F22E10.5	gene	taxon:6239			
+WB	WBGene00009058	F22E12.1			gene	taxon:6239			
+WB	WBGene00009059	chw-1		F22E12.2	gene	taxon:6239			
+WB	WBGene00009060	F22E12.3			gene	taxon:6239			
+WB	WBGene00009064	F22G12.4			gene	taxon:6239			
+WB	WBGene00009065	F22G12.5			gene	taxon:6239			
+WB	WBGene00009067	F23A7.1			gene	taxon:6239			
+WB	WBGene00009073	delm-1		F23B2.3	gene	taxon:6239			
+WB	WBGene00009075	F23B2.7			gene	taxon:6239			
+WB	WBGene00009077	F23B2.10			gene	taxon:6239			
+WB	WBGene00009078	rpb-12		F23B2.13|rpc-10	gene	taxon:6239			
+WB	WBGene00009079	F23B12.1			gene	taxon:6239			
+WB	WBGene00009082	dlat-1		F23B12.5	gene	taxon:6239			
+WB	WBGene00009085	F23D12.1			gene	taxon:6239			
+WB	WBGene00009089	jmjd-3.2		F23D12.5	gene	taxon:6239			
+WB	WBGene00009090	fipr-3		F23D12.6	gene	taxon:6239			
+WB	WBGene00009092	tomm-20		F23H12.2	gene	taxon:6239			
+WB	WBGene00009093	F23H12.3			gene	taxon:6239			
+WB	WBGene00009094	F23H12.5			gene	taxon:6239			
+WB	WBGene00009095	F23H12.7			gene	taxon:6239			
+WB	WBGene00009098	ehbp-1		F25B3.1	gene	taxon:6239			
+WB	WBGene00009100	rgef-1		F25B3.3	gene	taxon:6239			
+WB	WBGene00009101	F25B3.4			gene	taxon:6239			
+WB	WBGene00009103	rtfo-1		F25B3.6	gene	taxon:6239			
+WB	WBGene00009107	txt-10		F25D1.2	gene	taxon:6239			
+WB	WBGene00009108	F25D1.3			gene	taxon:6239			
+WB	WBGene00009109	degt-1		F25D1.4	gene	taxon:6239			
+WB	WBGene00009110	F25D1.5			gene	taxon:6239			
+WB	WBGene00009112	tag-353		F25D7.2	gene	taxon:6239			
+WB	WBGene00009113	maph-1.2		F25D7.4	gene	taxon:6239			
+WB	WBGene00009114	F25D7.5			gene	taxon:6239			
+WB	WBGene00009115	F25F2.1			gene	taxon:6239			
+WB	WBGene00009116	snx-27		F25H2.2	gene	taxon:6239			
+WB	WBGene00009118	F25H2.4			gene	taxon:6239			
+WB	WBGene00009119	ndk-1		F25H2.5	gene	taxon:6239			
+WB	WBGene00009120	F25H2.6			gene	taxon:6239			
+WB	WBGene00009122	tct-1		F25H2.11	gene	taxon:6239			
+WB	WBGene00009123	F25H2.12			gene	taxon:6239			
+WB	WBGene00009124	rtel-1		F25H2.13|bch-1	gene	taxon:6239			
+WB	WBGene00009125	F25H5.2			gene	taxon:6239			
+WB	WBGene00009126	pyk-1		F25H5.3	gene	taxon:6239			
+WB	WBGene00009127	clsp-1		F25H5.5	gene	taxon:6239			
+WB	WBGene00009128	mrpl-54		F25H5.6	gene	taxon:6239			
+WB	WBGene00009129	F25H5.7			gene	taxon:6239			
+WB	WBGene00009130	F25H5.8			gene	taxon:6239			
+WB	WBGene00009131	F25H8.1			gene	taxon:6239			
+WB	WBGene00009132	F25H8.2			gene	taxon:6239			
+WB	WBGene00009133	bed-3		F25H8.6|zbed-6	gene	taxon:6239			
+WB	WBGene00009136	lurp-3		F25H9.3	gene	taxon:6239			
+WB	WBGene00009138	F25H9.6			gene	taxon:6239			
+WB	WBGene00009139	F25H9.7			gene	taxon:6239			
+WB	WBGene00009140	F26A3.1			gene	taxon:6239			
+WB	WBGene00009141	ncbp-2		F26A3.2	gene	taxon:6239			
+WB	WBGene00009142	F26A3.4			gene	taxon:6239			
+WB	WBGene00009144	del-3		F26A3.6	gene	taxon:6239			
+WB	WBGene00009146	F26C11.1			gene	taxon:6239			
+WB	WBGene00009147	F26C11.3			gene	taxon:6239			
+WB	WBGene00009148	F26D2.3			gene	taxon:6239			
+WB	WBGene00009149	F26D2.10			gene	taxon:6239			
+WB	WBGene00009150	clec-234		F26D2.12	gene	taxon:6239			
+WB	WBGene00009153	F26D2.15			gene	taxon:6239			
+WB	WBGene00009155	lhfp-4		F26D10.11	gene	taxon:6239			
+WB	WBGene00009156	clec-196		F26D10.12	gene	taxon:6239			
+WB	WBGene00009157	F26E4.2			gene	taxon:6239			
+WB	WBGene00009158	F26E4.3			gene	taxon:6239			
+WB	WBGene00009159	F26E4.4			gene	taxon:6239			
+WB	WBGene00009160	F26E4.5			gene	taxon:6239			
+WB	WBGene00009161	cox-7C		F26E4.6	gene	taxon:6239			
+WB	WBGene00009162	F26E4.7			gene	taxon:6239			
+WB	WBGene00009163	drsh-1		F26E4.10	gene	taxon:6239			
+WB	WBGene00009164	hrdl-1		F26E4.11	gene	taxon:6239			
+WB	WBGene00009165	gpx-1		F26E4.12	gene	taxon:6239			
+WB	WBGene00009166	F26F2.1			gene	taxon:6239			
+WB	WBGene00009168	F26F2.3			gene	taxon:6239			
+WB	WBGene00009171	clec-263		F26F2.6	gene	taxon:6239			
+WB	WBGene00009172	F26F2.7			gene	taxon:6239			
+WB	WBGene00009176	nmat-2		F26H9.4	gene	taxon:6239			
+WB	WBGene00009177	F26H9.5			gene	taxon:6239			
+WB	WBGene00009178	uggt-2		F26H9.8	gene	taxon:6239			
+WB	WBGene00009179	kbp-3		F26H11.1|2O676	gene	taxon:6239			
+WB	WBGene00009180	nurf-1		F26H11.2	gene	taxon:6239			
+WB	WBGene00009186	trcs-1		F27C8.6	gene	taxon:6239			
+WB	WBGene00009187	F27D4.1			gene	taxon:6239			
+WB	WBGene00009188	lsy-22		F27D4.2	gene	taxon:6239			
+WB	WBGene00009189	F27D4.4			gene	taxon:6239			
+WB	WBGene00009191	F27D4.7			gene	taxon:6239			
+WB	WBGene00009192	asah-2		F27E5.1	gene	taxon:6239			
+WB	WBGene00009193	F27E5.3			gene	taxon:6239			
+WB	WBGene00009194	F27E5.5			gene	taxon:6239			
+WB	WBGene00009202	aptf-4		F28C6.1	gene	taxon:6239			
+WB	WBGene00009203	aptf-3		F28C6.2	gene	taxon:6239			
+WB	WBGene00009204	pigg-1		F28C6.4	gene	taxon:6239			
+WB	WBGene00009207	F28C6.8			gene	taxon:6239			
+WB	WBGene00009211	wdr-46		F28D1.1	gene	taxon:6239			
+WB	WBGene00009212	atz-1		F28D1.2	gene	taxon:6239			
+WB	WBGene00009213	thn-1		F28D1.3|dod-2	gene	taxon:6239			
+WB	WBGene00009215	thn-2		F28D1.5	gene	taxon:6239			
+WB	WBGene00009216	F28D1.6			gene	taxon:6239			
+WB	WBGene00009217	spe-45		F28D1.8|oig-7	gene	taxon:6239			
+WB	WBGene00009218	acs-20		F28D1.9	gene	taxon:6239			
+WB	WBGene00009219	dpm-3		F28D1.11	gene	taxon:6239			
+WB	WBGene00009220	F28D9.4			gene	taxon:6239			
+WB	WBGene00009221	acs-2		F28F8.2	gene	taxon:6239			
+WB	WBGene00009223	mdt-28		F28F8.5	gene	taxon:6239			
+WB	WBGene00009224	F28F8.7			gene	taxon:6239			
+WB	WBGene00009226	cyp-37B1		F28G4.1	gene	taxon:6239			
+WB	WBGene00009227	F28G4.2			gene	taxon:6239			
+WB	WBGene00009229	F28G4.4			gene	taxon:6239			
+WB	WBGene00009231	ceh-89		F28H6.2	gene	taxon:6239			
+WB	WBGene00009232	nkat-1		F28H6.3	gene	taxon:6239			
+WB	WBGene00009236	F28H7.2			gene	taxon:6239			
+WB	WBGene00009237	F28H7.3			gene	taxon:6239			
+WB	WBGene00009238	selt-1.2		F28H7.4	gene	taxon:6239			
+WB	WBGene00009239	irld-6		F28H7.6	gene	taxon:6239			
+WB	WBGene00009240	F28H7.7			gene	taxon:6239			
+WB	WBGene00009242	sre-6		F28H7.9	gene	taxon:6239			
+WB	WBGene00009245	rict-1		F29C12.3|lpo-6	gene	taxon:6239			
+WB	WBGene00009246	gfm-1		F29C12.4|CAB04216	gene	taxon:6239			
+WB	WBGene00009250	F29D10.1			gene	taxon:6239			
+WB	WBGene00009254	capg-1		F29D11.2	gene	taxon:6239			
+WB	WBGene00009255	ugt-34		F29F11.2	gene	taxon:6239			
+WB	WBGene00009256	tut-2		F29F11.3|ctu-2	gene	taxon:6239			
+WB	WBGene00009258	ccdc-149		F29G6.2	gene	taxon:6239			
+WB	WBGene00009259	hpo-34		F29G6.3	gene	taxon:6239			
+WB	WBGene00009260	calm-1		F30A10.1	gene	taxon:6239			
+WB	WBGene00009262	F30A10.3			gene	taxon:6239			
+WB	WBGene00009263	F30A10.4			gene	taxon:6239			
+WB	WBGene00009264	sac-1		F30A10.6	gene	taxon:6239			
+WB	WBGene00009266	F30A10.9			gene	taxon:6239			
+WB	WBGene00009267	usp-48		F30A10.10	gene	taxon:6239			
+WB	WBGene00009269	F30A10.12			gene	taxon:6239			
+WB	WBGene00009271	glna-3		F30F8.2	gene	taxon:6239			
+WB	WBGene00009276	F30F8.9			gene	taxon:6239			
+WB	WBGene00009277	F30F8.10			gene	taxon:6239			
+WB	WBGene00009278	npr-33		F31B9.1	gene	taxon:6239			
+WB	WBGene00009286	zipt-1		F31C3.4	gene	taxon:6239			
+WB	WBGene00009287	psf-2		F31C3.5	gene	taxon:6239			
+WB	WBGene00009288	F31C3.6			gene	taxon:6239			
+WB	WBGene00009290	F31D4.2			gene	taxon:6239			
+WB	WBGene00009291	clec-264		F31D4.4	gene	taxon:6239			
+WB	WBGene00009294	F31D4.9			gene	taxon:6239			
+WB	WBGene00009298	srz-58		F31E9.5	gene	taxon:6239			
+WB	WBGene00009303	lips-8		F31F6.7	gene	taxon:6239			
+WB	WBGene00009304	eva-1		F32A7.3|tag-271	gene	taxon:6239			
+WB	WBGene00009305	metl-17		F32A7.4	gene	taxon:6239			
+WB	WBGene00009306	maph-1.1		F32A7.5	gene	taxon:6239			
+WB	WBGene00009307	F32A11.1			gene	taxon:6239			
+WB	WBGene00009311	mltn-1		F32A11.7	gene	taxon:6239			
+WB	WBGene00009312	F32B4.1			gene	taxon:6239			
+WB	WBGene00009313	F32B4.2			gene	taxon:6239			
+WB	WBGene00009314	phm-2		F32B4.4	gene	taxon:6239			
+WB	WBGene00009316	abhd-11.1		F32B4.6	gene	taxon:6239			
+WB	WBGene00009319	mccc-1		F32B6.2	gene	taxon:6239			
+WB	WBGene00009320	prp-18		F32B6.3	gene	taxon:6239			
+WB	WBGene00009322	tbc-3		F32B6.8	gene	taxon:6239			
+WB	WBGene00009323	best-13		F32B6.9	gene	taxon:6239			
+WB	WBGene00009324	ttbk-3		F32B6.10	gene	taxon:6239			
+WB	WBGene00009325	F32D8.15			gene	taxon:6239			
+WB	WBGene00009326	F32D8.1			gene	taxon:6239			
+WB	WBGene00009327	F32D8.2			gene	taxon:6239			
+WB	WBGene00009328	F32D8.3			gene	taxon:6239			
+WB	WBGene00009330	F32D8.5			gene	taxon:6239			
+WB	WBGene00009331	F32D8.7			gene	taxon:6239			
+WB	WBGene00009332	F32D8.8			gene	taxon:6239			
+WB	WBGene00009333	zzz-1		F32D8.10	gene	taxon:6239			
+WB	WBGene00009334	F32D8.12			gene	taxon:6239			
+WB	WBGene00009335	F32D8.13			gene	taxon:6239			
+WB	WBGene00009336	F32D8.14			gene	taxon:6239			
+WB	WBGene00009337	uig-1		F32F2.1	gene	taxon:6239			
+WB	WBGene00009338	F32G8.2			gene	taxon:6239			
+WB	WBGene00009339	F32G8.3			gene	taxon:6239			
+WB	WBGene00009340	best-14		F32G8.4	gene	taxon:6239			
+WB	WBGene00009341	thoc-3		F32H2.4	gene	taxon:6239			
+WB	WBGene00009342	fasn-1		F32H2.5|emb-14	gene	taxon:6239			
+WB	WBGene00009343	F32H2.6		phi-46	gene	taxon:6239			
+WB	WBGene00009345	F32H2.8			gene	taxon:6239			
+WB	WBGene00009347	F32H5.1			gene	taxon:6239			
+WB	WBGene00009350	F32H5.4			gene	taxon:6239			
+WB	WBGene00009352	F33A8.4			gene	taxon:6239			
+WB	WBGene00009353	sdhd-1		F33A8.5	gene	taxon:6239			
+WB	WBGene00009354	ilkp-1		F33A8.6	gene	taxon:6239			
+WB	WBGene00009359	clec-102		F33E2.3	gene	taxon:6239			
+WB	WBGene00009364	wbp-11		F33H1.3	gene	taxon:6239			
+WB	WBGene00009368	pole-1		F33H2.5	gene	taxon:6239			
+WB	WBGene00009371	F33H2.8			gene	taxon:6239			
+WB	WBGene00009372	evl-18		F34D10.2|cdc-45	gene	taxon:6239			
+WB	WBGene00009373	F34D10.3			gene	taxon:6239			
+WB	WBGene00009378	F34H10.1			gene	taxon:6239			
+WB	WBGene00009384	piit-1		F35B12.4	gene	taxon:6239			
+WB	WBGene00009385	sas-5		F35B12.5	gene	taxon:6239			
+WB	WBGene00009386	tag-290		F35B12.6	gene	taxon:6239			
+WB	WBGene00009387	glb-15		F35B12.8	gene	taxon:6239			
+WB	WBGene00009388	F35B12.9			gene	taxon:6239			
+WB	WBGene00009389	F35B12.10			gene	taxon:6239			
+WB	WBGene00009393	clec-62		F35C5.5	gene	taxon:6239			
+WB	WBGene00009394	clec-63		F35C5.6	gene	taxon:6239			
+WB	WBGene00009395	clec-64		F35C5.7	gene	taxon:6239			
+WB	WBGene00009396	clec-65		F35C5.8	gene	taxon:6239			
+WB	WBGene00009397	clec-66		F35C5.9	gene	taxon:6239			
+WB	WBGene00009399	ddn-2		F35C5.11	gene	taxon:6239			
+WB	WBGene00009400	F35C5.12			gene	taxon:6239			
+WB	WBGene00009401	F35C11.2			gene	taxon:6239			
+WB	WBGene00009402	F35C11.3			gene	taxon:6239			
+WB	WBGene00009403	F35C11.4			gene	taxon:6239			
+WB	WBGene00009404	F35C11.5			gene	taxon:6239			
+WB	WBGene00009409	F35E2.1			gene	taxon:6239			
+WB	WBGene00009413	oac-19		F35E2.6	gene	taxon:6239			
+WB	WBGene00009417	F35E8.1			gene	taxon:6239			
+WB	WBGene00009426	F35E12.2			gene	taxon:6239			
+WB	WBGene00009429	irg-5		F35E12.5	gene	taxon:6239			
+WB	WBGene00009430	F35E12.6			gene	taxon:6239			
+WB	WBGene00009431	dct-17		F35E12.7	gene	taxon:6239			
+WB	WBGene00009432	cld-9		F35E12.8	gene	taxon:6239			
+WB	WBGene00009434	F35E12.10			gene	taxon:6239			
+WB	WBGene00009435	F35G2.1			gene	taxon:6239			
+WB	WBGene00009437	F35G2.3			gene	taxon:6239			
+WB	WBGene00009438	F35G2.5			gene	taxon:6239			
+WB	WBGene00009439	mlcd-1		F35G12.1	gene	taxon:6239			
+WB	WBGene00009440	idhg-1		F35G12.2	gene	taxon:6239			
+WB	WBGene00009441	wdr-48		F35G12.4	gene	taxon:6239			
+WB	WBGene00009443	F35G12.7			gene	taxon:6239			
+WB	WBGene00009444	erh-2		F35G12.11	gene	taxon:6239			
+WB	WBGene00009445	F35G12.12			gene	taxon:6239			
+WB	WBGene00009447	F35H8.2			gene	taxon:6239			
+WB	WBGene00009448	zfp-2		F35H8.3	gene	taxon:6239			
+WB	WBGene00009449	F35H8.4			gene	taxon:6239			
+WB	WBGene00009450	ugt-58		F35H8.6	gene	taxon:6239			
+WB	WBGene00009451	cids-2		F36A2.1	gene	taxon:6239			
+WB	WBGene00009452	F36A2.2			gene	taxon:6239			
+WB	WBGene00009453	F36A2.3			gene	taxon:6239			
+WB	WBGene00009454	F36A2.7			gene	taxon:6239			
+WB	WBGene00009455	phip-1		F36A2.8	gene	taxon:6239			
+WB	WBGene00009456	F36A2.9			gene	taxon:6239			
+WB	WBGene00009460	ubr-5		F36A2.13|sog-1	gene	taxon:6239			
+WB	WBGene00009462	sre-22		F36D1.2	gene	taxon:6239			
+WB	WBGene00009467	F36D1.8			gene	taxon:6239			
+WB	WBGene00009470	F36D3.4			gene	taxon:6239			
+WB	WBGene00009471	F36D3.5			gene	taxon:6239			
+WB	WBGene00009475	F36F2.1			gene	taxon:6239			
+WB	WBGene00009477	rbpl-1		F36F2.3|tag-214	gene	taxon:6239			
+WB	WBGene00009478	syx-7		F36F2.4|syn-13	gene	taxon:6239			
+WB	WBGene00009479	fcp-1		F36F2.6	gene	taxon:6239			
+WB	WBGene00009480	F36F2.7			gene	taxon:6239			
+WB	WBGene00009484	F36G3.3			gene	taxon:6239			
+WB	WBGene00009485	F36G9.3			gene	taxon:6239			
+WB	WBGene00009486	F36G9.7			gene	taxon:6239			
+WB	WBGene00009487	clec-232		F36G9.11	gene	taxon:6239			
+WB	WBGene00009488	oac-20		F36G9.12	gene	taxon:6239			
+WB	WBGene00009491	F36G9.15			gene	taxon:6239			
+WB	WBGene00009492	F36H1.3			gene	taxon:6239			
+WB	WBGene00009493	hrg-4		F36H1.5	gene	taxon:6239			
+WB	WBGene00009494	hrg-5		F36H1.9	gene	taxon:6239			
+WB	WBGene00009495	hrg-6		F36H1.10	gene	taxon:6239			
+WB	WBGene00009498	tat-5		F36H2.1	gene	taxon:6239			
+WB	WBGene00009499	ent-6		F36H2.2|ent-7	gene	taxon:6239			
+WB	WBGene00009503	F37A8.5			gene	taxon:6239			
+WB	WBGene00009504	F37B12.1			gene	taxon:6239			
+WB	WBGene00009505	F37B12.3			gene	taxon:6239			
+WB	WBGene00009507	mus-101		F37D6.1|emb-10|zyg-2	gene	taxon:6239			
+WB	WBGene00009509	F37D6.3			gene	taxon:6239			
+WB	WBGene00009510	F37D6.4			gene	taxon:6239			
+WB	WBGene00009513	sfxn-1.2		F37H8.4	gene	taxon:6239			
+WB	WBGene00009514	F37H8.5			gene	taxon:6239			
+WB	WBGene00009515	clec-170		F38A1.1	gene	taxon:6239			
+WB	WBGene00009517	clec-167		F38A1.4	gene	taxon:6239			
+WB	WBGene00009518	clec-166		F38A1.5	gene	taxon:6239			
+WB	WBGene00009520	clec-168		F38A1.7	gene	taxon:6239			
+WB	WBGene00009521	F38A1.8			gene	taxon:6239			
+WB	WBGene00009523	clec-165		F38A1.10	gene	taxon:6239			
+WB	WBGene00009526	clec-169		F38A1.14	gene	taxon:6239			
+WB	WBGene00009530	F38B2.3			gene	taxon:6239			
+WB	WBGene00009531	F38B2.4		XL906	gene	taxon:6239			
+WB	WBGene00009532	ccch-1		F38B7.1	gene	taxon:6239			
+WB	WBGene00009533	F38B7.2			gene	taxon:6239			
+WB	WBGene00009536	F38C2.4			gene	taxon:6239			
+WB	WBGene00009537	ccch-2		F38C2.5	gene	taxon:6239			
+WB	WBGene00009538	clec-191		F38C2.6	gene	taxon:6239			
+WB	WBGene00009539	F38C2.7			gene	taxon:6239			
+WB	WBGene00009540	hlh-31		F38C2.8	gene	taxon:6239			
+WB	WBGene00009541	cutl-17		F38E11.4	gene	taxon:6239			
+WB	WBGene00009542	copb-2		F38E11.5	gene	taxon:6239			
+WB	WBGene00009543	F38E11.6			gene	taxon:6239			
+WB	WBGene00009548	F38H4.4			gene	taxon:6239			
+WB	WBGene00009550	F38H4.6			gene	taxon:6239			
+WB	WBGene00009552	piki-1		F39B1.1	gene	taxon:6239			
+WB	WBGene00009554	F39B2.3			gene	taxon:6239			
+WB	WBGene00009556	F39B2.5			gene	taxon:6239			
+WB	WBGene00009557	mtcu-1		F39B2.7	gene	taxon:6239			
+WB	WBGene00009558	F39B2.8			gene	taxon:6239			
+WB	WBGene00009559	mtx-1		F39B2.11	gene	taxon:6239			
+WB	WBGene00009560	psa-3		F39D8.2	gene	taxon:6239			
+WB	WBGene00009562	flp-22		F39H2.1	gene	taxon:6239			
+WB	WBGene00009566	srsx-1		F40D4.5	gene	taxon:6239			
+WB	WBGene00009567	srbc-25		F40D4.6	gene	taxon:6239			
+WB	WBGene00009568	srbc-26		F40D4.7	gene	taxon:6239			
+WB	WBGene00009569	srz-66		F40D4.9	gene	taxon:6239			
+WB	WBGene00009574	F40E10.6			gene	taxon:6239			
+WB	WBGene00009575	F40F8.1			gene	taxon:6239			
+WB	WBGene00009576	F40F8.3			gene	taxon:6239			
+WB	WBGene00009580	xbx-6		F40F9.1	gene	taxon:6239			
+WB	WBGene00009582	slcr-46.3		F40F9.5	gene	taxon:6239			
+WB	WBGene00009583	aagr-3		F40F9.6	gene	taxon:6239			
+WB	WBGene00009584	drap-1		F40F9.7	gene	taxon:6239			
+WB	WBGene00009585	cal-7		F40F9.8	gene	taxon:6239			
+WB	WBGene00009586	F40F9.10			gene	taxon:6239			
+WB	WBGene00009587	mig-38		F40F11.2	gene	taxon:6239			
+WB	WBGene00009589	F40F11.4			gene	taxon:6239			
+WB	WBGene00009592	F40F12.3			gene	taxon:6239			
+WB	WBGene00009593	mam-7		F40F12.4	gene	taxon:6239			
+WB	WBGene00009594	cyld-1		F40F12.5	gene	taxon:6239			
+WB	WBGene00009595	cbp-3		F40F12.7	gene	taxon:6239			
+WB	WBGene00009596	sre-8		F40G12.1	gene	taxon:6239			
+WB	WBGene00009603	srt-33		F40G12.8	gene	taxon:6239			
+WB	WBGene00009605	F40G12.10			gene	taxon:6239			
+WB	WBGene00009607	oac-26		F41D3.2	gene	taxon:6239			
+WB	WBGene00009608	nhr-265		F41D3.3	gene	taxon:6239			
+WB	WBGene00009609	oac-27		F41D3.4	gene	taxon:6239			
+WB	WBGene00009610	oac-28		F41D3.5	gene	taxon:6239			
+WB	WBGene00009611	F41D3.6			gene	taxon:6239			
+WB	WBGene00009612	F41D3.7			gene	taxon:6239			
+WB	WBGene00009615	oac-25		F41D3.10	gene	taxon:6239			
+WB	WBGene00009616	F41D3.11			gene	taxon:6239			
+WB	WBGene00009617	slc-9B.1		F41E7.1|exc-11	gene	taxon:6239			
+WB	WBGene00009618	F41E7.2			gene	taxon:6239			
+WB	WBGene00009619	npr-6		F41E7.3	gene	taxon:6239			
+WB	WBGene00009622	F41E7.6			gene	taxon:6239			
+WB	WBGene00009627	cup-15		F42A8.3	gene	taxon:6239			
+WB	WBGene00009628	tatn-1		F42D1.2	gene	taxon:6239			
+WB	WBGene00009629	sprr-2		F42D1.3|mipr-1	gene	taxon:6239			
+WB	WBGene00009632	ttyh-1		F42E11.2	gene	taxon:6239			
+WB	WBGene00009633	F42E11.3			gene	taxon:6239			
+WB	WBGene00009635	F42F12.3			gene	taxon:6239			
+WB	WBGene00009636	F42F12.4			gene	taxon:6239			
+WB	WBGene00009644	F42G4.7			gene	taxon:6239			
+WB	WBGene00009645	F42G10.1			gene	taxon:6239			
+WB	WBGene00009646	F42H11.1			gene	taxon:6239			
+WB	WBGene00009647	phlp-2		F43C1.1	gene	taxon:6239			
+WB	WBGene00009648	zhit-2		F43C1.3	gene	taxon:6239			
+WB	WBGene00009649	F43C1.5			gene	taxon:6239			
+WB	WBGene00009650	ccnk-1		F43D2.1	gene	taxon:6239			
+WB	WBGene00009653	F43D9.1			gene	taxon:6239			
+WB	WBGene00009654	sly-1		F43D9.3|phi-26	gene	taxon:6239			
+WB	WBGene00009658	pap-3		F43G6.5	gene	taxon:6239			
+WB	WBGene00009660	F43G6.8			gene	taxon:6239			
+WB	WBGene00009661	patr-1		F43G6.9	gene	taxon:6239			
+WB	WBGene00009664	idha-1		F43G9.1	gene	taxon:6239			
+WB	WBGene00009665	lmd-1		F43G9.2	gene	taxon:6239			
+WB	WBGene00009666	slc-25A42		F43G9.3	gene	taxon:6239			
+WB	WBGene00009668	cfim-1		F43G9.5	gene	taxon:6239			
+WB	WBGene00009670	F43G9.8			gene	taxon:6239			
+WB	WBGene00009671	mfap-1		F43G9.10	gene	taxon:6239			
+WB	WBGene00009672	F43G9.12			gene	taxon:6239			
+WB	WBGene00009673	F43G9.13			gene	taxon:6239			
+WB	WBGene00009678	magu-4		F44D12.1	gene	taxon:6239			
+WB	WBGene00009679	F44D12.2			gene	taxon:6239			
+WB	WBGene00009680	msd-1		F44D12.3	gene	taxon:6239			
+WB	WBGene00009682	msd-2		F44D12.5	gene	taxon:6239			
+WB	WBGene00009683	F44D12.6			gene	taxon:6239			
+WB	WBGene00009684	msd-3		F44D12.7	gene	taxon:6239			
+WB	WBGene00009686	ent-7		F44D12.9|ent-4	gene	taxon:6239			
+WB	WBGene00009687	F44D12.10			gene	taxon:6239			
+WB	WBGene00009691	F44E5.4			gene	taxon:6239			
+WB	WBGene00009692	F44E5.5			gene	taxon:6239			
+WB	WBGene00009695	clp-8		F44F1.3	gene	taxon:6239			
+WB	WBGene00009696	F44F1.4			gene	taxon:6239			
+WB	WBGene00009698	F44F1.6			gene	taxon:6239			
+WB	WBGene00009700	lurp-1		F44F4.1	gene	taxon:6239			
+WB	WBGene00009701	egg-3		F44F4.2	gene	taxon:6239			
+WB	WBGene00009702	F44F4.3			gene	taxon:6239			
+WB	WBGene00009704	F44F4.9			gene	taxon:6239			
+WB	WBGene00009706	argk-1		F44G3.2	gene	taxon:6239			
+WB	WBGene00009707	srxa-16		F44G3.5	gene	taxon:6239			
+WB	WBGene00009708	F44G3.7			gene	taxon:6239			
+WB	WBGene00009710	F44G3.10			gene	taxon:6239			
+WB	WBGene00009711	F44G4.1			gene	taxon:6239			
+WB	WBGene00009712	F44G4.2		2J289	gene	taxon:6239			
+WB	WBGene00009713	F44G4.3			gene	taxon:6239			
+WB	WBGene00009715	F44G4.6			gene	taxon:6239			
+WB	WBGene00009717	dep-1		F44G4.8	gene	taxon:6239			
+WB	WBGene00009720	F45B8.3			gene	taxon:6239			
+WB	WBGene00009727	lips-1		F45E6.4	gene	taxon:6239			
+WB	WBGene00009728	sdz-19		F45E6.6	gene	taxon:6239			
+WB	WBGene00009729	F45E10.2			gene	taxon:6239			
+WB	WBGene00009730	myo-6		F45G2.2	gene	taxon:6239			
+WB	WBGene00009731	exo-1		F45G2.3	gene	taxon:6239			
+WB	WBGene00009732	cope-1		F45G2.4	gene	taxon:6239			
+WB	WBGene00009734	F45G2.8			gene	taxon:6239			
+WB	WBGene00009735	F45G2.9			gene	taxon:6239			
+WB	WBGene00009736	ciao-2B		F45G2.10	gene	taxon:6239			
+WB	WBGene00009738	hecw-1		F45H7.6	gene	taxon:6239			
+WB	WBGene00009739	F45H10.2			gene	taxon:6239			
+WB	WBGene00009740	F45H10.3			gene	taxon:6239			
+WB	WBGene00009741	drr-1		F45H10.4	gene	taxon:6239			
+WB	WBGene00009742	F45H10.5			gene	taxon:6239			
+WB	WBGene00009743	sptf-1		F45H11.1	gene	taxon:6239			
+WB	WBGene00009746	F46A8.3			gene	taxon:6239			
+WB	WBGene00009747	F46A8.4			gene	taxon:6239			
+WB	WBGene00009748	F46A8.5			gene	taxon:6239			
+WB	WBGene00009751	F46A8.8			gene	taxon:6239			
+WB	WBGene00009753	scrm-6		F46A8.10	gene	taxon:6239			
+WB	WBGene00009758	ttr-11		F46B3.3	gene	taxon:6239			
+WB	WBGene00009759	ttr-12		F46B3.4	gene	taxon:6239			
+WB	WBGene00009763	srz-18		F46B3.11	gene	taxon:6239			
+WB	WBGene00009768	F46B6.2			gene	taxon:6239			
+WB	WBGene00009769	F46B6.4			gene	taxon:6239			
+WB	WBGene00009771	F46B6.6			gene	taxon:6239			
+WB	WBGene00009773	lipl-2		F46B6.8	gene	taxon:6239			
+WB	WBGene00009774	F46B6.9			gene	taxon:6239			
+WB	WBGene00009776	F46B6.12			gene	taxon:6239			
+WB	WBGene00009777	F46C3.2			gene	taxon:6239			
+WB	WBGene00009778	F46C5.1			gene	taxon:6239			
+WB	WBGene00009779	F46C5.2			gene	taxon:6239			
+WB	WBGene00009780	F46C5.4			gene	taxon:6239			
+WB	WBGene00009782	F46C5.7			gene	taxon:6239			
+WB	WBGene00009783	rer-1		F46C5.8	gene	taxon:6239			
+WB	WBGene00009784	F46C5.9			gene	taxon:6239			
+WB	WBGene00009790	lgc-44		F46F3.2	gene	taxon:6239			
+WB	WBGene00009793	pkn-1		F46F6.2	gene	taxon:6239			
+WB	WBGene00009796	F46G10.1			gene	taxon:6239			
+WB	WBGene00009797	F46G10.2			gene	taxon:6239			
+WB	WBGene00009798	F46G10.4			gene	taxon:6239			
+WB	WBGene00009799	lgc-47		F47A4.1	gene	taxon:6239			
+WB	WBGene00009800	rrc-1		F47A4.3	gene	taxon:6239			
+WB	WBGene00009801	ipla-2		F47A4.5	gene	taxon:6239			
+WB	WBGene00009802	F47B8.1			gene	taxon:6239			
+WB	WBGene00009803	F47B8.2			gene	taxon:6239			
+WB	WBGene00009804	F47B8.3			gene	taxon:6239			
+WB	WBGene00009805	F47B8.4			gene	taxon:6239			
+WB	WBGene00009808	srm-4		F47B8.7	gene	taxon:6239			
+WB	WBGene00009810	srm-6		F47B8.9	gene	taxon:6239			
+WB	WBGene00009811	F47B8.10			gene	taxon:6239			
+WB	WBGene00009812	suca-1		F47B10.1	gene	taxon:6239			
+WB	WBGene00009813	haly-1		F47B10.2	gene	taxon:6239			
+WB	WBGene00009814	F47B10.3			gene	taxon:6239			
+WB	WBGene00009816	F47B10.5			gene	taxon:6239			
+WB	WBGene00009818	acbp-3		F47B10.7	gene	taxon:6239			
+WB	WBGene00009819	F47B10.8			gene	taxon:6239			
+WB	WBGene00009824	gpdh-1		F47G4.3	gene	taxon:6239			
+WB	WBGene00009825	F47G4.4			gene	taxon:6239			
+WB	WBGene00009826	F47G4.5			gene	taxon:6239			
+WB	WBGene00009827	hmg-6		F47G4.6	gene	taxon:6239			
+WB	WBGene00009829	tmed-10		F47G9.1	gene	taxon:6239			
+WB	WBGene00009830	cutl-18		F47G9.3	gene	taxon:6239			
+WB	WBGene00009831	F47G9.4			gene	taxon:6239			
+WB	WBGene00009842	igeg-2		F48C5.1	gene	taxon:6239			
+WB	WBGene00009843	F48C5.2			gene	taxon:6239			
+WB	WBGene00009844	cwp-5		F48C11.2	gene	taxon:6239			
+WB	WBGene00009848	F48F5.6			gene	taxon:6239			
+WB	WBGene00009849	F48F7.3			gene	taxon:6239			
+WB	WBGene00009852	arrd-24		F48F7.7	gene	taxon:6239			
+WB	WBGene00009854	clec-31		F49A5.2	gene	taxon:6239			
+WB	WBGene00009855	clec-22		F49A5.3	gene	taxon:6239			
+WB	WBGene00009856	clec-24		F49A5.4	gene	taxon:6239			
+WB	WBGene00009857	clec-28		F49A5.5	gene	taxon:6239			
+WB	WBGene00009858	thn-4		F49A5.6	gene	taxon:6239			
+WB	WBGene00009859	clec-33		F49A5.7	gene	taxon:6239			
+WB	WBGene00009860	clec-32		F49A5.9	gene	taxon:6239			
+WB	WBGene00009865	F49B2.6		Y105E8A.a	gene	taxon:6239			
+WB	WBGene00009867	F49C5.4			gene	taxon:6239			
+WB	WBGene00009871	F49C12.1			gene	taxon:6239			
+WB	WBGene00009874	F49C12.4			gene	taxon:6239			
+WB	WBGene00009875	F49C12.5			gene	taxon:6239			
+WB	WBGene00009876	F49C12.6			gene	taxon:6239			
+WB	WBGene00009878	F49C12.9			gene	taxon:6239			
+WB	WBGene00009879	F49C12.10			gene	taxon:6239			
+WB	WBGene00009881	F49C12.12		phi-62	gene	taxon:6239			
+WB	WBGene00009882	vha-17		F49C12.13|fus-1	gene	taxon:6239			
+WB	WBGene00009885	moc-5		F49E2.1	gene	taxon:6239			
+WB	WBGene00009887	glb-17		F49E2.4	gene	taxon:6239			
+WB	WBGene00009889	F49E11.2			gene	taxon:6239			
+WB	WBGene00009893	F49E11.7			gene	taxon:6239			
+WB	WBGene00009897	skpo-1		F49E12.1	gene	taxon:6239			
+WB	WBGene00009899	efl-3		F49E12.6	gene	taxon:6239			
+WB	WBGene00009900	F49E12.7			gene	taxon:6239			
+WB	WBGene00009902	drd-1		F49E12.9	gene	taxon:6239			
+WB	WBGene00009903	F49E12.10			gene	taxon:6239			
+WB	WBGene00009904	F49E12.12			gene	taxon:6239			
+WB	WBGene00009905	clec-240		F49H6.1	gene	taxon:6239			
+WB	WBGene00009906	clec-241		F49H6.2	gene	taxon:6239			
+WB	WBGene00009907	F49H6.3			gene	taxon:6239			
+WB	WBGene00009908	F49H6.5			gene	taxon:6239			
+WB	WBGene00009912	srz-94		F49H6.11	gene	taxon:6239			
+WB	WBGene00009914	F49H6.13			gene	taxon:6239			
+WB	WBGene00009915	F52A8.1			gene	taxon:6239			
+WB	WBGene00009916	F52A8.3			gene	taxon:6239			
+WB	WBGene00009917	glb-18		F52A8.4	gene	taxon:6239			
+WB	WBGene00009918	gcsh-2		F52A8.5	gene	taxon:6239			
+WB	WBGene00009919	kbrl-1		F52A8.6	gene	taxon:6239			
+WB	WBGene00009920	abts-1		F52B5.1	gene	taxon:6239			
+WB	WBGene00009921	F52B5.2			gene	taxon:6239			
+WB	WBGene00009922	F52B5.3			gene	taxon:6239			
+WB	WBGene00009924	cfp-1		F52B11.1	gene	taxon:6239			
+WB	WBGene00009925	F52B11.2			gene	taxon:6239			
+WB	WBGene00009926	noah-2		F52B11.3|phi-55	gene	taxon:6239			
+WB	WBGene00009929	abts-2		F52D10.1	gene	taxon:6239			
+WB	WBGene00009931	F52D10.4			gene	taxon:6239			
+WB	WBGene00009935	F52E10.4			gene	taxon:6239			
+WB	WBGene00009939	ztf-11		F52F12.6|ekl-2	gene	taxon:6239			
+WB	WBGene00009940	strl-1		F52F12.7	gene	taxon:6239			
+WB	WBGene00009941	F52F12.8			gene	taxon:6239			
+WB	WBGene00009944	mtcu-2		F52H3.2	gene	taxon:6239			
+WB	WBGene00009948	F52H3.6			gene	taxon:6239			
+WB	WBGene00009949	F53A2.1			gene	taxon:6239			
+WB	WBGene00009950	sdz-20		F53A2.2	gene	taxon:6239			
+WB	WBGene00009952	acaa-2		F53A2.7	gene	taxon:6239			
+WB	WBGene00009955	eak-4		F53B2.3	gene	taxon:6239			
+WB	WBGene00009958	madd-4		F53B6.2	gene	taxon:6239			
+WB	WBGene00009959	F53B6.4			gene	taxon:6239			
+WB	WBGene00009961	cutl-7		F53B6.6	gene	taxon:6239			
+WB	WBGene00009965	frpr-9		F53B7.2	gene	taxon:6239			
+WB	WBGene00009966	isy-1		F53B7.3	gene	taxon:6239			
+WB	WBGene00009967	F53B7.4			gene	taxon:6239			
+WB	WBGene00009968	fig-1		F53B7.5	gene	taxon:6239			
+WB	WBGene00009971	F53C11.1			gene	taxon:6239			
+WB	WBGene00009973	F53C11.3			gene	taxon:6239			
+WB	WBGene00009976	swan-2		F53C11.7|tag-206	gene	taxon:6239			
+WB	WBGene00009977	swan-1		F53C11.8	gene	taxon:6239			
+WB	WBGene00009979	cutl-1		F53F1.1	gene	taxon:6239			
+WB	WBGene00009980	F53F1.2			gene	taxon:6239			
+WB	WBGene00009981	F53F1.3			gene	taxon:6239			
+WB	WBGene00009983	cut-2		F53F1.5|vmp-2	gene	taxon:6239			
+WB	WBGene00009987	tbcb-1		F53F4.3|ckap-1	gene	taxon:6239			
+WB	WBGene00009992	F53F4.10			gene	taxon:6239			
+WB	WBGene00009996	sde-2		F53F4.14	gene	taxon:6239			
+WB	WBGene00009998	klf-2		F53F8.1	gene	taxon:6239			
+WB	WBGene00009999	srsx-35		F53F8.2	gene	taxon:6239			
+WB	WBGene00010000	F53F8.3			gene	taxon:6239			
+WB	WBGene00010003	F53F8.6			gene	taxon:6239			
+WB	WBGene00010005	cnc-7		F53H2.2	gene	taxon:6239			
+WB	WBGene00010010	gmeb-2		F53H4.5	gene	taxon:6239			
+WB	WBGene00010011	F53H4.6			gene	taxon:6239			
+WB	WBGene00010012	saeg-1		F53H10.2	gene	taxon:6239			
+WB	WBGene00010013	F54B3.1			gene	taxon:6239			
+WB	WBGene00010014	F54B3.2			gene	taxon:6239			
+WB	WBGene00010015	atad-3		F54B3.3	gene	taxon:6239			
+WB	WBGene00010017	nhr-282		F54B8.2	gene	taxon:6239			
+WB	WBGene00010019	F54B8.4			gene	taxon:6239			
+WB	WBGene00010020	srbc-48		F54B8.6	gene	taxon:6239			
+WB	WBGene00010021	srbc-49		F54B8.7	gene	taxon:6239			
+WB	WBGene00010022	srbc-50		F54B8.8	gene	taxon:6239			
+WB	WBGene00010023	srbc-51		F54B8.9	gene	taxon:6239			
+WB	WBGene00010025	srbc-54		F54B8.11	gene	taxon:6239			
+WB	WBGene00010026	srbc-56		F54B8.12	gene	taxon:6239			
+WB	WBGene00010028	F54B11.5			gene	taxon:6239			
+WB	WBGene00010035	F54C8.1			gene	taxon:6239			
+WB	WBGene00010036	cpar-1		F54C8.2	gene	taxon:6239			
+WB	WBGene00010037	F54C8.4			gene	taxon:6239			
+WB	WBGene00010038	rheb-1		F54C8.5	gene	taxon:6239			
+WB	WBGene00010039	F54C8.6			gene	taxon:6239			
+WB	WBGene00010040	F54C8.7			gene	taxon:6239			
+WB	WBGene00010042	bcs-1		F54C9.6	gene	taxon:6239			
+WB	WBGene00010043	F54C9.7			gene	taxon:6239			
+WB	WBGene00010045	F54C9.11			gene	taxon:6239			
+WB	WBGene00010046	F54D1.1			gene	taxon:6239			
+WB	WBGene00010047	F54D1.6			gene	taxon:6239			
+WB	WBGene00010050	F54D5.4			gene	taxon:6239			
+WB	WBGene00010052	F54D5.7			gene	taxon:6239			
+WB	WBGene00010053	F54D5.9			gene	taxon:6239			
+WB	WBGene00010054	gtf-2E2		F54D5.11	gene	taxon:6239			
+WB	WBGene00010055	F54D5.12			gene	taxon:6239			
+WB	WBGene00010056	smc-6		F54D5.14	gene	taxon:6239			
+WB	WBGene00010058	F54E4.2			gene	taxon:6239			
+WB	WBGene00010061	F54E12.2			gene	taxon:6239			
+WB	WBGene00010062	lipl-1		F54F3.3	gene	taxon:6239			
+WB	WBGene00010063	dhrs-4		F54F3.4|NP_506230|Q93790	gene	taxon:6239			
+WB	WBGene00010066	F54F7.6			gene	taxon:6239			
+WB	WBGene00010067	dot-1.2		F54F7.7	gene	taxon:6239			
+WB	WBGene00010070	nep-17		F54F11.2	gene	taxon:6239			
+WB	WBGene00010071	sre-45		F54F11.3	gene	taxon:6239			
+WB	WBGene00010072	F54F12.1			gene	taxon:6239			
+WB	WBGene00010073	F54F12.2			gene	taxon:6239			
+WB	WBGene00010075	F55A11.1			gene	taxon:6239			
+WB	WBGene00010077	F55A11.4			gene	taxon:6239			
+WB	WBGene00010079	F55A11.6			gene	taxon:6239			
+WB	WBGene00010080	F55A11.7			gene	taxon:6239			
+WB	WBGene00010083	xdh-1		F55B11.1	gene	taxon:6239			
+WB	WBGene00010088	F55B12.2			gene	taxon:6239			
+WB	WBGene00010089	hpo-31		F55B12.4	gene	taxon:6239			
+WB	WBGene00010093	capg-2		F55C5.4	gene	taxon:6239			
+WB	WBGene00010094	tsfm-1		F55C5.5	gene	taxon:6239			
+WB	WBGene00010096	rskd-1		F55C5.7	gene	taxon:6239			
+WB	WBGene00010097	srpa-68		F55C5.8	gene	taxon:6239			
+WB	WBGene00010108	F55C10.4			gene	taxon:6239			
+WB	WBGene00010109	F55C10.5			gene	taxon:6239			
+WB	WBGene00010110	F55D12.1			gene	taxon:6239			
+WB	WBGene00010114	F55D12.6			gene	taxon:6239			
+WB	WBGene00010116	cest-13		F55F3.2	gene	taxon:6239			
+WB	WBGene00010117	nkb-3		F55F3.3	gene	taxon:6239			
+WB	WBGene00010120	dot-1.4		F55G7.2	gene	taxon:6239			
+WB	WBGene00010122	F55G11.1			gene	taxon:6239			
+WB	WBGene00010123	F55G11.2			gene	taxon:6239			
+WB	WBGene00010124	F55G11.4			gene	taxon:6239			
+WB	WBGene00010125	dod-22		F55G11.5	gene	taxon:6239			
+WB	WBGene00010127	F55G11.7			gene	taxon:6239			
+WB	WBGene00010128	F55G11.8			gene	taxon:6239			
+WB	WBGene00010130	vha-14		F55H2.2	gene	taxon:6239			
+WB	WBGene00010131	F55H2.5			gene	taxon:6239			
+WB	WBGene00010134	F55H12.3			gene	taxon:6239			
+WB	WBGene00010136	F55H12.5			gene	taxon:6239			
+WB	WBGene00010137	ztf-26		F55H12.6	gene	taxon:6239			
+WB	WBGene00010138	anoh-1		F56A8.1	gene	taxon:6239			
+WB	WBGene00010139	F56A8.3			gene	taxon:6239			
+WB	WBGene00010143	F56A12.2			gene	taxon:6239			
+WB	WBGene00010145	F56C4.2			gene	taxon:6239			
+WB	WBGene00010146	glb-19		F56C4.3	gene	taxon:6239			
+WB	WBGene00010148	F56D5.3			gene	taxon:6239			
+WB	WBGene00010152	F56D5.9			gene	taxon:6239			
+WB	WBGene00010153	srxa-2		F56D5.10	gene	taxon:6239			
+WB	WBGene00010155	F56F3.4			gene	taxon:6239			
+WB	WBGene00010157	oac-34		F56G4.1	gene	taxon:6239			
+WB	WBGene00010159	wbp-4		F56G4.4	gene	taxon:6239			
+WB	WBGene00010160	png-1		F56G4.5|bam-1	gene	taxon:6239			
+WB	WBGene00010162	F56H6.1			gene	taxon:6239			
+WB	WBGene00010163	F56H6.2			gene	taxon:6239			
+WB	WBGene00010165	F56H6.4			gene	taxon:6239			
+WB	WBGene00010166	gmd-2		F56H6.5	gene	taxon:6239			
+WB	WBGene00010167	bgnt-1.6		F56H6.6	gene	taxon:6239			
+WB	WBGene00010168	F56H6.7			gene	taxon:6239			
+WB	WBGene00010169	clec-18		F56H6.8	gene	taxon:6239			
+WB	WBGene00010170	F56H6.9			gene	taxon:6239			
+WB	WBGene00010171	oac-35		F56H6.11	gene	taxon:6239			
+WB	WBGene00010172	oac-36		F56H6.12	gene	taxon:6239			
+WB	WBGene00010173	F56H6.13			gene	taxon:6239			
+WB	WBGene00010175	F56H11.2			gene	taxon:6239			
+WB	WBGene00010178	yif-1		F57A8.2	gene	taxon:6239			
+WB	WBGene00010179	F57A8.4			gene	taxon:6239			
+WB	WBGene00010180	nhr-192		F57A8.5	gene	taxon:6239			
+WB	WBGene00010182	F57A8.7			gene	taxon:6239			
+WB	WBGene00010184	F57A10.2			gene	taxon:6239			
+WB	WBGene00010185	F57A10.4			gene	taxon:6239			
+WB	WBGene00010186	nhr-283		F57A10.6	gene	taxon:6239			
+WB	WBGene00010187	F57B1.1			gene	taxon:6239			
+WB	WBGene00010188	F57B1.5			gene	taxon:6239			
+WB	WBGene00010189	F57B1.6			gene	taxon:6239			
+WB	WBGene00010191	dmsr-1		F57B7.1	gene	taxon:6239			
+WB	WBGene00010195	pot-2		F57C2.3|CeOB1	gene	taxon:6239			
+WB	WBGene00010197	F57C2.5			gene	taxon:6239			
+WB	WBGene00010198	spat-1		F57C2.6	gene	taxon:6239			
+WB	WBGene00010200	F57C7.4			gene	taxon:6239			
+WB	WBGene00010204	cpr-9		F57F5.1	gene	taxon:6239			
+WB	WBGene00010205	F57F5.3			gene	taxon:6239			
+WB	WBGene00010206	F57G4.1			gene	taxon:6239			
+WB	WBGene00010214	slc-9B.2		F57G8.5	gene	taxon:6239			
+WB	WBGene00010215	nhr-193		F57G8.6	gene	taxon:6239			
+WB	WBGene00010217	sre-31		F57G9.1	gene	taxon:6239			
+WB	WBGene00010218	sre-30		F57G9.2	gene	taxon:6239			
+WB	WBGene00010219	F57G9.3			gene	taxon:6239			
+WB	WBGene00010220	sre-29		F57G9.4	gene	taxon:6239			
+WB	WBGene00010224	F58A3.4			gene	taxon:6239			
+WB	WBGene00010225	ttr-31		F58A3.5	gene	taxon:6239			
+WB	WBGene00010228	clec-161		F58A4.5	gene	taxon:6239			
+WB	WBGene00010230	rpac-19		F58A4.9	gene	taxon:6239			
+WB	WBGene00010231	F58B3.4			gene	taxon:6239			
+WB	WBGene00010233	rbm-17		F58B3.7	gene	taxon:6239			
+WB	WBGene00010234	ttr-50		F58B3.9	gene	taxon:6239			
+WB	WBGene00010235	F58B4.2			gene	taxon:6239			
+WB	WBGene00010241	F58D2.2			gene	taxon:6239			
+WB	WBGene00010242	F58D5.2			gene	taxon:6239			
+WB	WBGene00010243	F58D5.3			gene	taxon:6239			
+WB	WBGene00010247	F58D5.8			gene	taxon:6239			
+WB	WBGene00010249	F58D12.1			gene	taxon:6239			
+WB	WBGene00010251	sta-2		F58E6.1	gene	taxon:6239			
+WB	WBGene00010253	F58E6.4			gene	taxon:6239			
+WB	WBGene00010254	F58E6.5			gene	taxon:6239			
+WB	WBGene00010255	F58E6.6			gene	taxon:6239			
+WB	WBGene00010256	hrg-3		F58E6.7	gene	taxon:6239			
+WB	WBGene00010257	F58E6.8			gene	taxon:6239			
+WB	WBGene00010258	F58E6.11			gene	taxon:6239			
+WB	WBGene00010259	ric-7		F58E10.1	gene	taxon:6239			
+WB	WBGene00010260	ddx-17		F58E10.3	gene	taxon:6239			
+WB	WBGene00010261	srh-308		F58E10.6	gene	taxon:6239			
+WB	WBGene00010263	wago-4		F58G1.1|F58G1.g	gene	taxon:6239			
+WB	WBGene00010265	F58G1.3			gene	taxon:6239			
+WB	WBGene00010267	lips-9		F58G1.5	gene	taxon:6239			
+WB	WBGene00010269	F58G1.7			gene	taxon:6239			
+WB	WBGene00010272	amph-1		F58G6.1	gene	taxon:6239			
+WB	WBGene00010273	srm-3		F58G6.2	gene	taxon:6239			
+WB	WBGene00010274	F58G6.3			gene	taxon:6239			
+WB	WBGene00010275	acc-1		F58G6.4	gene	taxon:6239			
+WB	WBGene00010277	F58G6.7			gene	taxon:6239			
+WB	WBGene00010278	F58G6.8			gene	taxon:6239			
+WB	WBGene00010279	letm-1		F58G11.1	gene	taxon:6239			
+WB	WBGene00010280	rde-12		F58G11.2	gene	taxon:6239			
+WB	WBGene00010282	F58G11.4			gene	taxon:6239			
+WB	WBGene00010283	ccz-1		F58G11.6|Ce-ccz-1	gene	taxon:6239			
+WB	WBGene00010284	aman-2		F58H1.1	gene	taxon:6239			
+WB	WBGene00010286	F58H1.3			gene	taxon:6239			
+WB	WBGene00010288	F58H1.5			gene	taxon:6239			
+WB	WBGene00010289	F58H1.6			gene	taxon:6239			
+WB	WBGene00010296	dgat-2		F59A1.10	gene	taxon:6239			
+WB	WBGene00010297	F59A1.11			gene	taxon:6239			
+WB	WBGene00010298	F59A1.12			gene	taxon:6239			
+WB	WBGene00010299	F59A1.13			gene	taxon:6239			
+WB	WBGene00010300	F59A1.15			gene	taxon:6239			
+WB	WBGene00010303	cri-3		F59A2.3	gene	taxon:6239			
+WB	WBGene00010304	clpf-1		F59A2.4	gene	taxon:6239			
+WB	WBGene00010307	skat-1		F59B2.2	gene	taxon:6239			
+WB	WBGene00010308	F59B2.3			gene	taxon:6239			
+WB	WBGene00010309	rpn-6.2		F59B2.5	gene	taxon:6239			
+WB	WBGene00010315	F59B2.13			gene	taxon:6239			
+WB	WBGene00010317	idh-1		F59B8.2	gene	taxon:6239			
+WB	WBGene00010319	F59B10.3			gene	taxon:6239			
+WB	WBGene00010320	F59B10.4			gene	taxon:6239			
+WB	WBGene00010322	F59B10.6			gene	taxon:6239			
+WB	WBGene00010323	dhhc-12		F59C6.2	gene	taxon:6239			
+WB	WBGene00010324	F59C6.3			gene	taxon:6239			
+WB	WBGene00010325	exos-3		F59C6.4|exso-3	gene	taxon:6239			
+WB	WBGene00010326	F59C6.5			gene	taxon:6239			
+WB	WBGene00010327	F59C6.8			gene	taxon:6239			
+WB	WBGene00010328	F59C6.11			gene	taxon:6239			
+WB	WBGene00010329	pcdr-1		F59D12.1	gene	taxon:6239			
+WB	WBGene00010330	F59D12.2			gene	taxon:6239			
+WB	WBGene00010331	F59D12.3			gene	taxon:6239			
+WB	WBGene00010333	copz-1		F59E10.3	gene	taxon:6239			
+WB	WBGene00010334	del-5		F59F3.4	gene	taxon:6239			
+WB	WBGene00010335	F59F3.6			gene	taxon:6239			
+WB	WBGene00010336	acox-1.6		F59F4.1|acox-6	gene	taxon:6239			
+WB	WBGene00010337	serp-1.1		F59F4.2	gene	taxon:6239			
+WB	WBGene00010338	F59F4.3			gene	taxon:6239			
+WB	WBGene00010339	acl-1		F59F4.4	gene	taxon:6239			
+WB	WBGene00010340	slcf-1		F59F5.1	gene	taxon:6239			
+WB	WBGene00010341	glo-3		F59F5.2|XL153	gene	taxon:6239			
+WB	WBGene00010342	F59F5.3			gene	taxon:6239			
+WB	WBGene00010343	F59F5.4			gene	taxon:6239			
+WB	WBGene00010349	dyf-18		H01G02.2	gene	taxon:6239			
+WB	WBGene00010350	H01G02.3			gene	taxon:6239			
+WB	WBGene00010351	cbd-1		H02I12.1	gene	taxon:6239			
+WB	WBGene00010354	cyp-31A2		H02I12.8	gene	taxon:6239			
+WB	WBGene00010355	clec-229		H02K04.1	gene	taxon:6239			
+WB	WBGene00010356	famk-1		H03A11.1|Fam20	gene	taxon:6239			
+WB	WBGene00010362	enu-3.1		H04D03.1|enu-3	gene	taxon:6239			
+WB	WBGene00010364	ecps-2		H04D03.3	gene	taxon:6239			
+WB	WBGene00010366	H05L14.1			gene	taxon:6239			
+WB	WBGene00010367	H05L14.2			gene	taxon:6239			
+WB	WBGene00010368	H06A10.1			gene	taxon:6239			
+WB	WBGene00010369	chd-1		H06O01.2	gene	taxon:6239			
+WB	WBGene00010370	ctg-1		H06O01.3	gene	taxon:6239			
+WB	WBGene00010373	H08M01.1			gene	taxon:6239			
+WB	WBGene00010374	rga-5		H08M01.2	gene	taxon:6239			
+WB	WBGene00010375	H09F14.1			gene	taxon:6239			
+WB	WBGene00010380	mpst-2		H12D21.4	gene	taxon:6239			
+WB	WBGene00010381	H12D21.5			gene	taxon:6239			
+WB	WBGene00010383	mpst-3		H12D21.7	gene	taxon:6239			
+WB	WBGene00010385	H12D21.9			gene	taxon:6239			
+WB	WBGene00010386	H12D21.10			gene	taxon:6239			
+WB	WBGene00010387	H12D21.11			gene	taxon:6239			
+WB	WBGene00010388	srz-42		H12I19.1	gene	taxon:6239			
+WB	WBGene00010389	srz-31		H12I19.2	gene	taxon:6239			
+WB	WBGene00010391	oac-37		H12I19.4	gene	taxon:6239			
+WB	WBGene00010392	oac-38		H12I19.5	gene	taxon:6239			
+WB	WBGene00010394	srz-59		H12I19.7	gene	taxon:6239			
+WB	WBGene00010397	suox-1		H13N06.4	gene	taxon:6239			
+WB	WBGene00010399	clec-13		H16D19.1	gene	taxon:6239			
+WB	WBGene00010403	otpl-8		H19J13.1	gene	taxon:6239			
+WB	WBGene00010405	erfa-3		H19N07.1|phi-19	gene	taxon:6239			
+WB	WBGene00010406	math-33		H19N07.2	gene	taxon:6239			
+WB	WBGene00010407	scb-1		H19N07.3	gene	taxon:6239			
+WB	WBGene00010408	mboa-2		H19N07.4	gene	taxon:6239			
+WB	WBGene00010409	H21P03.2			gene	taxon:6239			
+WB	WBGene00010410	nhr-267		H22D14.1	gene	taxon:6239			
+WB	WBGene00010411	H25K10.1			gene	taxon:6239			
+WB	WBGene00010414	hpa-1		H25K10.5	gene	taxon:6239			
+WB	WBGene00010416	hxk-2		H25P06.1	gene	taxon:6239			
+WB	WBGene00010417	clpr-3		H25P06.4	gene	taxon:6239			
+WB	WBGene00010418	H27A22.1			gene	taxon:6239			
+WB	WBGene00010419	atp-1		H28O16.1|phi-37	gene	taxon:6239			
+WB	WBGene00010420	mcrs-1		H28O16.2	gene	taxon:6239			
+WB	WBGene00010421	slc-36.4		H32K16.1	gene	taxon:6239			
+WB	WBGene00010423	zmp-5		H36L18.1	gene	taxon:6239			
+WB	WBGene00010425	lpin-1		H37A05.1	gene	taxon:6239			
+WB	WBGene00010427	hpo-11		H37N21.1	gene	taxon:6239			
+WB	WBGene00010428	dcn-1		H38K22.2	gene	taxon:6239			
+WB	WBGene00010435	JC8.2			gene	taxon:6239			
+WB	WBGene00010436	JC8.4			gene	taxon:6239			
+WB	WBGene00010437	cox-11		JC8.5	gene	taxon:6239			
+WB	WBGene00010440	ttr-51		JC8.8	gene	taxon:6239			
+WB	WBGene00010442	bus-12		JC8.12	gene	taxon:6239			
+WB	WBGene00010444	magi-1		K01A6.2	gene	taxon:6239			
+WB	WBGene00010446	K01A6.4			gene	taxon:6239			
+WB	WBGene00010448	K01A6.6			gene	taxon:6239			
+WB	WBGene00010450	metl-18		K01A11.2	gene	taxon:6239			
+WB	WBGene00010453	fozi-1		K01B6.1	gene	taxon:6239			
+WB	WBGene00010456	K01C8.1			gene	taxon:6239			
+WB	WBGene00010458	mrpl-10		K01C8.6	gene	taxon:6239			
+WB	WBGene00010459	slc-25A32		K01C8.7	gene	taxon:6239			
+WB	WBGene00010460	clec-142		K01C8.8	gene	taxon:6239			
+WB	WBGene00010461	K01D12.1			gene	taxon:6239			
+WB	WBGene00010465	miga-1		K01D12.6	gene	taxon:6239			
+WB	WBGene00010470	cdr-4		K01D12.11	gene	taxon:6239			
+WB	WBGene00010473	hrg-2		K01D12.14|cdr-5	gene	taxon:6239			
+WB	WBGene00010476	rnf-113		K01G5.1|3K846|tag-331	gene	taxon:6239			
+WB	WBGene00010478	K01G5.5			gene	taxon:6239			
+WB	WBGene00010479	K01G5.8			gene	taxon:6239			
+WB	WBGene00010480	tasp-1		K01G5.9	gene	taxon:6239			
+WB	WBGene00010484	dph-3		K01H12.1	gene	taxon:6239			
+WB	WBGene00010485	ant-1.3		K01H12.2|wan-4	gene	taxon:6239			
+WB	WBGene00010488	endu-1		K02A11.3	gene	taxon:6239			
+WB	WBGene00010492	meg-1		K02B9.1	gene	taxon:6239			
+WB	WBGene00010493	meg-2		K02B9.2	gene	taxon:6239			
+WB	WBGene00010496	sec-12		K02B12.3|phi-15	gene	taxon:6239			
+WB	WBGene00010497	axl-1		K02B12.4|Axin	gene	taxon:6239			
+WB	WBGene00010500	K02B12.7			gene	taxon:6239			
+WB	WBGene00010502	K02C4.3			gene	taxon:6239			
+WB	WBGene00010505	K02D3.2			gene	taxon:6239			
+WB	WBGene00010506	K02E2.1			gene	taxon:6239			
+WB	WBGene00010510	ent-3		K02E11.1	gene	taxon:6239			
+WB	WBGene00010511	sre-7		K02E11.2	gene	taxon:6239			
+WB	WBGene00010520	cpx-2		K03A11.2	gene	taxon:6239			
+WB	WBGene00010521	K03A11.4			gene	taxon:6239			
+WB	WBGene00010522	K03A11.5			gene	taxon:6239			
+WB	WBGene00010524	K03B8.6			gene	taxon:6239			
+WB	WBGene00010527	srz-74		K03D3.1	gene	taxon:6239			
+WB	WBGene00010530	srz-61		K03D3.4	gene	taxon:6239			
+WB	WBGene00010537	mys-2		K03D10.3	gene	taxon:6239			
+WB	WBGene00010538	ttr-3		K03H1.3	gene	taxon:6239			
+WB	WBGene00010539	ttr-2		K03H1.4	gene	taxon:6239			
+WB	WBGene00010540	K03H1.5			gene	taxon:6239			
+WB	WBGene00010541	ttr-1		K03H1.6	gene	taxon:6239			
+WB	WBGene00010544	K03H1.9			gene	taxon:6239			
+WB	WBGene00010545	cbp-2		K03H1.10	gene	taxon:6239			
+WB	WBGene00010547	K03H1.12			gene	taxon:6239			
+WB	WBGene00010551	smg-8		K04B12.3	gene	taxon:6239			
+WB	WBGene00010553	K04C1.3			gene	taxon:6239			
+WB	WBGene00010554	mlc-6		K04C1.4	gene	taxon:6239			
+WB	WBGene00010555	K04C1.5			gene	taxon:6239			
+WB	WBGene00010556	rack-1		K04D7.1	gene	taxon:6239			
+WB	WBGene00010557	mspn-1		K04D7.2	gene	taxon:6239			
+WB	WBGene00010558	ptp-4		K04D7.4	gene	taxon:6239			
+WB	WBGene00010559	K04D7.6			gene	taxon:6239			
+WB	WBGene00010560	eif-2beta		K04G2.1|iftb-1|phi-17	gene	taxon:6239			
+WB	WBGene00010562	cdc-48.3		K04G2.3	gene	taxon:6239			
+WB	WBGene00010564	ath-1		K04G2.5	gene	taxon:6239			
+WB	WBGene00010565	vacl-14		K04G2.6	gene	taxon:6239			
+WB	WBGene00010567	K04G2.9			gene	taxon:6239			
+WB	WBGene00010569	scbp-2		K04G2.11	gene	taxon:6239			
+WB	WBGene00010573	K04H4.2			gene	taxon:6239			
+WB	WBGene00010575	flp-25		K04H4.7	gene	taxon:6239			
+WB	WBGene00010576	clec-116		K04H8.1	gene	taxon:6239			
+WB	WBGene00010579	K05C4.2			gene	taxon:6239			
+WB	WBGene00010582	K05C4.5			gene	taxon:6239			
+WB	WBGene00010583	K05C4.7			gene	taxon:6239			
+WB	WBGene00010586	K05C4.10			gene	taxon:6239			
+WB	WBGene00010587	sol-2		K05C4.11	gene	taxon:6239			
+WB	WBGene00010588	srz-14		K05D4.3	gene	taxon:6239			
+WB	WBGene00010589	cyp-33D1		K05D4.4	gene	taxon:6239			
+WB	WBGene00010590	srz-13		K05D4.8	gene	taxon:6239			
+WB	WBGene00010591	K05D4.9			gene	taxon:6239			
+WB	WBGene00010592	K06A4.2			gene	taxon:6239			
+WB	WBGene00010593	gsnl-1		K06A4.3	gene	taxon:6239			
+WB	WBGene00010594	swt-5		K06A4.4	gene	taxon:6239			
+WB	WBGene00010595	haao-1		K06A4.5	gene	taxon:6239			
+WB	WBGene00010599	K06B4.4			gene	taxon:6239			
+WB	WBGene00010600	nhr-196		K06B4.5	gene	taxon:6239			
+WB	WBGene00010601	nhr-268		K06B4.6	gene	taxon:6239			
+WB	WBGene00010602	nhr-197		K06B4.7	gene	taxon:6239			
+WB	WBGene00010603	nhr-198		K06B4.8	gene	taxon:6239			
+WB	WBGene00010604	nhr-199		K06B4.10	gene	taxon:6239			
+WB	WBGene00010606	cyp-13B2		K06G5.2	gene	taxon:6239			
+WB	WBGene00010608	K07A1.1			gene	taxon:6239			
+WB	WBGene00010609	dut-1		K07A1.2	gene	taxon:6239			
+WB	WBGene00010610	K07A1.3			gene	taxon:6239			
+WB	WBGene00010612	K07A1.5			gene	taxon:6239			
+WB	WBGene00010613	K07A1.6			gene	taxon:6239			
+WB	WBGene00010615	ate-1		K07A1.9	gene	taxon:6239			
+WB	WBGene00010616	K07A1.10			gene	taxon:6239			
+WB	WBGene00010617	K07A1.13			gene	taxon:6239			
+WB	WBGene00010619	K07A1.15			gene	taxon:6239			
+WB	WBGene00010621	egg-6		K07A12.2	gene	taxon:6239			
+WB	WBGene00010622	hbs-1		K07A12.4	gene	taxon:6239			
+WB	WBGene00010624	mrps-15		K07A12.7	gene	taxon:6239			
+WB	WBGene00010625	K07C5.2			gene	taxon:6239			
+WB	WBGene00010626	K07C5.3		CeLig3	gene	taxon:6239			
+WB	WBGene00010627	nol-56		K07C5.4	gene	taxon:6239			
+WB	WBGene00010628	ceeh-2		K07C5.5	gene	taxon:6239			
+WB	WBGene00010629	sluh-7		K07C5.6	gene	taxon:6239			
+WB	WBGene00010630	ttll-15		K07C5.7	gene	taxon:6239			
+WB	WBGene00010631	cash-1		K07C5.8	gene	taxon:6239			
+WB	WBGene00010634	K07F5.6			gene	taxon:6239			
+WB	WBGene00010635	K07F5.7			gene	taxon:6239			
+WB	WBGene00010636	K07F5.8			gene	taxon:6239			
+WB	WBGene00010637	K07F5.12			gene	taxon:6239			
+WB	WBGene00010641	crml-1		K07G5.1	gene	taxon:6239			
+WB	WBGene00010642	mks-6		K07G5.3	gene	taxon:6239			
+WB	WBGene00010644	K07G5.5			gene	taxon:6239			
+WB	WBGene00010645	fecl-1		K07G5.6	gene	taxon:6239			
+WB	WBGene00010646	K08C7.1			gene	taxon:6239			
+WB	WBGene00010648	K08C7.6			gene	taxon:6239			
+WB	WBGene00010655	K08D8.1			gene	taxon:6239			
+WB	WBGene00010656	K08D8.2			gene	taxon:6239			
+WB	WBGene00010658	K08D8.4			gene	taxon:6239			
+WB	WBGene00010659	K08D8.5			gene	taxon:6239			
+WB	WBGene00010660	K08D8.6			gene	taxon:6239			
+WB	WBGene00010661	tyr-2		K08E3.1	gene	taxon:6239			
+WB	WBGene00010662	K08E3.2			gene	taxon:6239			
+WB	WBGene00010663	toca-2		K08E3.3	gene	taxon:6239			
+WB	WBGene00010664	dbn-1		K08E3.4	gene	taxon:6239			
+WB	WBGene00010665	rml-1		K08E3.5	gene	taxon:6239			
+WB	WBGene00010666	K08E4.2			gene	taxon:6239			
+WB	WBGene00010669	bath-37		K08E4.5	gene	taxon:6239			
+WB	WBGene00010670	tmed-1		K08E4.6	gene	taxon:6239			
+WB	WBGene00010671	eak-7		K08E7.1	gene	taxon:6239			
+WB	WBGene00010673	K08E7.5			gene	taxon:6239			
+WB	WBGene00010676	ctf-18		K08F4.1	gene	taxon:6239			
+WB	WBGene00010677	gtbp-1		K08F4.2	gene	taxon:6239			
+WB	WBGene00010678	K08F4.3			gene	taxon:6239			
+WB	WBGene00010681	mak-1		K08F8.1	gene	taxon:6239			
+WB	WBGene00010683	K08F8.7			gene	taxon:6239			
+WB	WBGene00010684	K08F9.1			gene	taxon:6239			
+WB	WBGene00010685	aipl-1		K08F9.2|tag-216	gene	taxon:6239			
+WB	WBGene00010686	K08F9.3			gene	taxon:6239			
+WB	WBGene00010688	srz-12		K08G2.7	gene	taxon:6239			
+WB	WBGene00010692	K08H2.5			gene	taxon:6239			
+WB	WBGene00010694	bgnt-1.5		K08H2.9	gene	taxon:6239			
+WB	WBGene00010697	uda-1		K08H10.4	gene	taxon:6239			
+WB	WBGene00010698	K08H10.6			gene	taxon:6239			
+WB	WBGene00010699	trpp-6		K08H10.9	gene	taxon:6239			
+WB	WBGene00010700	nipi-3		K09A9.1	gene	taxon:6239			
+WB	WBGene00010701	ent-2		K09A9.3	gene	taxon:6239			
+WB	WBGene00010702	usp-33		K09A9.4	gene	taxon:6239			
+WB	WBGene00010703	K09A9.6			gene	taxon:6239			
+WB	WBGene00010704	K09A11.1			gene	taxon:6239			
+WB	WBGene00010705	cyp-14A1		K09A11.2	gene	taxon:6239			
+WB	WBGene00010706	cyp-14A2		K09A11.3|tag-190	gene	taxon:6239			
+WB	WBGene00010707	cyp-14A3		K09A11.4	gene	taxon:6239			
+WB	WBGene00010708	phf-33		K09A11.5	gene	taxon:6239			
+WB	WBGene00010709	nol-9		K09B11.2	gene	taxon:6239			
+WB	WBGene00010712	K09B11.5			gene	taxon:6239			
+WB	WBGene00010713	uso-1		K09B11.9	gene	taxon:6239			
+WB	WBGene00010715	K09C8.2			gene	taxon:6239			
+WB	WBGene00010716	lge-1		K09C8.4	gene	taxon:6239			
+WB	WBGene00010719	K09E4.1			gene	taxon:6239			
+WB	WBGene00010720	algn-3		K09E4.2	gene	taxon:6239			
+WB	WBGene00010721	K09E4.3			gene	taxon:6239			
+WB	WBGene00010724	K09E9.1			gene	taxon:6239			
+WB	WBGene00010725	erv-46		K09E9.2	gene	taxon:6239			
+WB	WBGene00010727	K09G1.1			gene	taxon:6239			
+WB	WBGene00010728	K09G1.2			gene	taxon:6239			
+WB	WBGene00010730	ensa-1		K10C3.2	gene	taxon:6239			
+WB	WBGene00010731	K10C3.4			gene	taxon:6239			
+WB	WBGene00010732	K10C3.5			gene	taxon:6239			
+WB	WBGene00010734	parn-1		K10C8.1	gene	taxon:6239			
+WB	WBGene00010735	frpr-15		K10C8.2	gene	taxon:6239			
+WB	WBGene00010736	istr-1		K10C8.3	gene	taxon:6239			
+WB	WBGene00010737	K10C8.4			gene	taxon:6239			
+WB	WBGene00010738	K10D3.4			gene	taxon:6239			
+WB	WBGene00010740	K10D3.6			gene	taxon:6239			
+WB	WBGene00010741	lgc-49		K10D6.1	gene	taxon:6239			
+WB	WBGene00010742	clc-6		K10D6.2	gene	taxon:6239			
+WB	WBGene00010745	dod-17		K10D11.1	gene	taxon:6239			
+WB	WBGene00010749	K10D11.5			gene	taxon:6239			
+WB	WBGene00010755	vglu-2		K10G9.1	gene	taxon:6239			
+WB	WBGene00010757	pad-2		K10G9.3|pfut-2	gene	taxon:6239			
+WB	WBGene00010758	vnut-1		K10H10.1	gene	taxon:6239			
+WB	WBGene00010759	cysl-2		K10H10.2	gene	taxon:6239			
+WB	WBGene00010760	K10H10.4			gene	taxon:6239			
+WB	WBGene00010761	K10H10.5			gene	taxon:6239			
+WB	WBGene00010762	K10H10.6			gene	taxon:6239			
+WB	WBGene00010763	K10H10.7			gene	taxon:6239			
+WB	WBGene00010765	K10H10.10			gene	taxon:6239			
+WB	WBGene00010767	blos-9		K11B4.2	gene	taxon:6239			
+WB	WBGene00010769	asah-1		K11D2.2|dod-7	gene	taxon:6239			
+WB	WBGene00010771	mter-4		K11D2.5	gene	taxon:6239			
+WB	WBGene00010772	K11D9.3			gene	taxon:6239			
+WB	WBGene00010773	K11E4.1			gene	taxon:6239			
+WB	WBGene00010775	poml-1		K11E4.3	gene	taxon:6239			
+WB	WBGene00010776	pix-1		K11E4.4|tag-207	gene	taxon:6239			
+WB	WBGene00010778	gpdh-2		K11H3.1	gene	taxon:6239			
+WB	WBGene00010780	K11H3.3			gene	taxon:6239			
+WB	WBGene00010783	mrpl-36		K11H3.6	gene	taxon:6239			
+WB	WBGene00010784	twk-48		K11H3.7	gene	taxon:6239			
+WB	WBGene00010785	top-2		K12D12.1|mel-15|topo-II	gene	taxon:6239			
+WB	WBGene00010786	K12D12.4			gene	taxon:6239			
+WB	WBGene00010787	K12D12.5			gene	taxon:6239			
+WB	WBGene00010788	sulp-4		K12G11.1	gene	taxon:6239			
+WB	WBGene00010789	sulp-5		K12G11.2	gene	taxon:6239			
+WB	WBGene00010790	sodh-1		K12G11.3|dod-11	gene	taxon:6239			
+WB	WBGene00010791	sodh-2		K12G11.4|dod-14	gene	taxon:6239			
+WB	WBGene00010792	K12G11.6			gene	taxon:6239			
+WB	WBGene00010794	dld-1		LLC1.3	gene	taxon:6239			
+WB	WBGene00010795	M01A8.1			gene	taxon:6239			
+WB	WBGene00010796	clip-1		M01A8.2	gene	taxon:6239			
+WB	WBGene00010797	srbc-75		M01B2.3	gene	taxon:6239			
+WB	WBGene00010798	srbc-76		M01B2.4	gene	taxon:6239			
+WB	WBGene00010799	chil-12		M01B2.6	gene	taxon:6239			
+WB	WBGene00010800	srsx-37		M01B2.7	gene	taxon:6239			
+WB	WBGene00010802	srsx-39		M01B2.9	gene	taxon:6239			
+WB	WBGene00010805	M01E5.2			gene	taxon:6239			
+WB	WBGene00010807	M01E5.4			gene	taxon:6239			
+WB	WBGene00010808	sepa-1		M01E5.6	gene	taxon:6239			
+WB	WBGene00010809	lias-1		M01F1.3	gene	taxon:6239			
+WB	WBGene00010810	M01F1.4			gene	taxon:6239			
+WB	WBGene00010811	hmit-1.3		M01F1.5	gene	taxon:6239			
+WB	WBGene00010812	mrpl-35		M01F1.6	gene	taxon:6239			
+WB	WBGene00010813	pitp-1		M01F1.7	gene	taxon:6239			
+WB	WBGene00010815	M01F1.9			gene	taxon:6239			
+WB	WBGene00010821	M01G12.7			gene	taxon:6239			
+WB	WBGene00010822	M01G12.9			gene	taxon:6239			
+WB	WBGene00010825	M01G12.14			gene	taxon:6239			
+WB	WBGene00010827	txt-19		M02B1.2	gene	taxon:6239			
+WB	WBGene00010828	M02B1.3			gene	taxon:6239			
+WB	WBGene00010829	M02B1.4			gene	taxon:6239			
+WB	WBGene00010834	mct-3		M03B6.2	gene	taxon:6239			
+WB	WBGene00010836	M03B6.4			gene	taxon:6239			
+WB	WBGene00010837	M03B6.5			gene	taxon:6239			
+WB	WBGene00010838	M03C11.1			gene	taxon:6239			
+WB	WBGene00010839	chl-1		M03C11.2	gene	taxon:6239			
+WB	WBGene00010842	ymel-1		M03C11.5	gene	taxon:6239			
+WB	WBGene00010844	prp-3		M03C11.7	gene	taxon:6239			
+WB	WBGene00010845	M03C11.8			gene	taxon:6239			
+WB	WBGene00010846	M04B2.2			gene	taxon:6239			
+WB	WBGene00010847	M04B2.4			gene	taxon:6239			
+WB	WBGene00010849	M04B2.7			gene	taxon:6239			
+WB	WBGene00010850	M04C3.1			gene	taxon:6239			
+WB	WBGene00010851	M04C3.2			gene	taxon:6239			
+WB	WBGene00010855	M04C7.4			gene	taxon:6239			
+WB	WBGene00010856	M04C9.1			gene	taxon:6239			
+WB	WBGene00010857	M04C9.2			gene	taxon:6239			
+WB	WBGene00010858	M04C9.3			gene	taxon:6239			
+WB	WBGene00010862	M04D8.4			gene	taxon:6239			
+WB	WBGene00010863	M04D8.5			gene	taxon:6239			
+WB	WBGene00010864	xbx-3		M04D8.6	gene	taxon:6239			
+WB	WBGene00010865	M04D8.7			gene	taxon:6239			
+WB	WBGene00010866	M04D8.8			gene	taxon:6239			
+WB	WBGene00010867	ifbp-1		M04G12.1|tag-260	gene	taxon:6239			
+WB	WBGene00010868	somi-1		M04G12.4	gene	taxon:6239			
+WB	WBGene00010869	M05B5.1			gene	taxon:6239			
+WB	WBGene00010870	let-522		M05B5.2	gene	taxon:6239			
+WB	WBGene00010871	M05B5.3			gene	taxon:6239			
+WB	WBGene00010872	M05B5.4			gene	taxon:6239			
+WB	WBGene00010873	trpa-2		M05B5.6	gene	taxon:6239			
+WB	WBGene00010874	M05D6.1			gene	taxon:6239			
+WB	WBGene00010876	M05D6.3			gene	taxon:6239			
+WB	WBGene00010878	M05D6.5			gene	taxon:6239			
+WB	WBGene00010879	taap-1		M05D6.6	gene	taxon:6239			
+WB	WBGene00010882	atg-7		M7.5|atgr-7	gene	taxon:6239			
+WB	WBGene00010883	M7.7			gene	taxon:6239			
+WB	WBGene00010888	dlc-2		M18.2	gene	taxon:6239			
+WB	WBGene00010889	M18.3			gene	taxon:6239			
+WB	WBGene00010890	ddb-1		M18.5	gene	taxon:6239			
+WB	WBGene00010892	dhhc-6		M18.8	gene	taxon:6239			
+WB	WBGene00010893	cutl-9		M28.1	gene	taxon:6239			
+WB	WBGene00010895	M28.4			gene	taxon:6239			
+WB	WBGene00010896	snu-13		M28.5|phi-9	gene	taxon:6239			
+WB	WBGene00010898	nphp-1		M28.7|nph-1	gene	taxon:6239			
+WB	WBGene00010899	M28.8			gene	taxon:6239			
+WB	WBGene00010900	M28.9			gene	taxon:6239			
+WB	WBGene00010902	M79.2			gene	taxon:6239			
+WB	WBGene00010904	ugt-62		M88.1	gene	taxon:6239			
+WB	WBGene00010905	mrps-34		M88.2	gene	taxon:6239			
+WB	WBGene00010908	imph-1		M88.5|zbp-1	gene	taxon:6239			
+WB	WBGene00010909	cisd-3.1		M88.7	gene	taxon:6239			
+WB	WBGene00010910	M106.2			gene	taxon:6239			
+WB	WBGene00010911	M106.3			gene	taxon:6239			
+WB	WBGene00010912	gmps-1		M106.4	gene	taxon:6239			
+WB	WBGene00010913	M110.3			gene	taxon:6239			
+WB	WBGene00010915	M110.7			gene	taxon:6239			
+WB	WBGene00010916	M110.8			gene	taxon:6239			
+WB	WBGene00010918	M117.1			gene	taxon:6239			
+WB	WBGene00010923	rle-1		M142.6	gene	taxon:6239			
+WB	WBGene00010924	pycr-1		M153.1	gene	taxon:6239			
+WB	WBGene00010925	mfsd-11		M153.2	gene	taxon:6239			
+WB	WBGene00010928	clec-258		M162.2	gene	taxon:6239			
+WB	WBGene00010929	srt-45		M162.3	gene	taxon:6239			
+WB	WBGene00010931	M162.5			gene	taxon:6239			
+WB	WBGene00010939	M163.7			gene	taxon:6239			
+WB	WBGene00010941	gss-1		M176.2	gene	taxon:6239			
+WB	WBGene00010942	chch-3		M176.3	gene	taxon:6239			
+WB	WBGene00010943	M176.4			gene	taxon:6239			
+WB	WBGene00010945	chil-13		M176.8	gene	taxon:6239			
+WB	WBGene00010947	M176.11			gene	taxon:6239			
+WB	WBGene00010950	srt-44		M199.1	gene	taxon:6239			
+WB	WBGene00010951	M199.2			gene	taxon:6239			
+WB	WBGene00010953	clec-190		M199.4	gene	taxon:6239			
+WB	WBGene00010954	clec-189		M199.6	gene	taxon:6239			
+WB	WBGene00010957	nduo-6		MTCE.3|ND6	gene	taxon:6239			
+WB	WBGene00010958	ndfl-4		MTCE.4|ND4L	gene	taxon:6239			
+WB	WBGene00010959	nduo-1		MTCE.11|ND1	gene	taxon:6239			
+WB	WBGene00010960	atp-6		MTCE.12|ATP6|ATPase 6	gene	taxon:6239			
+WB	WBGene00010961	nduo-2		MTCE.16|ND2	gene	taxon:6239			
+WB	WBGene00010962	ctc-3		MTCE.23|COIII|COX3	gene	taxon:6239			
+WB	WBGene00010963	nduo-4		MTCE.25|ND4	gene	taxon:6239			
+WB	WBGene00010964	ctc-1		MTCE.26|COI|COX1	gene	taxon:6239			
+WB	WBGene00010965	ctc-2		MTCE.31|COII|COX2	gene	taxon:6239			
+WB	WBGene00010966	nduo-3		MTCE.34|ND3	gene	taxon:6239			
+WB	WBGene00010967	nduo-5		MTCE.35|ND5	gene	taxon:6239			
+WB	WBGene00010968	R01E6.2			gene	taxon:6239			
+WB	WBGene00010970	glb-20		R01E6.6	gene	taxon:6239			
+WB	WBGene00010973	rip-1		R01H10.5	gene	taxon:6239			
+WB	WBGene00010974	bbs-5		R01H10.6	gene	taxon:6239			
+WB	WBGene00010975	R01H10.7			gene	taxon:6239			
+WB	WBGene00010976	R02D5.1			gene	taxon:6239			
+WB	WBGene00010977	R02D5.3			gene	taxon:6239			
+WB	WBGene00010979	R02D5.6			gene	taxon:6239			
+WB	WBGene00010980	R02D5.7			gene	taxon:6239			
+WB	WBGene00010981	blos-8		R03A10.1	gene	taxon:6239			
+WB	WBGene00010983	mocs-1		R03A10.3	gene	taxon:6239			
+WB	WBGene00010984	nkat-3		R03A10.4	gene	taxon:6239			
+WB	WBGene00010986	sprr-1		R03A10.6	gene	taxon:6239			
+WB	WBGene00010988	metr-1		R03D7.1	gene	taxon:6239			
+WB	WBGene00010989	R03D7.2			gene	taxon:6239			
+WB	WBGene00010990	tceb-3		R03D7.4|C. elegans elongin A	gene	taxon:6239			
+WB	WBGene00010991	R03D7.5			gene	taxon:6239			
+WB	WBGene00010992	R03D7.8			gene	taxon:6239			
+WB	WBGene00010993	vha-20		R03E1.2	gene	taxon:6239			
+WB	WBGene00010994	lgc-25		R03E1.3	gene	taxon:6239			
+WB	WBGene00010995	ceh-90		R03E1.4	gene	taxon:6239			
+WB	WBGene00010996	R03G8.1			gene	taxon:6239			
+WB	WBGene00010998	R03G8.3			gene	taxon:6239			
+WB	WBGene00011000	R03G8.6			gene	taxon:6239			
+WB	WBGene00011001	R04B5.1			gene	taxon:6239			
+WB	WBGene00011002	nhr-205		R04B5.3	gene	taxon:6239			
+WB	WBGene00011003	R04B5.5			gene	taxon:6239			
+WB	WBGene00011004	R04B5.6			gene	taxon:6239			
+WB	WBGene00011006	ugt-47		R04B5.9	gene	taxon:6239			
+WB	WBGene00011009	cyp-14A4		R04D3.1	gene	taxon:6239			
+WB	WBGene00011013	srxa-8		R04D3.10	gene	taxon:6239			
+WB	WBGene00011014	hpo-30		R04F11.1	gene	taxon:6239			
+WB	WBGene00011015	R04F11.2			gene	taxon:6239			
+WB	WBGene00011016	R04F11.3			gene	taxon:6239			
+WB	WBGene00011017	R04F11.5			gene	taxon:6239			
+WB	WBGene00011021	R05A10.4			gene	taxon:6239			
+WB	WBGene00011023	R05A10.6			gene	taxon:6239			
+WB	WBGene00011024	R05A10.7			gene	taxon:6239			
+WB	WBGene00011025	R05A10.8			gene	taxon:6239			
+WB	WBGene00011026	R05D7.1			gene	taxon:6239			
+WB	WBGene00011028	R05D7.3			gene	taxon:6239			
+WB	WBGene00011029	abhd-11.2		R05D7.4	gene	taxon:6239			
+WB	WBGene00011032	ddx-52		R05D11.4	gene	taxon:6239			
+WB	WBGene00011033	tmem-208		R05D11.5	gene	taxon:6239			
+WB	WBGene00011034	paxt-1		R05D11.6	gene	taxon:6239			
+WB	WBGene00011035	snrp-27		R05D11.7	gene	taxon:6239			
+WB	WBGene00011036	edc-3		R05D11.8	gene	taxon:6239			
+WB	WBGene00011037	R05D11.9		NP_492324	gene	taxon:6239			
+WB	WBGene00011039	R05H5.4			gene	taxon:6239			
+WB	WBGene00011040	arv-1		R05H5.5	gene	taxon:6239			
+WB	WBGene00011043	rbm-28		R05H10.2	gene	taxon:6239			
+WB	WBGene00011045	gpx-2		R05H10.5	gene	taxon:6239			
+WB	WBGene00011047	tebp-1		R06A4.2|dtn-1	gene	taxon:6239			
+WB	WBGene00011050	agl-1		R06A4.8	gene	taxon:6239			
+WB	WBGene00011051	pfs-2		R06A4.9	gene	taxon:6239			
+WB	WBGene00011058	fdps-1		R06C1.2	gene	taxon:6239			
+WB	WBGene00011059	R06C1.4			gene	taxon:6239			
+WB	WBGene00011061	wago-1		R06C7.1	gene	taxon:6239			
+WB	WBGene00011064	adsl-1		R06C7.5	gene	taxon:6239			
+WB	WBGene00011065	R06C7.6			gene	taxon:6239			
+WB	WBGene00011067	vps-11		R06F6.2	gene	taxon:6239			
+WB	WBGene00011068	set-14		R06F6.4	gene	taxon:6239			
+WB	WBGene00011069	ceh-62		R06F6.6	gene	taxon:6239			
+WB	WBGene00011071	R06F6.8			gene	taxon:6239			
+WB	WBGene00011073	R07A4.2			gene	taxon:6239			
+WB	WBGene00011076	scav-5		R07B1.3	gene	taxon:6239			
+WB	WBGene00011082	R07B1.11			gene	taxon:6239			
+WB	WBGene00011083	glo-1		R07B1.12	gene	taxon:6239			
+WB	WBGene00011084	srsx-21		R07B5.5	gene	taxon:6239			
+WB	WBGene00011088	kmo-2		R07B7.4	gene	taxon:6239			
+WB	WBGene00011089	kmo-1		R07B7.5	gene	taxon:6239			
+WB	WBGene00011090	R07B7.6			gene	taxon:6239			
+WB	WBGene00011092	R07B7.8			gene	taxon:6239			
+WB	WBGene00011093	R07B7.9			gene	taxon:6239			
+WB	WBGene00011094	R07B7.10			gene	taxon:6239			
+WB	WBGene00011095	gana-1		R07B7.11	gene	taxon:6239			
+WB	WBGene00011096	R07B7.12			gene	taxon:6239			
+WB	WBGene00011097	nhr-206		R07B7.13	gene	taxon:6239			
+WB	WBGene00011098	nhr-207		R07B7.14	gene	taxon:6239			
+WB	WBGene00011099	nhr-208		R07B7.15	gene	taxon:6239			
+WB	WBGene00011100	nhr-209		R07B7.16	gene	taxon:6239			
+WB	WBGene00011101	R07D5.2			gene	taxon:6239			
+WB	WBGene00011102	R07E3.1			gene	taxon:6239			
+WB	WBGene00011104	cut-5		R07E3.3	gene	taxon:6239			
+WB	WBGene00011105	R07E3.4			gene	taxon:6239			
+WB	WBGene00011106	acl-5		R07E3.5	gene	taxon:6239			
+WB	WBGene00011108	R07E3.7			gene	taxon:6239			
+WB	WBGene00011109	gpch-1		R07E5.1	gene	taxon:6239			
+WB	WBGene00011110	prdx-3		R07E5.2|ceprx1	gene	taxon:6239			
+WB	WBGene00011111	snfc-5		R07E5.3|swsn-5	gene	taxon:6239			
+WB	WBGene00011112	R07E5.4			gene	taxon:6239			
+WB	WBGene00011115	R07E5.7			gene	taxon:6239			
+WB	WBGene00011116	pdcd-2		R07E5.10	gene	taxon:6239			
+WB	WBGene00011119	mpc-1		R07E5.13	gene	taxon:6239			
+WB	WBGene00011121	R07E5.17			gene	taxon:6239			
+WB	WBGene00011122	cpt-2		R07H5.2	gene	taxon:6239			
+WB	WBGene00011123	nuaf-3		R07H5.3	gene	taxon:6239			
+WB	WBGene00011124	sdz-27		R07H5.4	gene	taxon:6239			
+WB	WBGene00011128	adk-1		R07H5.8	gene	taxon:6239			
+WB	WBGene00011130	zip-6		R07H5.10	gene	taxon:6239			
+WB	WBGene00011133	R08A2.2			gene	taxon:6239			
+WB	WBGene00011139	R08B4.3			gene	taxon:6239			
+WB	WBGene00011140	R08B4.4			gene	taxon:6239			
+WB	WBGene00011141	nlp-66		R08B4.5	gene	taxon:6239			
+WB	WBGene00011143	rpap-2		R08D7.2	gene	taxon:6239			
+WB	WBGene00011145	R08D7.5			gene	taxon:6239			
+WB	WBGene00011146	pde-2		R08D7.6	gene	taxon:6239			
+WB	WBGene00011147	R08D7.7			gene	taxon:6239			
+WB	WBGene00011150	nhr-269		R08H2.9	gene	taxon:6239			
+WB	WBGene00011154	R09A8.5			gene	taxon:6239			
+WB	WBGene00011155	rbm-3.1		R09B3.2	gene	taxon:6239			
+WB	WBGene00011156	rbm-3.2		R09B3.3	gene	taxon:6239			
+WB	WBGene00011157	chil-15		R09D1.1	gene	taxon:6239			
+WB	WBGene00011158	chil-16		R09D1.2	gene	taxon:6239			
+WB	WBGene00011159	chil-17		R09D1.3	gene	taxon:6239			
+WB	WBGene00011161	chil-18		R09D1.5	gene	taxon:6239			
+WB	WBGene00011162	chil-19		R09D1.6	gene	taxon:6239			
+WB	WBGene00011164	chil-21		R09D1.8	gene	taxon:6239			
+WB	WBGene00011166	chil-22		R09D1.10	gene	taxon:6239			
+WB	WBGene00011167	chil-23		R09D1.11	gene	taxon:6239			
+WB	WBGene00011168	R09D1.12			gene	taxon:6239			
+WB	WBGene00011169	R09D1.13			gene	taxon:6239			
+WB	WBGene00011170	R09D1.14			gene	taxon:6239			
+WB	WBGene00011173	acs-18		R09E10.3	gene	taxon:6239			
+WB	WBGene00011175	R09E10.5			gene	taxon:6239			
+WB	WBGene00011181	R09H10.3			gene	taxon:6239			
+WB	WBGene00011183	R09H10.6			gene	taxon:6239			
+WB	WBGene00011184	R09H10.7			gene	taxon:6239			
+WB	WBGene00011185	R10D12.1			gene	taxon:6239			
+WB	WBGene00011187	R10D12.6			gene	taxon:6239			
+WB	WBGene00011188	R10D12.7			gene	taxon:6239			
+WB	WBGene00011190	swt-6		R10D12.9	gene	taxon:6239			
+WB	WBGene00011191	R10D12.10			gene	taxon:6239			
+WB	WBGene00011192	srh-24		R10D12.11	gene	taxon:6239			
+WB	WBGene00011193	algn-13		R10D12.12|hpo-17	gene	taxon:6239			
+WB	WBGene00011195	sao-1		R10D12.14	gene	taxon:6239			
+WB	WBGene00011196	R10D12.15			gene	taxon:6239			
+WB	WBGene00011197	srw-145		R10D12.17	gene	taxon:6239			
+WB	WBGene00011200	R10E4.3			gene	taxon:6239			
+WB	WBGene00011201	nth-1		R10E4.5|CAA90766|nthl-1	gene	taxon:6239			
+WB	WBGene00011202	R10E4.6			gene	taxon:6239			
+WB	WBGene00011205	R10E4.9			gene	taxon:6239			
+WB	WBGene00011211	R10E8.5			gene	taxon:6239			
+WB	WBGene00011215	R10E9.3			gene	taxon:6239			
+WB	WBGene00011216	usp-46		R10E11.3|toe-3	gene	taxon:6239			
+WB	WBGene00011219	srxa-10		R10E11.7	gene	taxon:6239			
+WB	WBGene00011220	R10E11.9			gene	taxon:6239			
+WB	WBGene00011223	R10H10.4			gene	taxon:6239			
+WB	WBGene00011224	rfk-1		R10H10.6	gene	taxon:6239			
+WB	WBGene00011226	slc-25A21		R11.1	gene	taxon:6239			
+WB	WBGene00011227	nlp-67		R11.2	gene	taxon:6239			
+WB	WBGene00011229	R11.4			gene	taxon:6239			
+WB	WBGene00011230	nud-2		R11A5.2	gene	taxon:6239			
+WB	WBGene00011232	pck-2		R11A5.4	gene	taxon:6239			
+WB	WBGene00011235	suro-1		R11A5.7	gene	taxon:6239			
+WB	WBGene00011237	gkow-1		R11A8.2	gene	taxon:6239			
+WB	WBGene00011238	ugt-59		R11A8.3	gene	taxon:6239			
+WB	WBGene00011239	pges-2		R11A8.5	gene	taxon:6239			
+WB	WBGene00011240	mask-1		R11A8.7	gene	taxon:6239			
+WB	WBGene00011246	R11D1.7			gene	taxon:6239			
+WB	WBGene00011247	mrpl-49		R11D1.9	gene	taxon:6239			
+WB	WBGene00011248	R11D1.10			gene	taxon:6239			
+WB	WBGene00011249	R11G10.2			gene	taxon:6239			
+WB	WBGene00011250	R11H6.2			gene	taxon:6239			
+WB	WBGene00011251	glb-22		R11H6.3	gene	taxon:6239			
+WB	WBGene00011254	R12G8.1			gene	taxon:6239			
+WB	WBGene00011255	R12H7.4			gene	taxon:6239			
+WB	WBGene00011257	npax-3		R13.2	gene	taxon:6239			
+WB	WBGene00011258	best-15		R13.3	gene	taxon:6239			
+WB	WBGene00011259	miz-1		R13.4	gene	taxon:6239			
+WB	WBGene00011260	cnnm-5		R13G10.4	gene	taxon:6239			
+WB	WBGene00011261	nphp-4		R13H4.1|nph-4	gene	taxon:6239			
+WB	WBGene00011264	R13H4.6			gene	taxon:6239			
+WB	WBGene00011265	R13H4.7			gene	taxon:6239			
+WB	WBGene00011268	pde-12		R17.2	gene	taxon:6239			
+WB	WBGene00011270	R31.2			gene	taxon:6239			
+WB	WBGene00011271	flad-1		R53.1	gene	taxon:6239			
+WB	WBGene00011272	dtmk-1		R53.2	gene	taxon:6239			
+WB	WBGene00011273	R53.4		ATP synthase subunit	gene	taxon:6239			
+WB	WBGene00011274	R53.5			gene	taxon:6239			
+WB	WBGene00011275	psf-1		R53.6	gene	taxon:6239			
+WB	WBGene00011276	aakg-5		R53.7	gene	taxon:6239			
+WB	WBGene00011279	asd-1		R74.5	gene	taxon:6239			
+WB	WBGene00011280	pelo-1		R74.6	gene	taxon:6239			
+WB	WBGene00011281	R74.7			gene	taxon:6239			
+WB	WBGene00011283	ttbk-7		R90.1	gene	taxon:6239			
+WB	WBGene00011284	ttr-27		R90.2	gene	taxon:6239			
+WB	WBGene00011285	ttr-28		R90.3	gene	taxon:6239			
+WB	WBGene00011286	ttr-29		R90.4	gene	taxon:6239			
+WB	WBGene00011287	glb-24		R90.5	gene	taxon:6239			
+WB	WBGene00011291	R102.4			gene	taxon:6239			
+WB	WBGene00011292	allo-1		R102.5	gene	taxon:6239			
+WB	WBGene00011293	R102.6			gene	taxon:6239			
+WB	WBGene00011296	glb-21		R102.9	gene	taxon:6239			
+WB	WBGene00011298	R107.2			gene	taxon:6239			
+WB	WBGene00011299	ikke-1		R107.4	gene	taxon:6239			
+WB	WBGene00011302	R166.2			gene	taxon:6239			
+WB	WBGene00011304	mnk-1		R166.5	gene	taxon:6239			
+WB	WBGene00011306	R186.3			gene	taxon:6239			
+WB	WBGene00011307	mpst-7		R186.6	gene	taxon:6239			
+WB	WBGene00011308	pnn-1		R186.7	gene	taxon:6239			
+WB	WBGene00011309	R186.8			gene	taxon:6239			
+WB	WBGene00011315	mbr-1		T01C1.2	gene	taxon:6239			
+WB	WBGene00011318	cdt-2		T01C3.1	gene	taxon:6239			
+WB	WBGene00011319	T01C3.2			gene	taxon:6239			
+WB	WBGene00011320	T01C3.3			gene	taxon:6239			
+WB	WBGene00011321	fil-1		T01C3.4	gene	taxon:6239			
+WB	WBGene00011322	irld-14		T01C3.5	gene	taxon:6239			
+WB	WBGene00011323	mut-15		T01C3.8|rde-5	gene	taxon:6239			
+WB	WBGene00011324	hrde-2		T01C3.9|enri-3|nip-3	gene	taxon:6239			
+WB	WBGene00011325	T01C3.11			gene	taxon:6239			
+WB	WBGene00011326	T01D3.1			gene	taxon:6239			
+WB	WBGene00011327	hlh-34		T01D3.2	gene	taxon:6239			
+WB	WBGene00011328	T01D3.3			gene	taxon:6239			
+WB	WBGene00011329	zipt-9		T01D3.5	gene	taxon:6239			
+WB	WBGene00011330	T01D3.6			gene	taxon:6239			
+WB	WBGene00011333	nrde-2		T01E8.5	gene	taxon:6239			
+WB	WBGene00011334	mrps-14		T01E8.6	gene	taxon:6239			
+WB	WBGene00011336	ubxn-5		T01E8.9	gene	taxon:6239			
+WB	WBGene00011337	T01G1.2			gene	taxon:6239			
+WB	WBGene00011338	sec-31		T01G1.3	gene	taxon:6239			
+WB	WBGene00011339	T01G5.1			gene	taxon:6239			
+WB	WBGene00011340	ugt-30		T01G5.2	gene	taxon:6239			
+WB	WBGene00011341	T01G5.6			gene	taxon:6239			
+WB	WBGene00011342	T01G5.7			gene	taxon:6239			
+WB	WBGene00011344	T01G9.2		ORF1	gene	taxon:6239			
+WB	WBGene00011345	dma-1		T01G9.3	gene	taxon:6239			
+WB	WBGene00011348	T01H3.2			gene	taxon:6239			
+WB	WBGene00011349	T01H3.3			gene	taxon:6239			
+WB	WBGene00011350	perm-1		T01H3.4	gene	taxon:6239			
+WB	WBGene00011352	rskn-1		T01H8.1	gene	taxon:6239			
+WB	WBGene00011353	serr-1		T01H8.2	gene	taxon:6239			
+WB	WBGene00011354	lgc-13		T01H10.1	gene	taxon:6239			
+WB	WBGene00011355	lgc-14		T01H10.2	gene	taxon:6239			
+WB	WBGene00011356	lgc-15		T01H10.3	gene	taxon:6239			
+WB	WBGene00011358	lgc-16		T01H10.5	gene	taxon:6239			
+WB	WBGene00011359	lgc-17		T01H10.6	gene	taxon:6239			
+WB	WBGene00011360	lgc-18		T01H10.7	gene	taxon:6239			
+WB	WBGene00011362	cest-1.1		T02B5.1|cest-1	gene	taxon:6239			
+WB	WBGene00011363	ocam-1		T02B5.2	gene	taxon:6239			
+WB	WBGene00011364	cest-1.2		T02B5.3	gene	taxon:6239			
+WB	WBGene00011365	T02C1.1			gene	taxon:6239			
+WB	WBGene00011366	T02C1.2			gene	taxon:6239			
+WB	WBGene00011367	snpc-3.4		T02C12.2	gene	taxon:6239			
+WB	WBGene00011368	tftc-5		T02C12.3	gene	taxon:6239			
+WB	WBGene00011371	T02D1.4			gene	taxon:6239			
+WB	WBGene00011372	npr-26		T02D1.6	gene	taxon:6239			
+WB	WBGene00011376	gla-3		T02E1.3	gene	taxon:6239			
+WB	WBGene00011378	T02E1.6			gene	taxon:6239			
+WB	WBGene00011379	T02E1.7			gene	taxon:6239			
+WB	WBGene00011380	T02E1.8			gene	taxon:6239			
+WB	WBGene00011381	npr-25		T02E9.1	gene	taxon:6239			
+WB	WBGene00011382	dop-5		T02E9.3	gene	taxon:6239			
+WB	WBGene00011387	T02G6.4			gene	taxon:6239			
+WB	WBGene00011388	T02G6.5			gene	taxon:6239			
+WB	WBGene00011391	mrps-12		T03D8.2	gene	taxon:6239			
+WB	WBGene00011392	sbt-1		T03D8.3	gene	taxon:6239			
+WB	WBGene00011393	T03D8.6			gene	taxon:6239			
+WB	WBGene00011396	nhr-271		T03E6.3	gene	taxon:6239			
+WB	WBGene00011397	T03E6.8			gene	taxon:6239			
+WB	WBGene00011398	qdpr-1		T03F6.1	gene	taxon:6239			
+WB	WBGene00011399	T03F6.3			gene	taxon:6239			
+WB	WBGene00011401	T03F6.6			gene	taxon:6239			
+WB	WBGene00011402	T03F7.5			gene	taxon:6239			
+WB	WBGene00011403	T03F7.6			gene	taxon:6239			
+WB	WBGene00011407	ppat-1		T04A8.5	gene	taxon:6239			
+WB	WBGene00011408	nifk-1		T04A8.6	gene	taxon:6239			
+WB	WBGene00011409	T04A8.7			gene	taxon:6239			
+WB	WBGene00011411	sel-13		T04A8.10	gene	taxon:6239			
+WB	WBGene00011412	mrpl-16		T04A8.11	gene	taxon:6239			
+WB	WBGene00011415	him-18		T04A8.15|slx-4	gene	taxon:6239			
+WB	WBGene00011416	T04A11.1			gene	taxon:6239			
+WB	WBGene00011417	T04A11.2			gene	taxon:6239			
+WB	WBGene00011418	igdb-1		T04A11.3	gene	taxon:6239			
+WB	WBGene00011419	T04A11.4			gene	taxon:6239			
+WB	WBGene00011420	T04A11.5			gene	taxon:6239			
+WB	WBGene00011423	ipla-7		T04B2.5	gene	taxon:6239			
+WB	WBGene00011424	dhs-31		T04B2.6	gene	taxon:6239			
+WB	WBGene00011427	T04C12.1			gene	taxon:6239			
+WB	WBGene00011428	nlp-80		T04C12.3	gene	taxon:6239			
+WB	WBGene00011429	T04C12.7			gene	taxon:6239			
+WB	WBGene00011430	T04C12.8			gene	taxon:6239			
+WB	WBGene00011431	T04D3.1			gene	taxon:6239			
+WB	WBGene00011432	sdz-30		T04D3.2	gene	taxon:6239			
+WB	WBGene00011433	pde-1		T04D3.3	gene	taxon:6239			
+WB	WBGene00011436	T04F3.1			gene	taxon:6239			
+WB	WBGene00011437	smoc-1		T04F3.2|susm-1	gene	taxon:6239			
+WB	WBGene00011438	T04F3.3			gene	taxon:6239			
+WB	WBGene00011439	T04F3.4			gene	taxon:6239			
+WB	WBGene00011440	sfxn-1.5		T04F8.1	gene	taxon:6239			
+WB	WBGene00011441	T04F8.2			gene	taxon:6239			
+WB	WBGene00011443	cutl-11		T04F8.4	gene	taxon:6239			
+WB	WBGene00011447	T04F8.9			gene	taxon:6239			
+WB	WBGene00011449	T04H1.2			gene	taxon:6239			
+WB	WBGene00011450	ttr-22		T04H1.3	gene	taxon:6239			
+WB	WBGene00011451	T04H1.5			gene	taxon:6239			
+WB	WBGene00011452	ugt-55		T04H1.7	gene	taxon:6239			
+WB	WBGene00011453	ugt-56		T04H1.8	gene	taxon:6239			
+WB	WBGene00011454	lron-14		T05A1.3	gene	taxon:6239			
+WB	WBGene00011456	T05A1.5			gene	taxon:6239			
+WB	WBGene00011460	ttr-14		T05A10.3	gene	taxon:6239			
+WB	WBGene00011462	vap-2		T05A10.5|scl-22	gene	taxon:6239			
+WB	WBGene00011466	T05C12.1			gene	taxon:6239			
+WB	WBGene00011467	decr-1.3		T05C12.3	gene	taxon:6239			
+WB	WBGene00011468	T05C12.4			gene	taxon:6239			
+WB	WBGene00011472	T05C12.9			gene	taxon:6239			
+WB	WBGene00011473	T05C12.11			gene	taxon:6239			
+WB	WBGene00011474	aldo-1		T05D4.1	gene	taxon:6239			
+WB	WBGene00011476	exc-12		T05D4.3	gene	taxon:6239			
+WB	WBGene00011478	T05D4.5			gene	taxon:6239			
+WB	WBGene00011479	clc-9		T05E11.2	gene	taxon:6239			
+WB	WBGene00011480	enpl-1		T05E11.3	gene	taxon:6239			
+WB	WBGene00011481	imp-2		T05E11.5	gene	taxon:6239			
+WB	WBGene00011482	pigk-1		T05E11.6|hpo-4	gene	taxon:6239			
+WB	WBGene00011485	srbc-14		T05E12.2	gene	taxon:6239			
+WB	WBGene00011486	T05E12.3			gene	taxon:6239			
+WB	WBGene00011488	nra-2		T05F1.1	gene	taxon:6239			
+WB	WBGene00011493	T05F1.8			gene	taxon:6239			
+WB	WBGene00011498	T05G5.1			gene	taxon:6239			
+WB	WBGene00011499	T05G5.4			gene	taxon:6239			
+WB	WBGene00011500	T05G5.5			gene	taxon:6239			
+WB	WBGene00011501	rmd-1		T05G5.7|psa-2	gene	taxon:6239			
+WB	WBGene00011502	vps-53		T05G5.8	gene	taxon:6239			
+WB	WBGene00011505	pzf-1		T05G11.1	gene	taxon:6239			
+WB	WBGene00011506	srbc-77		T05G11.2	gene	taxon:6239			
+WB	WBGene00011507	T05H10.1		usp-47	gene	taxon:6239			
+WB	WBGene00011510	pdha-1		T05H10.6	gene	taxon:6239			
+WB	WBGene00011511	gpcp-2		T05H10.7	gene	taxon:6239			
+WB	WBGene00011515	oac-42		T06C12.8	gene	taxon:6239			
+WB	WBGene00011516	T06C12.9			gene	taxon:6239			
+WB	WBGene00011517	cgt-1		T06C12.10|tag-217	gene	taxon:6239			
+WB	WBGene00011518	T06C12.11			gene	taxon:6239			
+WB	WBGene00011519	T06C12.12			gene	taxon:6239			
+WB	WBGene00011520	nhr-213		T06C12.13	gene	taxon:6239			
+WB	WBGene00011524	plpr-1		T06D8.3	gene	taxon:6239			
+WB	WBGene00011526	cox-15		T06D8.5	gene	taxon:6239			
+WB	WBGene00011527	cchl-1		T06D8.6	gene	taxon:6239			
+WB	WBGene00011528	fndc-1		T06D8.7	gene	taxon:6239			
+WB	WBGene00011529	T06D8.9			gene	taxon:6239			
+WB	WBGene00011530	T06D8.10			gene	taxon:6239			
+WB	WBGene00011531	rsbp-1		T06D10.1	gene	taxon:6239			
+WB	WBGene00011532	chaf-1		T06D10.2	gene	taxon:6239			
+WB	WBGene00011533	T06E4.5			gene	taxon:6239			
+WB	WBGene00011534	T06E4.7			gene	taxon:6239			
+WB	WBGene00011535	T06E4.8			gene	taxon:6239			
+WB	WBGene00011538	T06E6.1			gene	taxon:6239			
+WB	WBGene00011540	T06E6.10			gene	taxon:6239			
+WB	WBGene00011541	srbc-63		T06E6.11	gene	taxon:6239			
+WB	WBGene00011543	acl-2		T06E8.1	gene	taxon:6239			
+WB	WBGene00011554	T07A5.1			gene	taxon:6239			
+WB	WBGene00011556	vglu-3		T07A5.3	gene	taxon:6239			
+WB	WBGene00011558	ostf-4		T07A5.5|Ost4	gene	taxon:6239			
+WB	WBGene00011559	umps-1		T07C4.1|rad-6	gene	taxon:6239			
+WB	WBGene00011560	T07C4.3			gene	taxon:6239			
+WB	WBGene00011561	ttr-15		T07C4.5	gene	taxon:6239			
+WB	WBGene00011563	jmjd-4		T07C4.11	gene	taxon:6239			
+WB	WBGene00011564	ugt-50		T07C5.1	gene	taxon:6239			
+WB	WBGene00011565	nhr-272		T07C5.2	gene	taxon:6239			
+WB	WBGene00011566	nhr-214		T07C5.3	gene	taxon:6239			
+WB	WBGene00011568	nhr-26		T07C5.5	gene	taxon:6239			
+WB	WBGene00011570	sre-28		T07C12.6	gene	taxon:6239			
+WB	WBGene00011571	ttr-46		T07C12.7	gene	taxon:6239			
+WB	WBGene00011572	mam-5		T07C12.8	gene	taxon:6239			
+WB	WBGene00011573	anmt-3		T07C12.9	gene	taxon:6239			
+WB	WBGene00011576	rmh-2		T07C12.12	gene	taxon:6239			
+WB	WBGene00011578	npr-20		T07D4.1	gene	taxon:6239			
+WB	WBGene00011579	T07D4.2		cm14e7	gene	taxon:6239			
+WB	WBGene00011580	ddx-19		T07D4.4	gene	taxon:6239			
+WB	WBGene00011581	T07D10.1			gene	taxon:6239			
+WB	WBGene00011582	ntr-1		T07D10.2	gene	taxon:6239			
+WB	WBGene00011587	anp-1		T07F10.1	gene	taxon:6239			
+WB	WBGene00011589	T07F10.3			gene	taxon:6239			
+WB	WBGene00011590	bus-19		T07F10.4	gene	taxon:6239			
+WB	WBGene00011593	T07G12.2			gene	taxon:6239			
+WB	WBGene00011594	T07G12.3			gene	taxon:6239			
+WB	WBGene00011595	T07G12.4			gene	taxon:6239			
+WB	WBGene00011596	T07G12.5			gene	taxon:6239			
+WB	WBGene00011597	zim-1		T07G12.6	gene	taxon:6239			
+WB	WBGene00011600	zim-2		T07G12.10	gene	taxon:6239			
+WB	WBGene00011601	zim-3		T07G12.11	gene	taxon:6239			
+WB	WBGene00011604	T08A11.1			gene	taxon:6239			
+WB	WBGene00011605	sftb-1		T08A11.2|phi-11	gene	taxon:6239			
+WB	WBGene00011606	tmed-12		T08D2.1	gene	taxon:6239			
+WB	WBGene00011609	T08D2.4			gene	taxon:6239			
+WB	WBGene00011612	T08D2.7			gene	taxon:6239			
+WB	WBGene00011614	nfya-1		T08D10.1|tag-295	gene	taxon:6239			
+WB	WBGene00011615	lsd-1		T08D10.2	gene	taxon:6239			
+WB	WBGene00011621	T08G3.13			gene	taxon:6239			
+WB	WBGene00011625	vps-39		T08G5.5	gene	taxon:6239			
+WB	WBGene00011631	tgs-1		T08G11.4	gene	taxon:6239			
+WB	WBGene00011634	T09A5.5			gene	taxon:6239			
+WB	WBGene00011636	cec-3		T09A5.8|eap-1|eap-3	gene	taxon:6239			
+WB	WBGene00011637	sds-22		T09A5.9|szy-6	gene	taxon:6239			
+WB	WBGene00011638	ostb-1		T09A5.11	gene	taxon:6239			
+WB	WBGene00011639	ztf-17		T09A5.12	gene	taxon:6239			
+WB	WBGene00011641	T09A5.15			gene	taxon:6239			
+WB	WBGene00011642	T09B9.1			gene	taxon:6239			
+WB	WBGene00011643	slc-17.9		T09B9.2|droe-5	gene	taxon:6239			
+WB	WBGene00011644	T09B9.3			gene	taxon:6239			
+WB	WBGene00011646	T09B9.5			gene	taxon:6239			
+WB	WBGene00011647	noca-1		T09E8.1	gene	taxon:6239			
+WB	WBGene00011648	cni-1		T09E8.3|cnih-2	gene	taxon:6239			
+WB	WBGene00011649	T09E8.4			gene	taxon:6239			
+WB	WBGene00011650	glct-1		T09E11.1	gene	taxon:6239			
+WB	WBGene00011651	nhr-217		T09E11.2	gene	taxon:6239			
+WB	WBGene00011652	T09E11.3			gene	taxon:6239			
+WB	WBGene00011653	oac-43		T09E11.4	gene	taxon:6239			
+WB	WBGene00011654	oac-44		T09E11.5	gene	taxon:6239			
+WB	WBGene00011655	T09E11.6			gene	taxon:6239			
+WB	WBGene00011656	oac-45		T09E11.7	gene	taxon:6239			
+WB	WBGene00011657	T09E11.8			gene	taxon:6239			
+WB	WBGene00011658	T09E11.9			gene	taxon:6239			
+WB	WBGene00011659	T09E11.10			gene	taxon:6239			
+WB	WBGene00011662	T09F3.2			gene	taxon:6239			
+WB	WBGene00011664	T09F3.5			gene	taxon:6239			
+WB	WBGene00011665	T09F5.1			gene	taxon:6239			
+WB	WBGene00011666	T09F5.2			gene	taxon:6239			
+WB	WBGene00011668	clec-47		T09F5.9	gene	taxon:6239			
+WB	WBGene00011671	cyp-13A4		T10B9.1|ccp-13A4|dod-1	gene	taxon:6239			
+WB	WBGene00011672	cyp-13A5		T10B9.2	gene	taxon:6239			
+WB	WBGene00011673	cyp-13A6		T10B9.3	gene	taxon:6239			
+WB	WBGene00011674	cyp-13A8		T10B9.4	gene	taxon:6239			
+WB	WBGene00011675	cyp-13A3		T10B9.5	gene	taxon:6239			
+WB	WBGene00011676	cyp-13A2		T10B9.7	gene	taxon:6239			
+WB	WBGene00011677	cyp-13A1		T10B9.8	gene	taxon:6239			
+WB	WBGene00011679	ucr-2.2		T10B10.2	gene	taxon:6239			
+WB	WBGene00011681	T10B10.4			gene	taxon:6239			
+WB	WBGene00011682	snt-7		T10B10.5	gene	taxon:6239			
+WB	WBGene00011683	phat-6		T10B10.6	gene	taxon:6239			
+WB	WBGene00011684	T10B10.8			gene	taxon:6239			
+WB	WBGene00011687	cwc-15		T10C6.5	gene	taxon:6239			
+WB	WBGene00011688	T10C6.6			gene	taxon:6239			
+WB	WBGene00011693	T10G3.2			gene	taxon:6239			
+WB	WBGene00011695	T10G3.4			gene	taxon:6239			
+WB	WBGene00011696	eea-1		T10G3.5	gene	taxon:6239			
+WB	WBGene00011698	cyp-34A1		T10H4.10	gene	taxon:6239			
+WB	WBGene00011699	cyp-34A2		T10H4.11	gene	taxon:6239			
+WB	WBGene00011701	srab-17		T11A5.2	gene	taxon:6239			
+WB	WBGene00011702	srab-18		T11A5.3	gene	taxon:6239			
+WB	WBGene00011704	sdz-31		T11A5.5	gene	taxon:6239			
+WB	WBGene00011705	clp-9		T11A5.6	gene	taxon:6239			
+WB	WBGene00011706	T11B7.1			gene	taxon:6239			
+WB	WBGene00011709	T11F9.1			gene	taxon:6239			
+WB	WBGene00011717	T11G6.2			gene	taxon:6239			
+WB	WBGene00011718	T11G6.3			gene	taxon:6239			
+WB	WBGene00011719	T11G6.4			gene	taxon:6239			
+WB	WBGene00011722	rbm-22		T11G6.8	gene	taxon:6239			
+WB	WBGene00011723	T12A7.2			gene	taxon:6239			
+WB	WBGene00011725	lips-5		T12A7.4	gene	taxon:6239			
+WB	WBGene00011726	lpr-2		T12A7.5	gene	taxon:6239			
+WB	WBGene00011729	set-16		T12D8.1|tag-350	gene	taxon:6239			
+WB	WBGene00011730	drr-2		T12D8.2	gene	taxon:6239			
+WB	WBGene00011731	acbp-5		T12D8.3	gene	taxon:6239			
+WB	WBGene00011732	arrd-17		T12D8.4|cnp-1	gene	taxon:6239			
+WB	WBGene00011734	mlc-5		T12D8.6	gene	taxon:6239			
+WB	WBGene00011735	hip-1		T12D8.8	gene	taxon:6239			
+WB	WBGene00011737	sqst-1		T12G3.1	gene	taxon:6239			
+WB	WBGene00011739	T12G3.4			gene	taxon:6239			
+WB	WBGene00011740	mrpl-51		T12G3.5	gene	taxon:6239			
+WB	WBGene00011742	tgn-38		T12G3.7	gene	taxon:6239			
+WB	WBGene00011743	T13F2.2			gene	taxon:6239			
+WB	WBGene00011745	sre-4		T13F2.5	gene	taxon:6239			
+WB	WBGene00011750	nhr-218		T13F3.2	gene	taxon:6239			
+WB	WBGene00011754	T13F3.7			gene	taxon:6239			
+WB	WBGene00011755	T13H5.1			gene	taxon:6239			
+WB	WBGene00011757	cht-2		T13H5.3	gene	taxon:6239			
+WB	WBGene00011758	prp-9		T13H5.4|phi-8	gene	taxon:6239			
+WB	WBGene00011759	mrps-18B		T13H5.5	gene	taxon:6239			
+WB	WBGene00011760	T13H5.6			gene	taxon:6239			
+WB	WBGene00011761	T13H5.8			gene	taxon:6239			
+WB	WBGene00011762	T13H10.2			gene	taxon:6239			
+WB	WBGene00011765	frpr-17		T14C1.1	gene	taxon:6239			
+WB	WBGene00011767	agxt-1		T14D7.1	gene	taxon:6239			
+WB	WBGene00011768	oac-46		T14D7.2	gene	taxon:6239			
+WB	WBGene00011770	T14G8.2			gene	taxon:6239			
+WB	WBGene00011771	T14G8.3			gene	taxon:6239			
+WB	WBGene00011773	ttr-53		T14G10.3	gene	taxon:6239			
+WB	WBGene00011774	ttr-54		T14G10.4	gene	taxon:6239			
+WB	WBGene00011775	copg-1		T14G10.5	gene	taxon:6239			
+WB	WBGene00011776	pigs-1		T14G10.7|hpo-5	gene	taxon:6239			
+WB	WBGene00011777	T14G10.8			gene	taxon:6239			
+WB	WBGene00011778	T15D6.1			gene	taxon:6239			
+WB	WBGene00011779	bgnt-1.7		T15D6.4	gene	taxon:6239			
+WB	WBGene00011780	T15D6.5			gene	taxon:6239			
+WB	WBGene00011781	glct-3		T15D6.7	gene	taxon:6239			
+WB	WBGene00011784	T15D6.10			gene	taxon:6239			
+WB	WBGene00011786	T15D6.12			gene	taxon:6239			
+WB	WBGene00011791	pap-2		T15H9.6	gene	taxon:6239			
+WB	WBGene00011794	nep-21		T16A9.4	gene	taxon:6239			
+WB	WBGene00011795	T16A9.5			gene	taxon:6239			
+WB	WBGene00011802	T16G1.9			gene	taxon:6239			
+WB	WBGene00011803	T16G12.1			gene	taxon:6239			
+WB	WBGene00011805	T16G12.4			gene	taxon:6239			
+WB	WBGene00011808	T16G12.7			gene	taxon:6239			
+WB	WBGene00011809	T16G12.8			gene	taxon:6239			
+WB	WBGene00011814	gtf-2H2C		T16H12.4	gene	taxon:6239			
+WB	WBGene00011815	spop-1		T16H12.5	gene	taxon:6239			
+WB	WBGene00011816	srt-55		T16H12.8	gene	taxon:6239			
+WB	WBGene00011819	hal-2		T16H12.11	gene	taxon:6239			
+WB	WBGene00011821	cdf-2		T18D3.3	gene	taxon:6239			
+WB	WBGene00011822	T18D3.5			gene	taxon:6239			
+WB	WBGene00011824	tsct-1		T18D3.7|txt-21	gene	taxon:6239			
+WB	WBGene00011826	T18D3.9			gene	taxon:6239			
+WB	WBGene00011827	T19A6.1			gene	taxon:6239			
+WB	WBGene00011828	nepr-1		T19A6.3|spo-7	gene	taxon:6239			
+WB	WBGene00011829	T19A6.4			gene	taxon:6239			
+WB	WBGene00011830	cyp-29A2		T19B10.1	gene	taxon:6239			
+WB	WBGene00011832	bgal-1		T19B10.3	gene	taxon:6239			
+WB	WBGene00011833	T19B10.5			gene	taxon:6239			
+WB	WBGene00011834	dvc-1		T19B10.6	gene	taxon:6239			
+WB	WBGene00011835	pgap-1		T19B10.8	gene	taxon:6239			
+WB	WBGene00011837	srsx-33		T19B10.10	gene	taxon:6239			
+WB	WBGene00011838	T19C4.1			gene	taxon:6239			
+WB	WBGene00011839	T19C4.5			gene	taxon:6239			
+WB	WBGene00011840	srbc-62		T19C9.1	gene	taxon:6239			
+WB	WBGene00011846	chil-25		T19H5.1	gene	taxon:6239			
+WB	WBGene00011847	chil-26		T19H5.2	gene	taxon:6239			
+WB	WBGene00011848	chil-27		T19H5.3	gene	taxon:6239			
+WB	WBGene00011850	T20B3.1			gene	taxon:6239			
+WB	WBGene00011852	clec-26		T20B3.12	gene	taxon:6239			
+WB	WBGene00011853	clec-40		T20B3.13	gene	taxon:6239			
+WB	WBGene00011855	clec-183		T20D3.1	gene	taxon:6239			
+WB	WBGene00011858	T20D3.5			gene	taxon:6239			
+WB	WBGene00011859	T20D3.6			gene	taxon:6239			
+WB	WBGene00011860	pigc-1		T20D3.8	gene	taxon:6239			
+WB	WBGene00011864	T20F10.2			gene	taxon:6239			
+WB	WBGene00011867	chc-1		T20G5.1|clhc-1	gene	taxon:6239			
+WB	WBGene00011868	best-18		T20G5.4	gene	taxon:6239			
+WB	WBGene00011869	dod-6		T20G5.7	gene	taxon:6239			
+WB	WBGene00011871	T20G5.9			gene	taxon:6239			
+WB	WBGene00011872	blos-1		T20G5.10	gene	taxon:6239			
+WB	WBGene00011875	cox-14		T20G5.14	gene	taxon:6239			
+WB	WBGene00011876	srz-6		T21B4.1	gene	taxon:6239			
+WB	WBGene00011878	ador-1		T21B4.4	gene	taxon:6239			
+WB	WBGene00011882	nstp-9		T21B6.5	gene	taxon:6239			
+WB	WBGene00011883	mrpl-50		T21B10.1	gene	taxon:6239			
+WB	WBGene00011884	enol-1		T21B10.2	gene	taxon:6239			
+WB	WBGene00011886	T21B10.4			gene	taxon:6239			
+WB	WBGene00011887	set-17		T21B10.5	gene	taxon:6239			
+WB	WBGene00011888	cutl-15		T21B10.6	gene	taxon:6239			
+WB	WBGene00011890	mics-1		T21C9.1	gene	taxon:6239			
+WB	WBGene00011891	del-6		T21C9.3	gene	taxon:6239			
+WB	WBGene00011892	erh-1		T21C9.4	gene	taxon:6239			
+WB	WBGene00011893	T21C9.6			gene	taxon:6239			
+WB	WBGene00011894	ttr-23		T21C9.8	gene	taxon:6239			
+WB	WBGene00011896	T21C9.11			gene	taxon:6239			
+WB	WBGene00011897	scpl-4		T21C9.12	gene	taxon:6239			
+WB	WBGene00011898	T21C9.13			gene	taxon:6239			
+WB	WBGene00011899	nlp-68		T21C12.3|3K628	gene	taxon:6239			
+WB	WBGene00011904	hlb-1		T21H8.1	gene	taxon:6239			
+WB	WBGene00011906	hsp-12.1		T22A3.2	gene	taxon:6239			
+WB	WBGene00011908	pash-1		T22A3.5	gene	taxon:6239			
+WB	WBGene00011910	alg-3		T22B3.2	gene	taxon:6239			
+WB	WBGene00011911	T22B3.3			gene	taxon:6239			
+WB	WBGene00011912	T22C1.1			gene	taxon:6239			
+WB	WBGene00011913	glb-26		T22C1.2	gene	taxon:6239			
+WB	WBGene00011914	pigu-1		T22C1.3	gene	taxon:6239			
+WB	WBGene00011915	ctf-8		T22C1.4	gene	taxon:6239			
+WB	WBGene00011917	T22C1.6			gene	taxon:6239			
+WB	WBGene00011918	T22C1.8			gene	taxon:6239			
+WB	WBGene00011919	T22C1.9			gene	taxon:6239			
+WB	WBGene00011922	T22C8.1			gene	taxon:6239			
+WB	WBGene00011923	chhy-1		T22C8.2|CSHY|hya-1	gene	taxon:6239			
+WB	WBGene00011926	sptf-2		T22C8.5	gene	taxon:6239			
+WB	WBGene00011928	cutl-12		T22C8.7	gene	taxon:6239			
+WB	WBGene00011929	T22G5.1			gene	taxon:6239			
+WB	WBGene00011931	srsx-19		T22G5.4	gene	taxon:6239			
+WB	WBGene00011932	sptl-3		T22G5.5	gene	taxon:6239			
+WB	WBGene00011935	scrm-1		T22H2.5|plsc-2	gene	taxon:6239			
+WB	WBGene00011936	pgrn-1		T22H2.6	gene	taxon:6239			
+WB	WBGene00011937	ilc-17.1		T22H6.1	gene	taxon:6239			
+WB	WBGene00011938	alh-13		T22H6.2	gene	taxon:6239			
+WB	WBGene00011939	prmt-9		T23B5.1|prmt-3	gene	taxon:6239			
+WB	WBGene00011941	T23B5.4			gene	taxon:6239			
+WB	WBGene00011942	T23D5.3			gene	taxon:6239			
+WB	WBGene00011943	T23D5.8			gene	taxon:6239			
+WB	WBGene00011944	T23D8.3			gene	taxon:6239			
+WB	WBGene00011945	alg-5		T23D8.7|hpo-24	gene	taxon:6239			
+WB	WBGene00011948	rocf-1		T23F1.5	gene	taxon:6239			
+WB	WBGene00011951	T23F6.3			gene	taxon:6239			
+WB	WBGene00011953	ppm-2		T23F11.1	gene	taxon:6239			
+WB	WBGene00011955	cdka-1		T23F11.3	gene	taxon:6239			
+WB	WBGene00011958	T23G4.2			gene	taxon:6239			
+WB	WBGene00011959	nyn-1		T23G4.3	gene	taxon:6239			
+WB	WBGene00011960	oac-48		T23G4.4	gene	taxon:6239			
+WB	WBGene00011963	T23G5.3			gene	taxon:6239			
+WB	WBGene00011964	saeg-2		T23G5.6	gene	taxon:6239			
+WB	WBGene00011965	T23G7.2			gene	taxon:6239			
+WB	WBGene00011966	T23G7.3			gene	taxon:6239			
+WB	WBGene00011967	pir-1		T23G7.5	gene	taxon:6239			
+WB	WBGene00011968	T23G11.1			gene	taxon:6239			
+WB	WBGene00011970	rlbp-1		T23G11.5	gene	taxon:6239			
+WB	WBGene00011971	lron-9		T23G11.6	gene	taxon:6239			
+WB	WBGene00011972	T23G11.7			gene	taxon:6239			
+WB	WBGene00011973	T23G11.10			gene	taxon:6239			
+WB	WBGene00011974	xbx-5		T24A11.2	gene	taxon:6239			
+WB	WBGene00011975	T24B1.1			gene	taxon:6239			
+WB	WBGene00011976	chmp-7		T24B8.2	gene	taxon:6239			
+WB	WBGene00011978	T24B8.4			gene	taxon:6239			
+WB	WBGene00011979	sysm-1		T24B8.5	gene	taxon:6239			
+WB	WBGene00011980	T24B8.7			gene	taxon:6239			
+WB	WBGene00011985	T24D1.2			gene	taxon:6239			
+WB	WBGene00011986	T24D1.3			gene	taxon:6239			
+WB	WBGene00011988	har-2		T24D1.5	gene	taxon:6239			
+WB	WBGene00011992	T24D5.4			gene	taxon:6239			
+WB	WBGene00011994	samp-1		T24F1.2	gene	taxon:6239			
+WB	WBGene00011995	rsf-1		T24F1.3|rasf-1	gene	taxon:6239			
+WB	WBGene00011996	T24F1.4			gene	taxon:6239			
+WB	WBGene00011997	nlp-51		T24F1.5	gene	taxon:6239			
+WB	WBGene00011999	T24F1.7			gene	taxon:6239			
+WB	WBGene00012000	T24H10.1			gene	taxon:6239			
+WB	WBGene00012002	T24H10.4			gene	taxon:6239			
+WB	WBGene00012004	dyrb-1		T24H10.6	gene	taxon:6239			
+WB	WBGene00012005	jun-1		T24H10.7	gene	taxon:6239			
+WB	WBGene00012007	T25B9.1			gene	taxon:6239			
+WB	WBGene00012008	T25B9.2			gene	taxon:6239			
+WB	WBGene00012010	T25B9.4			gene	taxon:6239			
+WB	WBGene00012011	T25B9.5			gene	taxon:6239			
+WB	WBGene00012013	ugt-54		T25B9.7	gene	taxon:6239			
+WB	WBGene00012015	T25B9.9			gene	taxon:6239			
+WB	WBGene00012016	inpp-1		T25B9.10	gene	taxon:6239			
+WB	WBGene00012017	shpk-1		T25C8.1|exc-10	gene	taxon:6239			
+WB	WBGene00012019	dkf-2		T25E12.4	gene	taxon:6239			
+WB	WBGene00012020	gyg-2		T25E12.5	gene	taxon:6239			
+WB	WBGene00012022	clec-39		T25E12.7	gene	taxon:6239			
+WB	WBGene00012023	clec-34		T25E12.8	gene	taxon:6239			
+WB	WBGene00012024	clec-29		T25E12.9	gene	taxon:6239			
+WB	WBGene00012025	clec-38		T25E12.10	gene	taxon:6239			
+WB	WBGene00012026	srz-100		T25E12.11	gene	taxon:6239			
+WB	WBGene00012028	srz-99		T25E12.13	gene	taxon:6239			
+WB	WBGene00012030	T25G3.3			gene	taxon:6239			
+WB	WBGene00012031	gpdh-3		T25G3.4	gene	taxon:6239			
+WB	WBGene00012033	T26C5.3			gene	taxon:6239			
+WB	WBGene00012036	clec-103		T26E3.1	gene	taxon:6239			
+WB	WBGene00012039	T26E3.6			gene	taxon:6239			
+WB	WBGene00012040	T26E3.7			gene	taxon:6239			
+WB	WBGene00012042	T26E3.10			gene	taxon:6239			
+WB	WBGene00012043	irld-52		T26E4.1	gene	taxon:6239			
+WB	WBGene00012045	T26E4.3			gene	taxon:6239			
+WB	WBGene00012046	T26E4.4			gene	taxon:6239			
+WB	WBGene00012050	nhr-223		T26E4.8	gene	taxon:6239			
+WB	WBGene00012054	srsx-38		T26E4.14	gene	taxon:6239			
+WB	WBGene00012055	srsx-36		T26E4.15	gene	taxon:6239			
+WB	WBGene00012056	nhr-285		T26E4.16	gene	taxon:6239			
+WB	WBGene00012057	T26F2.1			gene	taxon:6239			
+WB	WBGene00012059	T26G10.1			gene	taxon:6239			
+WB	WBGene00012060	T26G10.3			gene	taxon:6239			
+WB	WBGene00012064	fbxb-115		T26H2.2	gene	taxon:6239			
+WB	WBGene00012067	sqst-3		T26H2.5	gene	taxon:6239			
+WB	WBGene00012068	oac-49		T26H2.7	gene	taxon:6239			
+WB	WBGene00012070	T26H5.8			gene	taxon:6239			
+WB	WBGene00012072	T26H8.4			gene	taxon:6239			
+WB	WBGene00012073	cpd-2		T27A8.1	gene	taxon:6239			
+WB	WBGene00012074	T27A8.2			gene	taxon:6239			
+WB	WBGene00012075	T27A8.3			gene	taxon:6239			
+WB	WBGene00012081	T27C5.8			gene	taxon:6239			
+WB	WBGene00012083	T27C5.10			gene	taxon:6239			
+WB	WBGene00012084	npr-15		T27D1.3	gene	taxon:6239			
+WB	WBGene00012085	T27D12.1			gene	taxon:6239			
+WB	WBGene00012086	clec-144		T27D12.3	gene	taxon:6239			
+WB	WBGene00012088	T27E7.3			gene	taxon:6239			
+WB	WBGene00012089	T27E7.4			gene	taxon:6239			
+WB	WBGene00012090	T27E7.5			gene	taxon:6239			
+WB	WBGene00012093	T27E7.9			gene	taxon:6239			
+WB	WBGene00012094	T27E9.2			gene	taxon:6239			
+WB	WBGene00012095	pssy-2		T27E9.5	gene	taxon:6239			
+WB	WBGene00012097	abcf-2		T27E9.7	gene	taxon:6239			
+WB	WBGene00012099	acc-4		T27E9.9	gene	taxon:6239			
+WB	WBGene00012100	sipa-1		T27F2.2	gene	taxon:6239			
+WB	WBGene00012101	zip-10		T27F2.4	gene	taxon:6239			
+WB	WBGene00012102	T27F6.1			gene	taxon:6239			
+WB	WBGene00012103	clec-12		T27F6.2	gene	taxon:6239			
+WB	WBGene00012105	T27F6.6			gene	taxon:6239			
+WB	WBGene00012106	T27F6.7			gene	taxon:6239			
+WB	WBGene00012108	T28A8.2			gene	taxon:6239			
+WB	WBGene00012114	T28B8.3			gene	taxon:6239			
+WB	WBGene00012115	T28B8.4			gene	taxon:6239			
+WB	WBGene00012116	del-4		T28B8.5	gene	taxon:6239			
+WB	WBGene00012119	T28C6.3			gene	taxon:6239			
+WB	WBGene00012122	T28C6.8			gene	taxon:6239			
+WB	WBGene00012125	T28D6.5			gene	taxon:6239			
+WB	WBGene00012126	T28D6.6			gene	taxon:6239			
+WB	WBGene00012127	T28D6.7			gene	taxon:6239			
+WB	WBGene00012128	nra-1		T28F3.1	gene	taxon:6239			
+WB	WBGene00012130	slc-17.4		T28F3.4	gene	taxon:6239			
+WB	WBGene00012131	T28F3.5			gene	taxon:6239			
+WB	WBGene00012132	ifta-2		T28F3.6	gene	taxon:6239			
+WB	WBGene00012135	T28F3.9			gene	taxon:6239			
+WB	WBGene00012137	asic-2		T28F4.2	gene	taxon:6239			
+WB	WBGene00012138	T28F4.3			gene	taxon:6239			
+WB	WBGene00012142	T28H10.1			gene	taxon:6239			
+WB	WBGene00012144	lgmn-1		T28H10.3	gene	taxon:6239			
+WB	WBGene00012145	nlp-46		T28H10.4	gene	taxon:6239			
+WB	WBGene00012148	inos-1		VF13D12L.1	gene	taxon:6239			
+WB	WBGene00012149	VF13D12L.3			gene	taxon:6239			
+WB	WBGene00012150	syx-17		VF39H2L.1	gene	taxon:6239			
+WB	WBGene00012155	VW02B12L.2			gene	taxon:6239			
+WB	WBGene00012156	ebp-2		VW02B12L.3	gene	taxon:6239			
+WB	WBGene00012157	adbp-1		VW02B12L.4|2L737	gene	taxon:6239			
+WB	WBGene00012158	ucr-2.1		VW06B3R.1	gene	taxon:6239			
+WB	WBGene00012159	VY10G11R.1			gene	taxon:6239			
+WB	WBGene00012162	sek-6		VZC374L.1	gene	taxon:6239			
+WB	WBGene00012163	VZK822L.2			gene	taxon:6239			
+WB	WBGene00012165	cutl-6		W01A8.3	gene	taxon:6239			
+WB	WBGene00012166	nuo-6		W01A8.4	gene	taxon:6239			
+WB	WBGene00012168	W01A8.6			gene	taxon:6239			
+WB	WBGene00012169	ttbk-4		W01B6.2	gene	taxon:6239			
+WB	WBGene00012170	W01B6.3			gene	taxon:6239			
+WB	WBGene00012172	W01B6.5			gene	taxon:6239			
+WB	WBGene00012173	W01B6.6			gene	taxon:6239			
+WB	WBGene00012174	W01B6.8			gene	taxon:6239			
+WB	WBGene00012177	decr-1.2		W01C9.4	gene	taxon:6239			
+WB	WBGene00012178	glb-27		W01C9.5	gene	taxon:6239			
+WB	WBGene00012179	W01D2.1			gene	taxon:6239			
+WB	WBGene00012180	W01D2.3			gene	taxon:6239			
+WB	WBGene00012181	srt-11		W01D2.4	gene	taxon:6239			
+WB	WBGene00012182	osta-3		W01D2.5	gene	taxon:6239			
+WB	WBGene00012183	W01D2.6			gene	taxon:6239			
+WB	WBGene00012184	mnr-1		W01F3.1	gene	taxon:6239			
+WB	WBGene00012185	W01F3.2			gene	taxon:6239			
+WB	WBGene00012186	mlt-11		W01F3.3|phi-36	gene	taxon:6239			
+WB	WBGene00012187	rpb-11		W01G7.3	gene	taxon:6239			
+WB	WBGene00012188	W01G7.4			gene	taxon:6239			
+WB	WBGene00012190	W02A2.5			gene	taxon:6239			
+WB	WBGene00012192	W02A11.1			gene	taxon:6239			
+WB	WBGene00012193	vps-25		W02A11.2	gene	taxon:6239			
+WB	WBGene00012194	toe-4		W02A11.3	gene	taxon:6239			
+WB	WBGene00012197	W02B8.1			gene	taxon:6239			
+WB	WBGene00012198	W02B8.2			gene	taxon:6239			
+WB	WBGene00012199	mltn-3		W02B8.3	gene	taxon:6239			
+WB	WBGene00012201	W02B12.1			gene	taxon:6239			
+WB	WBGene00012203	rga-1		W02B12.8	gene	taxon:6239			
+WB	WBGene00012204	mfn-1		W02B12.9	gene	taxon:6239			
+WB	WBGene00012205	metl-1		W02B12.10	gene	taxon:6239			
+WB	WBGene00012206	W02B12.11			gene	taxon:6239			
+WB	WBGene00012207	W02B12.12			gene	taxon:6239			
+WB	WBGene00012208	W02D9.2			gene	taxon:6239			
+WB	WBGene00012209	hmg-20		W02D9.3	gene	taxon:6239			
+WB	WBGene00012211	ssp-37		W02D9.5	gene	taxon:6239			
+WB	WBGene00012214	W02D9.8			gene	taxon:6239			
+WB	WBGene00012215	W02D9.9			gene	taxon:6239			
+WB	WBGene00012219	W03C9.1			gene	taxon:6239			
+WB	WBGene00012220	W03C9.2			gene	taxon:6239			
+WB	WBGene00012222	W03C9.6			gene	taxon:6239			
+WB	WBGene00012223	W03C9.8			gene	taxon:6239			
+WB	WBGene00012224	W03G11.2			gene	taxon:6239			
+WB	WBGene00012225	W03G11.3			gene	taxon:6239			
+WB	WBGene00012230	cacn-1		W03H9.4	gene	taxon:6239			
+WB	WBGene00012232	W04A4.3			gene	taxon:6239			
+WB	WBGene00012233	clpr-1		W04A4.4	gene	taxon:6239			
+WB	WBGene00012236	W04A8.1			gene	taxon:6239			
+WB	WBGene00012239	W04A8.4			gene	taxon:6239			
+WB	WBGene00012242	srt-39		W04D2.2	gene	taxon:6239			
+WB	WBGene00012244	mrps-11		W04D2.5	gene	taxon:6239			
+WB	WBGene00012245	rbm-25		W04D2.6	gene	taxon:6239			
+WB	WBGene00012247	W04E12.2			gene	taxon:6239			
+WB	WBGene00012248	W04E12.3			gene	taxon:6239			
+WB	WBGene00012249	W04E12.4			gene	taxon:6239			
+WB	WBGene00012250	W04E12.5			gene	taxon:6239			
+WB	WBGene00012251	clec-49		W04E12.6	gene	taxon:6239			
+WB	WBGene00012252	W04E12.7			gene	taxon:6239			
+WB	WBGene00012253	clec-50		W04E12.8	gene	taxon:6239			
+WB	WBGene00012254	W04E12.9			gene	taxon:6239			
+WB	WBGene00012255	lpr-6		W04G3.1	gene	taxon:6239			
+WB	WBGene00012256	lpr-5		W04G3.2|cpg-15	gene	taxon:6239			
+WB	WBGene00012257	lpr-4		W04G3.3	gene	taxon:6239			
+WB	WBGene00012258	W04G3.5			gene	taxon:6239			
+WB	WBGene00012259	sulp-7		W04G3.6	gene	taxon:6239			
+WB	WBGene00012261	lpr-3		W04G3.8	gene	taxon:6239			
+WB	WBGene00012265	W04G5.4			gene	taxon:6239			
+WB	WBGene00012266	W04G5.5			gene	taxon:6239			
+WB	WBGene00012269	W04G5.9			gene	taxon:6239			
+WB	WBGene00012270	W04G5.10			gene	taxon:6239			
+WB	WBGene00012271	W05B2.2			gene	taxon:6239			
+WB	WBGene00012275	npr-14		W05B5.2	gene	taxon:6239			
+WB	WBGene00012276	his-74		W05B10.1	gene	taxon:6239			
+WB	WBGene00012277	ccch-3		W05B10.2	gene	taxon:6239			
+WB	WBGene00012279	W05B10.4			gene	taxon:6239			
+WB	WBGene00012280	W05E10.1			gene	taxon:6239			
+WB	WBGene00012281	W05E10.2			gene	taxon:6239			
+WB	WBGene00012283	W05H5.1			gene	taxon:6239			
+WB	WBGene00012285	pitr-6		W05H5.3	gene	taxon:6239			
+WB	WBGene00012286	sre-35		W05H5.5	gene	taxon:6239			
+WB	WBGene00012287	sre-33		W05H5.6	gene	taxon:6239			
+WB	WBGene00012288	sre-32		W05H5.7	gene	taxon:6239			
+WB	WBGene00012289	W05H12.1			gene	taxon:6239			
+WB	WBGene00012291	W06A7.2			gene	taxon:6239			
+WB	WBGene00012293	W06A7.4			gene	taxon:6239			
+WB	WBGene00012295	nmat-1		W06B3.1	gene	taxon:6239			
+WB	WBGene00012296	spe-46		W06D4.2	gene	taxon:6239			
+WB	WBGene00012297	W06D4.3			gene	taxon:6239			
+WB	WBGene00012298	prmt-7		W06D4.4|pmrt-2	gene	taxon:6239			
+WB	WBGene00012302	dot-1.3		W06D11.4	gene	taxon:6239			
+WB	WBGene00012304	cutl-4		W06D12.1	gene	taxon:6239			
+WB	WBGene00012306	W06F12.2			gene	taxon:6239			
+WB	WBGene00012307	W06F12.3			gene	taxon:6239			
+WB	WBGene00012308	oac-53		W06G6.1	gene	taxon:6239			
+WB	WBGene00012310	mltn-11		W06G6.7	gene	taxon:6239			
+WB	WBGene00012315	immt-2		W06H3.1	gene	taxon:6239			
+WB	WBGene00012316	ctps-1		W06H3.3	gene	taxon:6239			
+WB	WBGene00012317	ztf-6		W06H12.1|dopy-1	gene	taxon:6239			
+WB	WBGene00012318	srxa-1		W07A8.1	gene	taxon:6239			
+WB	WBGene00012319	ipla-3		W07A8.2	gene	taxon:6239			
+WB	WBGene00012321	srxa-6		W07A8.5	gene	taxon:6239			
+WB	WBGene00012323	oac-54		W07A12.6	gene	taxon:6239			
+WB	WBGene00012324	rhy-1		W07A12.7|tag-323	gene	taxon:6239			
+WB	WBGene00012326	W07E11.1			gene	taxon:6239			
+WB	WBGene00012328	W07G1.1			gene	taxon:6239			
+WB	WBGene00012329	sre-44		W07G1.2	gene	taxon:6239			
+WB	WBGene00012330	zip-3		W07G1.3	gene	taxon:6239			
+WB	WBGene00012332	rpi-1		W07G1.5	gene	taxon:6239			
+WB	WBGene00012333	sre-43		W07G1.6	gene	taxon:6239			
+WB	WBGene00012336	W07G4.2			gene	taxon:6239			
+WB	WBGene00012337	scyl-1		W07G4.3	gene	taxon:6239			
+WB	WBGene00012340	dct-15		W08D2.3	gene	taxon:6239			
+WB	WBGene00012341	catp-6		W08D2.5|ATP13A2	gene	taxon:6239			
+WB	WBGene00012342	mtr-4		W08D2.7	gene	taxon:6239			
+WB	WBGene00012343	casc-3		W08E3.2	gene	taxon:6239			
+WB	WBGene00012344	ola-1		W08E3.3|tag-210	gene	taxon:6239			
+WB	WBGene00012345	W08E3.4			gene	taxon:6239			
+WB	WBGene00012346	W08G11.1			gene	taxon:6239			
+WB	WBGene00012348	pptr-1		W08G11.4	gene	taxon:6239			
+WB	WBGene00012349	W08G11.5			gene	taxon:6239			
+WB	WBGene00012351	W09C5.1			gene	taxon:6239			
+WB	WBGene00012352	dkf-1		W09C5.5	gene	taxon:6239			
+WB	WBGene00012353	sac-2		W09C5.7	gene	taxon:6239			
+WB	WBGene00012354	cox-4		W09C5.8	gene	taxon:6239			
+WB	WBGene00012358	W09D6.5			gene	taxon:6239			
+WB	WBGene00012359	W09D10.1			gene	taxon:6239			
+WB	WBGene00012360	tat-3		W09D10.2	gene	taxon:6239			
+WB	WBGene00012361	mrpl-12		W09D10.3	gene	taxon:6239			
+WB	WBGene00012362	W09D10.4			gene	taxon:6239			
+WB	WBGene00012363	W09D10.5			gene	taxon:6239			
+WB	WBGene00012364	zmp-4		W09D12.1	gene	taxon:6239			
+WB	WBGene00012366	maea-1		W09G3.2	gene	taxon:6239			
+WB	WBGene00012371	W09G3.8			gene	taxon:6239			
+WB	WBGene00012375	mecr-1		W09H1.5	gene	taxon:6239			
+WB	WBGene00012376	nduf-7		W10D5.2	gene	taxon:6239			
+WB	WBGene00012379	Y1A5A.1			gene	taxon:6239			
+WB	WBGene00012381	Y2H9A.4			gene	taxon:6239			
+WB	WBGene00012382	ttr-16		Y5F2A.1	gene	taxon:6239			
+WB	WBGene00012383	ttr-17		Y5F2A.2	gene	taxon:6239			
+WB	WBGene00012386	agef-1		Y6B3A.1	gene	taxon:6239			
+WB	WBGene00012390	gpap-1		Y6B3B.5	gene	taxon:6239			
+WB	WBGene00012391	Y6B3B.7			gene	taxon:6239			
+WB	WBGene00012393	Y6B3B.9			gene	taxon:6239			
+WB	WBGene00012394	hsd-1		Y6B3B.11|eak-2	gene	taxon:6239			
+WB	WBGene00012396	Y6D1A.2			gene	taxon:6239			
+WB	WBGene00012397	Y6E2A.1			gene	taxon:6239			
+WB	WBGene00012402	sfxn-1.3		Y6E2A.9	gene	taxon:6239			
+WB	WBGene00012406	srz-91		Y6G8.4	gene	taxon:6239			
+WB	WBGene00012407	Y7A5A.1			gene	taxon:6239			
+WB	WBGene00012416	Y7A9A.1			gene	taxon:6239			
+WB	WBGene00012421	Y9C2UA.1			gene	taxon:6239			
+WB	WBGene00012423	Y10G11A.1			gene	taxon:6239			
+WB	WBGene00012424	dlc-3		Y10G11A.2	gene	taxon:6239			
+WB	WBGene00012425	dlc-4		Y10G11A.3	gene	taxon:6239			
+WB	WBGene00012428	Y11D7A.3			gene	taxon:6239			
+WB	WBGene00012433	Y11D7A.9			gene	taxon:6239			
+WB	WBGene00012435	flh-1		Y11D7A.12	gene	taxon:6239			
+WB	WBGene00012436	flh-3		Y11D7A.13	gene	taxon:6239			
+WB	WBGene00012437	nmy-3		Y11D7A.14|hum-9	gene	taxon:6239			
+WB	WBGene00012439	Y12A6A.1			gene	taxon:6239			
+WB	WBGene00012440	nlp-53		Y12A6A.2	gene	taxon:6239			
+WB	WBGene00012441	glb-28		Y15E3A.2	gene	taxon:6239			
+WB	WBGene00012443	Y15E3A.4			gene	taxon:6239			
+WB	WBGene00012445	Y16B4A.2			gene	taxon:6239			
+WB	WBGene00012446	nhr-230		Y17D7A.1	gene	taxon:6239			
+WB	WBGene00012448	cyp-33D3		Y17D7A.4	gene	taxon:6239			
+WB	WBGene00012449	nhr-231		Y17D7B.1	gene	taxon:6239			
+WB	WBGene00012454	clec-256		Y17D7B.6	gene	taxon:6239			
+WB	WBGene00012457	acbp-6		Y17G7B.1	gene	taxon:6239			
+WB	WBGene00012458	ash-2		Y17G7B.2|Y17G7B.2a	gene	taxon:6239			
+WB	WBGene00012459	Y17G7B.3			gene	taxon:6239			
+WB	WBGene00012460	dhps-1		Y17G7B.4	gene	taxon:6239			
+WB	WBGene00012461	glb-29		Y17G7B.6	gene	taxon:6239			
+WB	WBGene00012462	Y17G7B.8			gene	taxon:6239			
+WB	WBGene00012463	nadk-2		Y17G7B.10	gene	taxon:6239			
+WB	WBGene00012464	arrd-7		Y17G7B.11	gene	taxon:6239			
+WB	WBGene00012465	Y17G7B.12			gene	taxon:6239			
+WB	WBGene00012466	ippk-1		Y17G7B.13	gene	taxon:6239			
+WB	WBGene00012468	Y17G7B.17			gene	taxon:6239			
+WB	WBGene00012469	Y17G7B.18			gene	taxon:6239			
+WB	WBGene00012474	attf-6		Y18D10A.1	gene	taxon:6239			
+WB	WBGene00012475	Y18D10A.2			gene	taxon:6239			
+WB	WBGene00012476	Y18D10A.3			gene	taxon:6239			
+WB	WBGene00012477	Y18D10A.4			gene	taxon:6239			
+WB	WBGene00012478	mxt-1		Y18D10A.8	gene	taxon:6239			
+WB	WBGene00012479	ciao-1		Y18D10A.9	gene	taxon:6239			
+WB	WBGene00012480	clec-104		Y18D10A.10	gene	taxon:6239			
+WB	WBGene00012481	Y18D10A.11			gene	taxon:6239			
+WB	WBGene00012482	clec-106		Y18D10A.12	gene	taxon:6239			
+WB	WBGene00012484	car-1		Y18D10A.17|lsm-14	gene	taxon:6239			
+WB	WBGene00012487	Y18D10A.23			gene	taxon:6239			
+WB	WBGene00012488	clec-105		Y18D10A.24	gene	taxon:6239			
+WB	WBGene00012489	Y19D2B.1			gene	taxon:6239			
+WB	WBGene00012494	nhr-232		Y22F5A.1	gene	taxon:6239			
+WB	WBGene00012496	Y24F12A.1			gene	taxon:6239			
+WB	WBGene00012497	ragc-1		Y24F12A.2	gene	taxon:6239			
+WB	WBGene00012501	Y26D4A.3			gene	taxon:6239			
+WB	WBGene00012502	clec-107		Y26D4A.4	gene	taxon:6239			
+WB	WBGene00012503	Y26D4A.5			gene	taxon:6239			
+WB	WBGene00012504	clec-108		Y26D4A.6	gene	taxon:6239			
+WB	WBGene00012509	Y26D4A.12			gene	taxon:6239			
+WB	WBGene00012515	Y26G10.1			gene	taxon:6239			
+WB	WBGene00012516	sqst-4		Y32B12A.1	gene	taxon:6239			
+WB	WBGene00012518	comt-2		Y32B12A.3	gene	taxon:6239			
+WB	WBGene00012521	Y32B12B.1			gene	taxon:6239			
+WB	WBGene00012523	srbc-65		Y32B12B.3	gene	taxon:6239			
+WB	WBGene00012524	Y32B12B.4			gene	taxon:6239			
+WB	WBGene00012528	pap-1		Y32F6A.3	gene	taxon:6239			
+WB	WBGene00012529	Y32F6A.4			gene	taxon:6239			
+WB	WBGene00012530	Y32F6A.5			gene	taxon:6239			
+WB	WBGene00012531	Y32F6B.1			gene	taxon:6239			
+WB	WBGene00012532	crp-1		Y32F6B.3	gene	taxon:6239			
+WB	WBGene00012535	Y37A1A.2			gene	taxon:6239			
+WB	WBGene00012536	Y37A1A.3			gene	taxon:6239			
+WB	WBGene00012538	semo-1		Y37A1B.5	gene	taxon:6239			
+WB	WBGene00012543	nkcc-1		Y37A1C.1	gene	taxon:6239			
+WB	WBGene00012544	Y37D8A.2			gene	taxon:6239			
+WB	WBGene00012547	Y37D8A.5			gene	taxon:6239			
+WB	WBGene00012548	Y37D8A.6			gene	taxon:6239			
+WB	WBGene00012549	Y37D8A.8			gene	taxon:6239			
+WB	WBGene00012550	spcs-2		Y37D8A.10|hpo-21	gene	taxon:6239			
+WB	WBGene00012551	cec-7		Y37D8A.11	gene	taxon:6239			
+WB	WBGene00012552	enu-3.5		Y37D8A.12	gene	taxon:6239			
+WB	WBGene00012553	cox-5A		Y37D8A.14|cco-2	gene	taxon:6239			
+WB	WBGene00012554	Y37D8A.16			gene	taxon:6239			
+WB	WBGene00012555	npp-25		Y37D8A.17	gene	taxon:6239			
+WB	WBGene00012556	mrps-10		Y37D8A.18	gene	taxon:6239			
+WB	WBGene00012558	rbm-7		Y37D8A.21	gene	taxon:6239			
+WB	WBGene00012559	epg-3		Y37D8A.22	gene	taxon:6239			
+WB	WBGene00012560	Y37D8A.25			gene	taxon:6239			
+WB	WBGene00012561	Y37D8A.26			gene	taxon:6239			
+WB	WBGene00012562	Y37H2A.1			gene	taxon:6239			
+WB	WBGene00012570	Y37H2A.10			gene	taxon:6239			
+WB	WBGene00012575	Y37H2C.4			gene	taxon:6239			
+WB	WBGene00012578	ccct-1		Y37H9A.3	gene	taxon:6239			
+WB	WBGene00012582	clec-8		Y38E10A.4	gene	taxon:6239			
+WB	WBGene00012583	clec-4		Y38E10A.5	gene	taxon:6239			
+WB	WBGene00012584	ceh-100		Y38E10A.6	gene	taxon:6239			
+WB	WBGene00012585	lips-15		Y38E10A.7	gene	taxon:6239			
+WB	WBGene00012586	Y38E10A.8			gene	taxon:6239			
+WB	WBGene00012596	nhr-234		Y38E10A.18	gene	taxon:6239			
+WB	WBGene00012597	nhr-235		Y38E10A.19	gene	taxon:6239			
+WB	WBGene00012606	Y38F1A.2			gene	taxon:6239			
+WB	WBGene00012607	Y38F1A.4			gene	taxon:6239			
+WB	WBGene00012608	hphd-1		Y38F1A.6	gene	taxon:6239			
+WB	WBGene00012609	Y38F1A.7			gene	taxon:6239			
+WB	WBGene00012610	Y38F1A.8			gene	taxon:6239			
+WB	WBGene00012616	dct-14		Y38H6C.3	gene	taxon:6239			
+WB	WBGene00012621	Y38H6C.8			gene	taxon:6239			
+WB	WBGene00012624	fbxa-150		Y38H6C.11	gene	taxon:6239			
+WB	WBGene00012626	famh-161		Y38H6C.14|fam-161	gene	taxon:6239			
+WB	WBGene00012627	Y38H6C.15			gene	taxon:6239			
+WB	WBGene00012628	Y38H6C.16			gene	taxon:6239			
+WB	WBGene00012629	slc-36.3		Y38H6C.17	gene	taxon:6239			
+WB	WBGene00012632	Y38H6C.20			gene	taxon:6239			
+WB	WBGene00012633	Y38H6C.21			gene	taxon:6239			
+WB	WBGene00012635	Y38H8A.1			gene	taxon:6239			
+WB	WBGene00012636	Y38H8A.2			gene	taxon:6239			
+WB	WBGene00012637	Y38H8A.3			gene	taxon:6239			
+WB	WBGene00012638	Y38H8A.4			gene	taxon:6239			
+WB	WBGene00012641	epg-6		Y39A1A.1	gene	taxon:6239			
+WB	WBGene00012643	Y39A1A.3			gene	taxon:6239			
+WB	WBGene00012644	rabx-5		Y39A1A.5	gene	taxon:6239			
+WB	WBGene00012645	mrpl-22		Y39A1A.6	gene	taxon:6239			
+WB	WBGene00012647	swt-4		Y39A1A.8	gene	taxon:6239			
+WB	WBGene00012648	Y39A1A.9			gene	taxon:6239			
+WB	WBGene00012650	orc-1		Y39A1A.12	gene	taxon:6239			
+WB	WBGene00012651	orc-4		Y39A1A.13	gene	taxon:6239			
+WB	WBGene00012652	Y39A1A.14			gene	taxon:6239			
+WB	WBGene00012657	Y39A1A.20			gene	taxon:6239			
+WB	WBGene00012658	Y39A1A.21			gene	taxon:6239			
+WB	WBGene00012659	Y39A1A.22			gene	taxon:6239			
+WB	WBGene00012661	clec-163		Y39A1B.1	gene	taxon:6239			
+WB	WBGene00012662	Y39A1C.1			gene	taxon:6239			
+WB	WBGene00012663	hex-3		Y39A1C.4	gene	taxon:6239			
+WB	WBGene00012665	pph-5		Y39B6A.2	gene	taxon:6239			
+WB	WBGene00012666	Y39B6A.3			gene	taxon:6239			
+WB	WBGene00012669	Y39B6A.7		Y39B6B.z	gene	taxon:6239			
+WB	WBGene00012670	cpg-23		Y39B6A.8|Y39B6B.y	gene	taxon:6239			
+WB	WBGene00012672	Y39B6A.10		Y39B6B.w	gene	taxon:6239			
+WB	WBGene00012673	dyf-17		Y39B6A.11|Y39B6B.v	gene	taxon:6239			
+WB	WBGene00012674	bed-1		Y39B6A.12|Y39B6B.t|Y39B6B.u	gene	taxon:6239			
+WB	WBGene00012676	pro-3		Y39B6A.14|Y39B6B.a|Y39B6B.r	gene	taxon:6239			
+WB	WBGene00012678	zhp-4		Y39B6A.16|Y39B6B.b	gene	taxon:6239			
+WB	WBGene00012681	asp-15		Y39B6A.22|Y39B6B.i	gene	taxon:6239			
+WB	WBGene00012682	asp-16		Y39B6A.23|Y39B6B.j	gene	taxon:6239			
+WB	WBGene00012683	asp-17		Y39B6A.24	gene	taxon:6239			
+WB	WBGene00012686	Y39B6A.27			gene	taxon:6239			
+WB	WBGene00012688	Y39B6A.29		Y39B6B.l	gene	taxon:6239			
+WB	WBGene00012689	Y39B6A.30		Y39B6B.m	gene	taxon:6239			
+WB	WBGene00012692	Y39B6A.33		Y39B6.33|Y39B6B.o	gene	taxon:6239			
+WB	WBGene00012693	Y39B6A.34		Y39B6B.p	gene	taxon:6239			
+WB	WBGene00012694	gtf-2F2		Y39B6A.36	gene	taxon:6239			
+WB	WBGene00012697	mrps-35		Y39B6A.39|Y39B6A.f	gene	taxon:6239			
+WB	WBGene00012698	sws-1		Y39B6A.40|Y39B6A.e	gene	taxon:6239			
+WB	WBGene00012699	Y39B6A.41		Y39B6A.d	gene	taxon:6239			
+WB	WBGene00012703	nhr-145		Y39B6A.47|Y39B6B.c	gene	taxon:6239			
+WB	WBGene00012704	mlt-3		Y39C12A.1	gene	taxon:6239			
+WB	WBGene00012705	sre-18		Y39C12A.3	gene	taxon:6239			
+WB	WBGene00012707	sre-16		Y39C12A.5	gene	taxon:6239			
+WB	WBGene00012708	sre-19		Y39C12A.6	gene	taxon:6239			
+WB	WBGene00012709	sre-15		Y39C12A.7	gene	taxon:6239			
+WB	WBGene00012711	Y39E4A.1			gene	taxon:6239			
+WB	WBGene00012712	ttm-1		Y39E4A.2	gene	taxon:6239			
+WB	WBGene00012713	bckd-1A		Y39E4A.3	gene	taxon:6239			
+WB	WBGene00012714	abce-1		Y39E4B.1|tag-351	gene	taxon:6239			
+WB	WBGene00012716	Y39E4B.5			gene	taxon:6239			
+WB	WBGene00012717	Y39E4B.6			gene	taxon:6239			
+WB	WBGene00012718	dhhc-8		Y39E4B.7	gene	taxon:6239			
+WB	WBGene00012721	Y39E4B.13			gene	taxon:6239			
+WB	WBGene00012722	Y39G8B.1			gene	taxon:6239			
+WB	WBGene00012723	Y39G8B.2			gene	taxon:6239			
+WB	WBGene00012724	sre-48		Y39G8B.3	gene	taxon:6239			
+WB	WBGene00012725	sre-47		Y39G8B.4	gene	taxon:6239			
+WB	WBGene00012726	Y39G8B.5			gene	taxon:6239			
+WB	WBGene00012730	xrn-1		Y39G8C.1|Y39G8C.b	gene	taxon:6239			
+WB	WBGene00012731	Y39G8C.2		Y39G8C.c	gene	taxon:6239			
+WB	WBGene00012732	wac-1.2		Y40B1A.1	gene	taxon:6239			
+WB	WBGene00012734	wac-1.1		Y40B1A.3	gene	taxon:6239			
+WB	WBGene00012735	sptf-3		Y40B1A.4	gene	taxon:6239			
+WB	WBGene00012738	eif-3.J		Y40B1B.5	gene	taxon:6239			
+WB	WBGene00012739	Y40B1B.7			gene	taxon:6239			
+WB	WBGene00012740	slc-25A46		Y40B1B.8	gene	taxon:6239			
+WB	WBGene00012741	Y40H4A.2			gene	taxon:6239			
+WB	WBGene00012743	Y40H7A.3			gene	taxon:6239			
+WB	WBGene00012744	Y40H7A.4			gene	taxon:6239			
+WB	WBGene00012747	Y40H7A.10			gene	taxon:6239			
+WB	WBGene00012748	Y40H7A.11			gene	taxon:6239			
+WB	WBGene00012755	Y41C4A.8			gene	taxon:6239			
+WB	WBGene00012756	Y41C4A.9			gene	taxon:6239			
+WB	WBGene00012757	Y41C4A.11			gene	taxon:6239			
+WB	WBGene00012759	sup-1		Y41C4A.13	gene	taxon:6239			
+WB	WBGene00012761	Y41C4A.18			gene	taxon:6239			
+WB	WBGene00012762	Y41E3.1			gene	taxon:6239			
+WB	WBGene00012763	atln-2		Y41E3.3	gene	taxon:6239			
+WB	WBGene00012765	Y41E3.7			gene	taxon:6239			
+WB	WBGene00012766	Y41E3.8			gene	taxon:6239			
+WB	WBGene00012767	fcd-2		Y41E3.9	gene	taxon:6239			
+WB	WBGene00012768	eef-1B.2		Y41E3.10	gene	taxon:6239			
+WB	WBGene00012770	srt-47		Y41E3.12	gene	taxon:6239			
+WB	WBGene00012772	srt-49		Y41E3.14	gene	taxon:6239			
+WB	WBGene00012773	srt-48		Y41E3.15	gene	taxon:6239			
+WB	WBGene00012775	srt-50		Y41E3.17	gene	taxon:6239			
+WB	WBGene00012776	Y42A5A.1			gene	taxon:6239			
+WB	WBGene00012779	cdkl-1		Y42A5A.4	gene	taxon:6239			
+WB	WBGene00012783	Y43C5A.3			gene	taxon:6239			
+WB	WBGene00012784	Y43C5A.4			gene	taxon:6239			
+WB	WBGene00012785	Y43C5B.2			gene	taxon:6239			
+WB	WBGene00012786	Y43C5B.3			gene	taxon:6239			
+WB	WBGene00012787	Y43D4A.1			gene	taxon:6239			
+WB	WBGene00012788	Y43D4A.2			gene	taxon:6239			
+WB	WBGene00012789	Y43D4A.3			gene	taxon:6239			
+WB	WBGene00012790	Y43D4A.4			gene	taxon:6239			
+WB	WBGene00012792	Y43D4A.6			gene	taxon:6239			
+WB	WBGene00012794	Y43E12A.2			gene	taxon:6239			
+WB	WBGene00012796	Y43F4A.1			gene	taxon:6239			
+WB	WBGene00012802	set-25		Y43F4B.3	gene	taxon:6239			
+WB	WBGene00012803	Y43F4B.5			gene	taxon:6239			
+WB	WBGene00012804	slc-36.1		Y43F4B.7	gene	taxon:6239			
+WB	WBGene00012810	nceh-1		Y43F8A.3	gene	taxon:6239			
+WB	WBGene00012811	slcr-46.2		Y43F8A.5	gene	taxon:6239			
+WB	WBGene00012813	Y43F8B.2			gene	taxon:6239			
+WB	WBGene00012814	Y43F8B.3			gene	taxon:6239			
+WB	WBGene00012815	phy-4		Y43F8B.4	gene	taxon:6239			
+WB	WBGene00012820	Y43F8B.10			gene	taxon:6239			
+WB	WBGene00012824	Y43F8B.14			gene	taxon:6239			
+WB	WBGene00012826	dyf-19		Y43F8C.4	gene	taxon:6239			
+WB	WBGene00012829	Y43F8C.7			gene	taxon:6239			
+WB	WBGene00012830	mrps-28		Y43F8C.8	gene	taxon:6239			
+WB	WBGene00012832	dmd-3		Y43F8C.10	gene	taxon:6239			
+WB	WBGene00012833	Y43F8C.11			gene	taxon:6239			
+WB	WBGene00012834	Y43F8C.13			gene	taxon:6239			
+WB	WBGene00012846	srxa-14		Y44A6B.1	gene	taxon:6239			
+WB	WBGene00012847	srxa-15		Y44A6B.2	gene	taxon:6239			
+WB	WBGene00012849	ttr-13		Y44A6B.4	gene	taxon:6239			
+WB	WBGene00012855	Y44A6D.5			gene	taxon:6239			
+WB	WBGene00012856	Y44A6D.6			gene	taxon:6239			
+WB	WBGene00012857	pbo-5		Y44A6E.1|lgc-2	gene	taxon:6239			
+WB	WBGene00012858	Y44F5A.1		3E324	gene	taxon:6239			
+WB	WBGene00012860	acdh-11		Y45F3A.3	gene	taxon:6239			
+WB	WBGene00012864	Y45F3A.9			gene	taxon:6239			
+WB	WBGene00012866	afmd-2		Y45F10A.3	gene	taxon:6239			
+WB	WBGene00012867	seld-1		Y45F10A.4	gene	taxon:6239			
+WB	WBGene00012868	tbc-9		Y45F10A.6	gene	taxon:6239			
+WB	WBGene00012869	Y45F10A.7			gene	taxon:6239			
+WB	WBGene00012872	Y45F10B.8			gene	taxon:6239			
+WB	WBGene00012873	Y45F10B.9			gene	taxon:6239			
+WB	WBGene00012875	Y45F10B.13			gene	taxon:6239			
+WB	WBGene00012878	Y45F10C.2			gene	taxon:6239			
+WB	WBGene00012880	Y45F10C.4			gene	taxon:6239			
+WB	WBGene00012885	iscu-1		Y45F10D.4	gene	taxon:6239			
+WB	WBGene00012887	Y45F10D.7			gene	taxon:6239			
+WB	WBGene00012888	sas-6		Y45F10D.9	gene	taxon:6239			
+WB	WBGene00012889	icap-1		Y45F10D.10	gene	taxon:6239			
+WB	WBGene00012891	sorb-1		Y45F10D.13|tag-208	gene	taxon:6239			
+WB	WBGene00012892	Y45F10D.14			gene	taxon:6239			
+WB	WBGene00012893	Y45F10D.15			gene	taxon:6239			
+WB	WBGene00012895	cox-10		Y46G5A.2|dapat	gene	taxon:6239			
+WB	WBGene00012896	snrp-200		Y46G5A.4|phi-10	gene	taxon:6239			
+WB	WBGene00012897	pisy-1		Y46G5A.5	gene	taxon:6239			
+WB	WBGene00012900	Y46G5A.8			gene	taxon:6239			
+WB	WBGene00012901	cnp-2		Y46G5A.10	gene	taxon:6239			
+WB	WBGene00012903	vps-2		Y46G5A.12	gene	taxon:6239			
+WB	WBGene00012904	tiar-2		Y46G5A.13|tia-1	gene	taxon:6239			
+WB	WBGene00012907	cpt-1		Y46G5A.17	gene	taxon:6239			
+WB	WBGene00012908	Y46G5A.18			gene	taxon:6239			
+WB	WBGene00012909	spds-1		Y46G5A.19	gene	taxon:6239			
+WB	WBGene00012910	Y46G5A.20			gene	taxon:6239			
+WB	WBGene00012911	acl-7		Y46G5A.21	gene	taxon:6239			
+WB	WBGene00012912	Y46G5A.22			gene	taxon:6239			
+WB	WBGene00012914	bcmo-1		Y46G5A.24	gene	taxon:6239			
+WB	WBGene00012915	lgc-35		Y46G5A.26	gene	taxon:6239			
+WB	WBGene00012916	Y46G5A.28			gene	taxon:6239			
+WB	WBGene00012917	Y46G5A.29			gene	taxon:6239			
+WB	WBGene00012920	alkb-7		Y46G5A.35	gene	taxon:6239			
+WB	WBGene00012922	Y47D3A.1			gene	taxon:6239			
+WB	WBGene00012925	wht-8		Y47D3A.11	gene	taxon:6239			
+WB	WBGene00012927	Y47D3A.14			gene	taxon:6239			
+WB	WBGene00012928	aakb-2		Y47D3A.15	gene	taxon:6239			
+WB	WBGene00012929	rsks-1		Y47D3A.16|S6K	gene	taxon:6239			
+WB	WBGene00012930	obr-1		Y47D3A.17	gene	taxon:6239			
+WB	WBGene00012932	Y47D3A.21			gene	taxon:6239			
+WB	WBGene00012933	mib-1		Y47D3A.22	gene	taxon:6239			
+WB	WBGene00012934	gly-9		Y47D3A.23|tag-356	gene	taxon:6239			
+WB	WBGene00012935	mcm-10		Y47D3A.28	gene	taxon:6239			
+WB	WBGene00012936	pola-1		Y47D3A.29	gene	taxon:6239			
+WB	WBGene00012938	Y47D3A.32			gene	taxon:6239			
+WB	WBGene00012939	subs-4		Y47D3B.1	gene	taxon:6239			
+WB	WBGene00012941	Y47D3B.4			gene	taxon:6239			
+WB	WBGene00012943	bed-2		Y47D3B.9	gene	taxon:6239			
+WB	WBGene00012945	Y47H9A.1			gene	taxon:6239			
+WB	WBGene00012948	dhhc-2		Y47H9C.2	gene	taxon:6239			
+WB	WBGene00012950	eif-2Bbeta		Y47H9C.7	gene	taxon:6239			
+WB	WBGene00012959	Y47H10A.3			gene	taxon:6239			
+WB	WBGene00012960	Y47H10A.4			gene	taxon:6239			
+WB	WBGene00012961	Y47H10A.5			gene	taxon:6239			
+WB	WBGene00012962	dmsr-5		Y48A6B.1	gene	taxon:6239			
+WB	WBGene00012964	Y48A6B.3			gene	taxon:6239			
+WB	WBGene00012966	exos-1		Y48A6B.5	gene	taxon:6239			
+WB	WBGene00012967	kvs-4		Y48A6B.6	gene	taxon:6239			
+WB	WBGene00012968	Y48A6B.7			gene	taxon:6239			
+WB	WBGene00012970	Y48A6B.9			gene	taxon:6239			
+WB	WBGene00012972	rsa-2		Y48A6B.11	gene	taxon:6239			
+WB	WBGene00012976	sup-35		Y48A6C.3|ztf-21	gene	taxon:6239			
+WB	WBGene00012978	Y48B6A.1			gene	taxon:6239			
+WB	WBGene00012979	Y48B6A.5			gene	taxon:6239			
+WB	WBGene00012980	efhd-1		Y48B6A.6|EFhd2 orthologue	gene	taxon:6239			
+WB	WBGene00012981	Y48B6A.10			gene	taxon:6239			
+WB	WBGene00012982	jmjd-2		Y48B6A.11	gene	taxon:6239			
+WB	WBGene00012983	men-1		Y48B6A.12	gene	taxon:6239			
+WB	WBGene00012984	Y48B6A.13			gene	taxon:6239			
+WB	WBGene00012989	Y48C3A.5			gene	taxon:6239			
+WB	WBGene00012990	sam-10		Y48C3A.8	gene	taxon:6239			
+WB	WBGene00012992	mrpl-20		Y48C3A.10	gene	taxon:6239			
+WB	WBGene00012993	dmsr-3		Y48C3A.11	gene	taxon:6239			
+WB	WBGene00012994	Y48C3A.12			gene	taxon:6239			
+WB	WBGene00012995	Y48C3A.14			gene	taxon:6239			
+WB	WBGene00012996	pinn-4		Y48C3A.16|Pin2	gene	taxon:6239			
+WB	WBGene00012997	Y48C3A.18			gene	taxon:6239			
+WB	WBGene00012998	Y48C3A.20			gene	taxon:6239			
+WB	WBGene00012999	rpoa-1		Y48E1A.1	gene	taxon:6239			
+WB	WBGene00013000	ddl-2		Y48E1B.1	gene	taxon:6239			
+WB	WBGene00013001	noa-1		Y48E1B.2	gene	taxon:6239			
+WB	WBGene00013002	Y48E1B.3			gene	taxon:6239			
+WB	WBGene00013004	mrpl-37		Y48E1B.5	gene	taxon:6239			
+WB	WBGene00013006	lin-38		Y48E1B.7	gene	taxon:6239			
+WB	WBGene00013007	Y48E1B.8			gene	taxon:6239			
+WB	WBGene00013008	clec-146		Y48E1B.9	gene	taxon:6239			
+WB	WBGene00013011	snx-14		Y48E1B.14	gene	taxon:6239			
+WB	WBGene00013013	clec-145		Y48E1B.16	gene	taxon:6239			
+WB	WBGene00013014	Y48E1C.1			gene	taxon:6239			
+WB	WBGene00013015	Y48E1C.2			gene	taxon:6239			
+WB	WBGene00013018	Y48G10A.1			gene	taxon:6239			
+WB	WBGene00013020	Y48G10A.3			gene	taxon:6239			
+WB	WBGene00013021	ints-8		Y48G10A.4	gene	taxon:6239			
+WB	WBGene00013024	cept-2		Y49A3A.1	gene	taxon:6239			
+WB	WBGene00013025	vha-13		Y49A3A.2|phi-51|Y49A3A.b	gene	taxon:6239			
+WB	WBGene00013026	Y49A3A.3			gene	taxon:6239			
+WB	WBGene00013029	glrx-5		Y49E10.2	gene	taxon:6239			
+WB	WBGene00013030	Y49E10.4			gene	taxon:6239			
+WB	WBGene00013033	Y49E10.10			gene	taxon:6239			
+WB	WBGene00013034	tat-1		Y49E10.11	gene	taxon:6239			
+WB	WBGene00013035	Y49E10.16			gene	taxon:6239			
+WB	WBGene00013037	Y49E10.18			gene	taxon:6239			
+WB	WBGene00013038	ani-1		Y49E10.19	gene	taxon:6239			
+WB	WBGene00013039	scav-3		Y49E10.20	gene	taxon:6239			
+WB	WBGene00013041	pstk-1		Y49E10.22	gene	taxon:6239			
+WB	WBGene00013042	cccp-1		Y49E10.23|unc-81	gene	taxon:6239			
+WB	WBGene00013044	Y49E10.25			gene	taxon:6239			
+WB	WBGene00013045	Y49E10.27			gene	taxon:6239			
+WB	WBGene00013047	Y50E8A.2			gene	taxon:6239			
+WB	WBGene00013049	Y50E8A.6			gene	taxon:6239			
+WB	WBGene00013050	lipl-8		Y50E8A.7	gene	taxon:6239			
+WB	WBGene00013052	scrm-7		Y50E8A.9	gene	taxon:6239			
+WB	WBGene00013053	Y50E8A.10			gene	taxon:6239			
+WB	WBGene00013054	Y50E8A.11			gene	taxon:6239			
+WB	WBGene00013058	clec-247		Y51A2A.1	gene	taxon:6239			
+WB	WBGene00013063	clec-249		Y51A2A.7	gene	taxon:6239			
+WB	WBGene00013066	Y51A2B.2			gene	taxon:6239			
+WB	WBGene00013067	nhr-288		Y51A2B.3	gene	taxon:6239			
+WB	WBGene00013068	Y51A2B.4			gene	taxon:6239			
+WB	WBGene00013072	Y51A2D.1			gene	taxon:6239			
+WB	WBGene00013073	hmit-1.1		Y51A2D.4	gene	taxon:6239			
+WB	WBGene00013074	hmit-1.2		Y51A2D.5	gene	taxon:6239			
+WB	WBGene00013076	Y51A2D.8			gene	taxon:6239			
+WB	WBGene00013077	ttr-24		Y51A2D.9	gene	taxon:6239			
+WB	WBGene00013078	ttr-25		Y51A2D.10	gene	taxon:6239			
+WB	WBGene00013079	ttr-26		Y51A2D.11	gene	taxon:6239			
+WB	WBGene00013080	Y51A2D.13			gene	taxon:6239			
+WB	WBGene00013082	grdn-1		Y51A2D.15	gene	taxon:6239			
+WB	WBGene00013083	Y51A2D.18			gene	taxon:6239			
+WB	WBGene00013088	Y51B9A.6			gene	taxon:6239			
+WB	WBGene00013089	Y51B9A.7			gene	taxon:6239			
+WB	WBGene00013091	Y51B9A.9			gene	taxon:6239			
+WB	WBGene00013093	cup-14		Y51H1A.2	gene	taxon:6239			
+WB	WBGene00013094	Y51H1A.3			gene	taxon:6239			
+WB	WBGene00013095	ing-3		Y51H1A.4	gene	taxon:6239			
+WB	WBGene00013096	mcd-1		Y51H1A.6	gene	taxon:6239			
+WB	WBGene00013100	zip-7		Y51H4A.4	gene	taxon:6239			
+WB	WBGene00013101	Y51H4A.5			gene	taxon:6239			
+WB	WBGene00013103	Y51H4A.7			gene	taxon:6239			
+WB	WBGene00013106	set-26		Y51H4A.12|Y51H4A.m	gene	taxon:6239			
+WB	WBGene00013109	Y51H4A.15			gene	taxon:6239			
+WB	WBGene00013111	sta-1		Y51H4A.17	gene	taxon:6239			
+WB	WBGene00013119	Y51H4A.25			gene	taxon:6239			
+WB	WBGene00013121	spe-38		Y52B11A.1	gene	taxon:6239			
+WB	WBGene00013122	impt-1		Y52B11A.2	gene	taxon:6239			
+WB	WBGene00013123	Y52B11A.3			gene	taxon:6239			
+WB	WBGene00013124	Y52B11A.4			gene	taxon:6239			
+WB	WBGene00013125	clec-92		Y52B11A.5	gene	taxon:6239			
+WB	WBGene00013126	mltn-2		Y52B11A.7	gene	taxon:6239			
+WB	WBGene00013127	Y52B11A.8			gene	taxon:6239			
+WB	WBGene00013128	dxbp-1		Y52B11A.9|dox-1	gene	taxon:6239			
+WB	WBGene00013129	Y52B11A.10			gene	taxon:6239			
+WB	WBGene00013131	pigl-1		Y52B11C.1	gene	taxon:6239			
+WB	WBGene00013132	strd-1		Y52D3.1	gene	taxon:6239			
+WB	WBGene00013135	rga-2		Y53C10A.4	gene	taxon:6239			
+WB	WBGene00013136	tmem-189		Y53C10A.5	gene	taxon:6239			
+WB	WBGene00013139	Y53C12A.3			gene	taxon:6239			
+WB	WBGene00013140	mop-25.2		Y53C12A.4|lss-18	gene	taxon:6239			
+WB	WBGene00013143	Y53C12B.1			gene	taxon:6239			
+WB	WBGene00013144	pno-1		Y53C12B.2	gene	taxon:6239			
+WB	WBGene00013146	Y53C12B.7			gene	taxon:6239			
+WB	WBGene00013147	eyg-1		Y53C12C.1	gene	taxon:6239			
+WB	WBGene00013149	Y53F4B.1			gene	taxon:6239			
+WB	WBGene00013150	pole-4		Y53F4B.3	gene	taxon:6239			
+WB	WBGene00013151	nsun-5		Y53F4B.4	gene	taxon:6239			
+WB	WBGene00013158	Y53F4B.11			gene	taxon:6239			
+WB	WBGene00013159	Y53F4B.12			gene	taxon:6239			
+WB	WBGene00013160	cmtr-1		Y53F4B.13	gene	taxon:6239			
+WB	WBGene00013161	Y53F4B.14			gene	taxon:6239			
+WB	WBGene00013164	Y53F4B.18			gene	taxon:6239			
+WB	WBGene00013165	Y53F4B.19			gene	taxon:6239			
+WB	WBGene00013167	Y53F4B.21			gene	taxon:6239			
+WB	WBGene00013168	arp-1		Y53F4B.22	gene	taxon:6239			
+WB	WBGene00013176	Y53F4B.39			gene	taxon:6239			
+WB	WBGene00013177	rsy-1		Y53H1A.1	gene	taxon:6239			
+WB	WBGene00013179	clec-100		Y53H1A.3	gene	taxon:6239			
+WB	WBGene00013180	cutl-10		Y53H1B.1	gene	taxon:6239			
+WB	WBGene00013184	clpr-4		Y53H1B.6	gene	taxon:6239			
+WB	WBGene00013186	Y53H1C.3			gene	taxon:6239			
+WB	WBGene00013187	npr-34		Y54E2A.1	gene	taxon:6239			
+WB	WBGene00013188	smg-9		Y54E2A.2	gene	taxon:6239			
+WB	WBGene00013189	Y54E2A.4			gene	taxon:6239			
+WB	WBGene00013190	Y54E2A.5			gene	taxon:6239			
+WB	WBGene00013192	Y54E2A.7			gene	taxon:6239			
+WB	WBGene00013193	Y54E2A.8			gene	taxon:6239			
+WB	WBGene00013195	Y54E2A.10			gene	taxon:6239			
+WB	WBGene00013196	tbc-20		Y54E2A.12	gene	taxon:6239			
+WB	WBGene00013197	ttm-5		Y54E5A.1|Y105E8B.o	gene	taxon:6239			
+WB	WBGene00013198	Y54E5A.2			gene	taxon:6239			
+WB	WBGene00013200	Y54E5A.5			gene	taxon:6239			
+WB	WBGene00013201	dus-2		Y54E5A.6	gene	taxon:6239			
+WB	WBGene00013203	Y54E5A.8			gene	taxon:6239			
+WB	WBGene00013204	Y54E5B.2			gene	taxon:6239			
+WB	WBGene00013207	zipt-2.3		Y54G9A.4	gene	taxon:6239			
+WB	WBGene00013208	Y54G9A.5			gene	taxon:6239			
+WB	WBGene00013209	bub-3		Y54G9A.6	gene	taxon:6239			
+WB	WBGene00013211	Y54G9A.9			gene	taxon:6239			
+WB	WBGene00013212	Y54G11A.1			gene	taxon:6239			
+WB	WBGene00013213	Y54G11A.2			gene	taxon:6239			
+WB	WBGene00013214	Y54G11A.3			gene	taxon:6239			
+WB	WBGene00013217	ddl-3		Y54G11A.8	gene	taxon:6239			
+WB	WBGene00013218	Y54G11A.9			gene	taxon:6239			
+WB	WBGene00013219	elof-1		Y54G11A.11	gene	taxon:6239			
+WB	WBGene00013220	ctl-3		Y54G11A.13	gene	taxon:6239			
+WB	WBGene00013221	Y54G11A.14			gene	taxon:6239			
+WB	WBGene00013222	dmsr-6		Y54G11B.1	gene	taxon:6239			
+WB	WBGene00013223	efa-6		Y55D9A.1	gene	taxon:6239			
+WB	WBGene00013224	Y55D9A.2			gene	taxon:6239			
+WB	WBGene00013225	Y56A3A.2		S2P	gene	taxon:6239			
+WB	WBGene00013226	faah-5		Y56A3A.5	gene	taxon:6239			
+WB	WBGene00013228	Y56A3A.7			gene	taxon:6239			
+WB	WBGene00013231	tsen-2		Y56A3A.11	gene	taxon:6239			
+WB	WBGene00013232	faah-4		Y56A3A.12	gene	taxon:6239			
+WB	WBGene00013236	znf-593		Y56A3A.18	gene	taxon:6239			
+WB	WBGene00013237	Y56A3A.19			gene	taxon:6239			
+WB	WBGene00013238	trap-4		Y56A3A.21	gene	taxon:6239			
+WB	WBGene00013239	Y56A3A.22			gene	taxon:6239			
+WB	WBGene00013240	Y56A3A.28			gene	taxon:6239			
+WB	WBGene00013241	ung-1		Y56A3A.29	gene	taxon:6239			
+WB	WBGene00013244	Y56A3A.33			gene	taxon:6239			
+WB	WBGene00013255	tric-1B.1		Y57A10A.10	gene	taxon:6239			
+WB	WBGene00013256	Y57A10A.13			gene	taxon:6239			
+WB	WBGene00013258	polg-1		Y57A10A.15|POLG	gene	taxon:6239			
+WB	WBGene00013259	trpp-5		Y57A10A.16	gene	taxon:6239			
+WB	WBGene00013260	rsr-2		Y57A10A.19	gene	taxon:6239			
+WB	WBGene00013261	sinh-1		Y57A10A.20|CeSRm300	gene	taxon:6239			
+WB	WBGene00013263	txdc-12.1		Y57A10A.23	gene	taxon:6239			
+WB	WBGene00013265	parn-2		Y57A10A.25	gene	taxon:6239			
+WB	WBGene00013268	tric-1B.2		Y57A10A.28	gene	taxon:6239			
+WB	WBGene00013269	Y57A10A.29			gene	taxon:6239			
+WB	WBGene00013270	Y57A10A.31			gene	taxon:6239			
+WB	WBGene00013272	aqp-12		Y57A10A.35	gene	taxon:6239			
+WB	WBGene00013273	marc-5		Y57A10B.1	gene	taxon:6239			
+WB	WBGene00013275	btb-14		Y57A10B.3	gene	taxon:6239			
+WB	WBGene00013276	sre-42		Y57A10B.4	gene	taxon:6239			
+WB	WBGene00013277	sre-41		Y57A10B.5	gene	taxon:6239			
+WB	WBGene00013278	Y57A10B.6			gene	taxon:6239			
+WB	WBGene00013280	Y57A10C.1			gene	taxon:6239			
+WB	WBGene00013281	sre-27		Y57A10C.3	gene	taxon:6239			
+WB	WBGene00013282	sre-26		Y57A10C.4	gene	taxon:6239			
+WB	WBGene00013284	daf-22		Y57A10C.6	gene	taxon:6239			
+WB	WBGene00013286	Y57A10C.8			gene	taxon:6239			
+WB	WBGene00013287	Y57A10C.9			gene	taxon:6239			
+WB	WBGene00013288	Y57A10C.10			gene	taxon:6239			
+WB	WBGene00013289	tag-273		Y57G11A.1	gene	taxon:6239			
+WB	WBGene00013293	Y57G11A.5			gene	taxon:6239			
+WB	WBGene00013299	irld-18		Y57G11B.7	gene	taxon:6239			
+WB	WBGene00013300	lgc-7		Y57G11C.2	gene	taxon:6239			
+WB	WBGene00013301	Y57G11C.3			gene	taxon:6239			
+WB	WBGene00013302	vti-1		Y57G11C.4	gene	taxon:6239			
+WB	WBGene00013303	Y57G11C.5			gene	taxon:6239			
+WB	WBGene00013304	ptp-5.2		Y57G11C.6	gene	taxon:6239			
+WB	WBGene00013307	Y57G11C.9			gene	taxon:6239			
+WB	WBGene00013308	nuo-3		Y57G11C.12	gene	taxon:6239			
+WB	WBGene00013311	sec-61.A		Y57G11C.15|sec-61	gene	taxon:6239			
+WB	WBGene00013312	hhat-2		Y57G11C.17	gene	taxon:6239			
+WB	WBGene00013317	Y57G11C.22		PICK1ce	gene	taxon:6239			
+WB	WBGene00013318	Y57G11C.23			gene	taxon:6239			
+WB	WBGene00013319	ccch-5		Y57G11C.25	gene	taxon:6239			
+WB	WBGene00013321	Y57G11C.31			gene	taxon:6239			
+WB	WBGene00013323	Y57G11C.33			gene	taxon:6239			
+WB	WBGene00013324	mrps-7		Y57G11C.34	gene	taxon:6239			
+WB	WBGene00013325	Y57G11C.36			gene	taxon:6239			
+WB	WBGene00013326	anoh-2		Y57G11C.37	gene	taxon:6239			
+WB	WBGene00013332	Y57G11C.43			gene	taxon:6239			
+WB	WBGene00013333	Y57G11C.44			gene	taxon:6239			
+WB	WBGene00013334	nlp-56		Y57G11C.45	gene	taxon:6239			
+WB	WBGene00013335	Y57G11C.46			gene	taxon:6239			
+WB	WBGene00013336	pnc-2		Y57G11C.47	gene	taxon:6239			
+WB	WBGene00013338	lgc-8		Y57G11C.49	gene	taxon:6239			
+WB	WBGene00013339	phf-14		Y59A8A.2	gene	taxon:6239			
+WB	WBGene00013340	tcc-1		Y59A8A.3	gene	taxon:6239			
+WB	WBGene00013343	prp-6		Y59A8B.6|Y59A8B.o|Y59A8C.a	gene	taxon:6239			
+WB	WBGene00013344	ebp-1		Y59A8B.7|Y59A8B.p|Y59A8B.r	gene	taxon:6239			
+WB	WBGene00013345	Y59A8B.8			gene	taxon:6239			
+WB	WBGene00013347	nova-1		Y59A8B.10	gene	taxon:6239			
+WB	WBGene00013352	lon-8		Y59A8B.20|Y59A8B.j	gene	taxon:6239			
+WB	WBGene00013353	Y59A8B.21		Y59A8B.i	gene	taxon:6239			
+WB	WBGene00013354	snx-6		Y59A8B.22|Y59A8B.g	gene	taxon:6239			
+WB	WBGene00013355	gck-3		Y59A8B.23|Y59A8B.e|Y59A8B.f	gene	taxon:6239			
+WB	WBGene00013357	clec-260		Y60A3A.2	gene	taxon:6239			
+WB	WBGene00013358	abhd-3.1		Y60A3A.7	gene	taxon:6239			
+WB	WBGene00013360	tmed-4		Y60A3A.9	gene	taxon:6239			
+WB	WBGene00013361	fars-2		Y60A3A.13|frs-3	gene	taxon:6239			
+WB	WBGene00013362	algn-7		Y60A3A.14	gene	taxon:6239			
+WB	WBGene00013364	Y60A3A.16			gene	taxon:6239			
+WB	WBGene00013365	Y60A3A.19			gene	taxon:6239			
+WB	WBGene00013367	Y60A3A.23			gene	taxon:6239			
+WB	WBGene00013370	Y60A9.3			gene	taxon:6239			
+WB	WBGene00013373	popl-7		Y62E10A.2	gene	taxon:6239			
+WB	WBGene00013375	srsx-25		Y62E10A.4	gene	taxon:6239			
+WB	WBGene00013376	Y62E10A.6		Y62E10A.f	gene	taxon:6239			
+WB	WBGene00013378	emc-3		Y62E10A.10	gene	taxon:6239			
+WB	WBGene00013379	Y62E10A.13			gene	taxon:6239			
+WB	WBGene00013381	cyp-31A5		Y62E10A.15	gene	taxon:6239			
+WB	WBGene00013382	gcl-1		Y62E10A.16	gene	taxon:6239			
+WB	WBGene00013383	aptf-2		Y62E10A.17|mal-1	gene	taxon:6239			
+WB	WBGene00013388	Y62F5A.10			gene	taxon:6239			
+WB	WBGene00013389	Y62H9A.1			gene	taxon:6239			
+WB	WBGene00013398	Y62H9A.10			gene	taxon:6239			
+WB	WBGene00013400	Y62H9A.12			gene	taxon:6239			
+WB	WBGene00013405	tdpt-1		Y63D3A.4|TDP2	gene	taxon:6239			
+WB	WBGene00013406	Y63D3A.7			gene	taxon:6239			
+WB	WBGene00013407	fld-1		Y63D3A.8	gene	taxon:6239			
+WB	WBGene00013415	ilcr-1		Y64G10A.6	gene	taxon:6239			
+WB	WBGene00013416	Y64G10A.7			gene	taxon:6239			
+WB	WBGene00013417	srab-24		Y64G10A.8	gene	taxon:6239			
+WB	WBGene00013419	Y65A5A.2			gene	taxon:6239			
+WB	WBGene00013422	popl-5		Y66A7A.2	gene	taxon:6239			
+WB	WBGene00013425	ceh-91		Y66A7A.5	gene	taxon:6239			
+WB	WBGene00013426	Y66A7A.7			gene	taxon:6239			
+WB	WBGene00013431	ceh-92		Y66D12A.5	gene	taxon:6239			
+WB	WBGene00013433	Y66D12A.7			gene	taxon:6239			
+WB	WBGene00013435	Y66D12A.9			gene	taxon:6239			
+WB	WBGene00013437	Y66D12A.11			gene	taxon:6239			
+WB	WBGene00013439	Y66D12A.13			gene	taxon:6239			
+WB	WBGene00013440	nrps-1		Y66D12A.14	gene	taxon:6239			
+WB	WBGene00013441	xpb-1		Y66D12A.15	gene	taxon:6239			
+WB	WBGene00013443	such-1		Y66D12A.17|som-2	gene	taxon:6239			
+WB	WBGene00013446	Y66D12A.21			gene	taxon:6239			
+WB	WBGene00013447	nars-2		Y66D12A.23|nrs-2	gene	taxon:6239			
+WB	WBGene00013448	Y66D12A.24			gene	taxon:6239			
+WB	WBGene00013450	oac-56		Y67A10A.1	gene	taxon:6239			
+WB	WBGene00013452	Y67A10A.3			gene	taxon:6239			
+WB	WBGene00013457	paqr-3		Y67A10A.8	gene	taxon:6239			
+WB	WBGene00013458	clc-8		Y67A10A.9	gene	taxon:6239			
+WB	WBGene00013460	cpsf-3		Y67H2A.1	gene	taxon:6239			
+WB	WBGene00013462	micu-1		Y67H2A.4	gene	taxon:6239			
+WB	WBGene00013463	kdp-1		Y67H2A.5	gene	taxon:6239			
+WB	WBGene00013464	Y67H2A.7			gene	taxon:6239			
+WB	WBGene00013466	srz-47		Y68A4A.2	gene	taxon:6239			
+WB	WBGene00013468	srz-96		Y68A4A.6	gene	taxon:6239			
+WB	WBGene00013470	clec-243		Y68A4B.1	gene	taxon:6239			
+WB	WBGene00013471	clec-242		Y68A4B.2	gene	taxon:6239			
+WB	WBGene00013473	Y69E1A.1			gene	taxon:6239			
+WB	WBGene00013475	Y69E1A.3			gene	taxon:6239			
+WB	WBGene00013476	Y69E1A.4			gene	taxon:6239			
+WB	WBGene00013479	Y69H2.1			gene	taxon:6239			
+WB	WBGene00013480	egas-3		Y69H2.2	gene	taxon:6239			
+WB	WBGene00013481	Y69H2.3			gene	taxon:6239			
+WB	WBGene00013483	nhr-241		Y69H2.8	gene	taxon:6239			
+WB	WBGene00013484	Y69H2.9			gene	taxon:6239			
+WB	WBGene00013485	Y69H2.10			gene	taxon:6239			
+WB	WBGene00013486	egas-1		Y69H2.11	gene	taxon:6239			
+WB	WBGene00013487	egas-2		Y69H2.12|tag-336	gene	taxon:6239			
+WB	WBGene00013489	col-42		Y69H2.14	gene	taxon:6239			
+WB	WBGene00013490	Y70C5A.2			gene	taxon:6239			
+WB	WBGene00013492	Y70C5C.1			gene	taxon:6239			
+WB	WBGene00013493	clec-9		Y70C5C.2	gene	taxon:6239			
+WB	WBGene00013496	Y70D2A.1			gene	taxon:6239			
+WB	WBGene00013497	hex-5		Y70D2A.2	gene	taxon:6239			
+WB	WBGene00013498	Y70G10A.2			gene	taxon:6239			
+WB	WBGene00013499	Y70G10A.3			gene	taxon:6239			
+WB	WBGene00013502	clec-111		Y71A12B.5|Y71A12B.f	gene	taxon:6239			
+WB	WBGene00013506	usp-3		Y71A12B.9|Y71A12B.j	gene	taxon:6239			
+WB	WBGene00013507	Y71A12B.10		Y71A12B.m	gene	taxon:6239			
+WB	WBGene00013508	Y71A12B.11		Y71A12B.r	gene	taxon:6239			
+WB	WBGene00013512	nhr-276		Y71A12C.1	gene	taxon:6239			
+WB	WBGene00013513	Y71A12C.2			gene	taxon:6239			
+WB	WBGene00013514	Y73F4A.1			gene	taxon:6239			
+WB	WBGene00013515	Y73F4A.2			gene	taxon:6239			
+WB	WBGene00013517	lgc-52		Y73F8A.2	gene	taxon:6239			
+WB	WBGene00013518	Y73F8A.5			gene	taxon:6239			
+WB	WBGene00013520	best-21		Y73F8A.11	gene	taxon:6239			
+WB	WBGene00013529	gft-2H4		Y73F8A.24	gene	taxon:6239			
+WB	WBGene00013530	ntl-11		Y73F8A.25	gene	taxon:6239			
+WB	WBGene00013532	Y73F8A.27			gene	taxon:6239			
+WB	WBGene00013534	acr-24		Y73F8A.30	gene	taxon:6239			
+WB	WBGene00013538	ari-1.4		Y73F8A.34|tag-349	gene	taxon:6239			
+WB	WBGene00013539	Y73F8A.35			gene	taxon:6239			
+WB	WBGene00013541	lonp-2		Y75B8A.4	gene	taxon:6239			
+WB	WBGene00013542	lron-12		Y75B8A.5	gene	taxon:6239			
+WB	WBGene00013543	Y75B8A.6			gene	taxon:6239			
+WB	WBGene00013544	Y75B8A.7			gene	taxon:6239			
+WB	WBGene00013547	Y75B8A.10			gene	taxon:6239			
+WB	WBGene00013548	lury-1		Y75B8A.11|nlp-72	gene	taxon:6239			
+WB	WBGene00013550	Y75B8A.14			gene	taxon:6239			
+WB	WBGene00013551	Y75B8A.16			gene	taxon:6239			
+WB	WBGene00013552	gmn-1		Y75B8A.17	gene	taxon:6239			
+WB	WBGene00013557	Y75B8A.24			gene	taxon:6239			
+WB	WBGene00013563	Y75B8A.33			gene	taxon:6239			
+WB	WBGene00013564	Y75B8A.34			gene	taxon:6239			
+WB	WBGene00013566	Y75B12A.2			gene	taxon:6239			
+WB	WBGene00013572	Y75B12B.10			gene	taxon:6239			
+WB	WBGene00013575	acs-5		Y76A2B.3	gene	taxon:6239			
+WB	WBGene00013576	Y76A2B.4			gene	taxon:6239			
+WB	WBGene00013577	Y76A2B.5			gene	taxon:6239			
+WB	WBGene00013578	scav-2		Y76A2B.6	gene	taxon:6239			
+WB	WBGene00013579	Y79H2A.2			gene	taxon:6239			
+WB	WBGene00013581	Y79H2A.4			gene	taxon:6239			
+WB	WBGene00013583	ceh-51		Y80D3A.3|dlx-1	gene	taxon:6239			
+WB	WBGene00013584	nhr-243		Y80D3A.4	gene	taxon:6239			
+WB	WBGene00013585	cyp-42A1		Y80D3A.5	gene	taxon:6239			
+WB	WBGene00013586	Y80D3A.8			gene	taxon:6239			
+WB	WBGene00013588	nlp-42		Y80D3A.10	gene	taxon:6239			
+WB	WBGene00013591	gcn-2		Y81G3A.3|GCN2	gene	taxon:6239			
+WB	WBGene00013594	Y87G2A.2			gene	taxon:6239			
+WB	WBGene00013595	atg-4.1		Y87G2A.3	gene	taxon:6239			
+WB	WBGene00013596	nyn-2		Y87G2A.7	gene	taxon:6239			
+WB	WBGene00013597	gpi-1		Y87G2A.8	gene	taxon:6239			
+WB	WBGene00013598	vps-28		Y87G2A.10	gene	taxon:6239			
+WB	WBGene00013599	eipr-1		Y87G2A.11	gene	taxon:6239			
+WB	WBGene00013601	Y87G2A.13			gene	taxon:6239			
+WB	WBGene00013602	Y87G2A.16			gene	taxon:6239			
+WB	WBGene00013604	Y87G2A.18			gene	taxon:6239			
+WB	WBGene00013605	Y95D11A.1			gene	taxon:6239			
+WB	WBGene00013606	cand-1		Y102A5A.1	gene	taxon:6239			
+WB	WBGene00013607	clec-27		Y102A5B.1	gene	taxon:6239			
+WB	WBGene00013608	clec-35		Y102A5B.2	gene	taxon:6239			
+WB	WBGene00013609	clec-37		Y102A5B.3	gene	taxon:6239			
+WB	WBGene00013621	clec-239		Y102A5C.16	gene	taxon:6239			
+WB	WBGene00013622	clec-238		Y102A5C.17	gene	taxon:6239			
+WB	WBGene00013626	srz-54		Y102A5C.25	gene	taxon:6239			
+WB	WBGene00013629	srz-95		Y102A5C.33	gene	taxon:6239			
+WB	WBGene00013632	Y105C5A.1			gene	taxon:6239			
+WB	WBGene00013639	Y105C5A.15			gene	taxon:6239			
+WB	WBGene00013642	daf-38		Y105C5A.23|gnrr-8	gene	taxon:6239			
+WB	WBGene00013643	Y105C5A.24			gene	taxon:6239			
+WB	WBGene00013645	Y105C5B.1			gene	taxon:6239			
+WB	WBGene00013646	Y105C5B.3			gene	taxon:6239			
+WB	WBGene00013649	Y105C5B.8			gene	taxon:6239			
+WB	WBGene00013650	Y105C5B.9			gene	taxon:6239			
+WB	WBGene00013651	Y105C5B.11			gene	taxon:6239			
+WB	WBGene00013654	Y105C5B.15			gene	taxon:6239			
+WB	WBGene00013655	lgc-19		Y105C5B.16	gene	taxon:6239			
+WB	WBGene00013656	Y105C5B.17			gene	taxon:6239			
+WB	WBGene00013658	Y105C5B.19			gene	taxon:6239			
+WB	WBGene00013662	Y105C5B.25			gene	taxon:6239			
+WB	WBGene00013665	hlh-32		Y105C5B.29	gene	taxon:6239			
+WB	WBGene00013667	Y105E8A.2		Y105E8A.c	gene	taxon:6239			
+WB	WBGene00013668	slc-30A5		Y105E8A.3|Y105E8A.d	gene	taxon:6239			
+WB	WBGene00013670	hpo-13		Y105E8A.10|Y105E8E.l	gene	taxon:6239			
+WB	WBGene00013672	catp-1		Y105E8A.12|Y105E8E.n|Y105E8E.p	gene	taxon:6239			
+WB	WBGene00013674	Y105E8A.14		Y105E8E.r	gene	taxon:6239			
+WB	WBGene00013676	ekl-4		Y105E8A.17|Y105E8E.t	gene	taxon:6239			
+WB	WBGene00013677	yars-1		Y105E8A.19|Y105E8E.u|Y105E8E.v	gene	taxon:6239			
+WB	WBGene00013678	Y105E8A.20		Y105E8E.w	gene	taxon:6239			
+WB	WBGene00013680	rpom-1		Y105E8A.23|Y105E8C.c	gene	taxon:6239			
+WB	WBGene00013682	Y105E8A.25		Y105E8C.d|Y105E8C.e|Y105E8C.f	gene	taxon:6239			
+WB	WBGene00013683	zoo-1		Y105E8A.26|tag-301|Y105E8C.b	gene	taxon:6239			
+WB	WBGene00013684	Y105E8A.27		Y105E8E.o	gene	taxon:6239			
+WB	WBGene00013687	exoc-8		Y105E8B.2|Y105E8B.d|Y105E8B.e	gene	taxon:6239			
+WB	WBGene00013688	riok-2		Y105E8B.3|Y105E8B.h|Y105E8B.i	gene	taxon:6239			
+WB	WBGene00013689	bath-40		Y105E8B.4|Y105E8B.g	gene	taxon:6239			
+WB	WBGene00013690	hprt-1		Y105E8B.5|Y105E8B.j	gene	taxon:6239			
+WB	WBGene00013692	Y105E8B.7		Y105E8B.f	gene	taxon:6239			
+WB	WBGene00013693	Y105E8B.9		Y105E8B.n	gene	taxon:6239			
+WB	WBGene00013694	mekk-3		Y106G6A.1	gene	taxon:6239			
+WB	WBGene00013695	epg-8		Y106G6A.2	gene	taxon:6239			
+WB	WBGene00013697	dsbn-1		Y106G6A.5	gene	taxon:6239			
+WB	WBGene00013701	Y106G6D.4			gene	taxon:6239			
+WB	WBGene00013703	rbm-12		Y106G6D.7	gene	taxon:6239			
+WB	WBGene00013704	Y106G6D.8			gene	taxon:6239			
+WB	WBGene00013705	Y106G6E.1			gene	taxon:6239			
+WB	WBGene00013708	Y106G6E.4			gene	taxon:6239			
+WB	WBGene00013709	csnk-1		Y106G6E.6	gene	taxon:6239			
+WB	WBGene00013711	Y106G6G.2			gene	taxon:6239			
+WB	WBGene00013712	dlc-6		Y106G6G.3	gene	taxon:6239			
+WB	WBGene00013713	Y106G6G.4			gene	taxon:6239			
+WB	WBGene00013718	pdpr-1		Y106G6H.5	gene	taxon:6239			
+WB	WBGene00013720	Y106G6H.8			gene	taxon:6239			
+WB	WBGene00013725	ska-1		Y106G6H.15	gene	taxon:6239			
+WB	WBGene00013726	Y106G6H.16			gene	taxon:6239			
+WB	WBGene00013727	Y111B2A.1		Y111B2A.a	gene	taxon:6239			
+WB	WBGene00013728	Y111B2A.2			gene	taxon:6239			
+WB	WBGene00013730	sql-1		Y111B2A.4|Y111B2A.d|Y111B2A.f	gene	taxon:6239			
+WB	WBGene00013732	aakg-1		Y111B2A.8|Y111B2A.j|Y111B2A.k|Y111B2A.l	gene	taxon:6239			
+WB	WBGene00013736	gtf-2A2		Y111B2A.13	gene	taxon:6239			
+WB	WBGene00013737	tpst-1		Y111B2A.15|TPST-A	gene	taxon:6239			
+WB	WBGene00013738	elpc-2		Y111B2A.17|Y111B2G.h	gene	taxon:6239			
+WB	WBGene00013739	spin-4		Y111B2A.19|Y111B2G.j	gene	taxon:6239			
+WB	WBGene00013740	hut-1		Y111B2A.20|Y111B2E.b	gene	taxon:6239			
+WB	WBGene00013742	sas-1		Y111B2A.24|Y111B2E.a	gene	taxon:6239			
+WB	WBGene00013746	lgc-55		Y113G7A.5	gene	taxon:6239			
+WB	WBGene00013747	spe-19		Y113G7A.10	gene	taxon:6239			
+WB	WBGene00013748	ssu-1		Y113G7A.11|ceST1	gene	taxon:6239			
+WB	WBGene00013751	Y113G7A.14			gene	taxon:6239			
+WB	WBGene00013752	nlp-69		Y113G7A.15	gene	taxon:6239			
+WB	WBGene00013754	fbxa-116		Y113G7B.1	gene	taxon:6239			
+WB	WBGene00013760	srbc-34		Y113G7B.9	gene	taxon:6239			
+WB	WBGene00013761	Y113G7B.11			gene	taxon:6239			
+WB	WBGene00013762	Y113G7B.12			gene	taxon:6239			
+WB	WBGene00013764	Y113G7B.15			gene	taxon:6239			
+WB	WBGene00013765	cdkr-3		Y113G7B.16	gene	taxon:6239			
+WB	WBGene00013766	prmt-1		Y113G7B.17|epg-11	gene	taxon:6239			
+WB	WBGene00013768	sld-5		Y113G7B.24	gene	taxon:6239			
+WB	WBGene00013771	Y113G7C.1			gene	taxon:6239			
+WB	WBGene00013773	Y116A8A.2			gene	taxon:6239			
+WB	WBGene00013774	clec-193		Y116A8A.3	gene	taxon:6239			
+WB	WBGene00013777	Y116A8A.7			gene	taxon:6239			
+WB	WBGene00013778	clec-194		Y116A8A.8	gene	taxon:6239			
+WB	WBGene00013782	npr-32		Y116A8B.5	gene	taxon:6239			
+WB	WBGene00013785	nep-23		Y116A8C.4	gene	taxon:6239			
+WB	WBGene00013786	nep-24		Y116A8C.5	gene	taxon:6239			
+WB	WBGene00013789	Y116A8C.9			gene	taxon:6239			
+WB	WBGene00013792	rad-54.B		Y116A8C.13	gene	taxon:6239			
+WB	WBGene00013794	dct-13		Y116A8C.17	gene	taxon:6239			
+WB	WBGene00013795	nhr-229		Y116A8C.18	gene	taxon:6239			
+WB	WBGene00013796	Y116A8C.19			gene	taxon:6239			
+WB	WBGene00013797	Y116A8C.20			gene	taxon:6239			
+WB	WBGene00013798	clec-195		Y116A8C.21	gene	taxon:6239			
+WB	WBGene00013799	athp-3		Y116A8C.22	gene	taxon:6239			
+WB	WBGene00013800	Y116A8C.23			gene	taxon:6239			
+WB	WBGene00013801	Y116A8C.24			gene	taxon:6239			
+WB	WBGene00013802	Y116A8C.25			gene	taxon:6239			
+WB	WBGene00013803	snx-13		Y116A8C.26	gene	taxon:6239			
+WB	WBGene00013804	Y116A8C.27			gene	taxon:6239			
+WB	WBGene00013805	bca-2		Y116A8C.28	gene	taxon:6239			
+WB	WBGene00013806	Y116A8C.29			gene	taxon:6239			
+WB	WBGene00013807	Y116A8C.30			gene	taxon:6239			
+WB	WBGene00013808	sfa-1		Y116A8C.32|sf1	gene	taxon:6239			
+WB	WBGene00013810	Y116A8C.37			gene	taxon:6239			
+WB	WBGene00013811	Y116A8C.38			gene	taxon:6239			
+WB	WBGene00013812	Y116A8C.40			gene	taxon:6239			
+WB	WBGene00013816	Y116F11A.1			gene	taxon:6239			
+WB	WBGene00013825	Y116F11B.9		Y116F11B.j	gene	taxon:6239			
+WB	WBGene00013833	ZC15.5			gene	taxon:6239			
+WB	WBGene00013834	clec-261		ZC15.6	gene	taxon:6239			
+WB	WBGene00013835	mlt-4		ZC15.7	gene	taxon:6239			
+WB	WBGene00013837	fbxa-30		ZC47.4	gene	taxon:6239			
+WB	WBGene00013840	fbxa-151		ZC47.7	gene	taxon:6239			
+WB	WBGene00013846	ZC84.1			gene	taxon:6239			
+WB	WBGene00013847	cls-3		ZC84.3	gene	taxon:6239			
+WB	WBGene00013848	npr-29		ZC84.4	gene	taxon:6239			
+WB	WBGene00013849	ZC84.6			gene	taxon:6239			
+WB	WBGene00013850	ZC84.7			gene	taxon:6239			
+WB	WBGene00013852	hhat-1		ZC101.3	gene	taxon:6239			
+WB	WBGene00013854	cyc-2.2		ZC116.2	gene	taxon:6239			
+WB	WBGene00013855	cubn-1		ZC116.3	gene	taxon:6239			
+WB	WBGene00013856	ZC168.2			gene	taxon:6239			
+WB	WBGene00013857	orc-5		ZC168.3	gene	taxon:6239			
+WB	WBGene00013862	wdr-5.3		ZC302.2|swd-3.3	gene	taxon:6239			
+WB	WBGene00013865	ZC334.7			gene	taxon:6239			
+WB	WBGene00013866	cbs-1		ZC373.1	gene	taxon:6239			
+WB	WBGene00013868	ZC373.3			gene	taxon:6239			
+WB	WBGene00013869	mlck-1		ZC373.4	gene	taxon:6239			
+WB	WBGene00013870	ZC373.5			gene	taxon:6239			
+WB	WBGene00013871	gnrr-3		ZC374.1	gene	taxon:6239			
+WB	WBGene00013873	cest-2.3		ZC376.1	gene	taxon:6239			
+WB	WBGene00013874	cest-2.2		ZC376.2	gene	taxon:6239			
+WB	WBGene00013875	cest-2.1		ZC376.3	gene	taxon:6239			
+WB	WBGene00013876	ceh-74		ZC376.4	gene	taxon:6239			
+WB	WBGene00013877	ints-2		ZC376.6	gene	taxon:6239			
+WB	WBGene00013878	atfs-1		ZC376.7	gene	taxon:6239			
+WB	WBGene00013879	ZC376.8			gene	taxon:6239			
+WB	WBGene00013880	mppb-1		ZC410.2	gene	taxon:6239			
+WB	WBGene00013881	mans-4		ZC410.3	gene	taxon:6239			
+WB	WBGene00013882	msa-1		ZC410.5	gene	taxon:6239			
+WB	WBGene00013883	npr-13		ZC412.1	gene	taxon:6239			
+WB	WBGene00013884	ZC412.3			gene	taxon:6239			
+WB	WBGene00013893	coa-6		ZC434.7	gene	taxon:6239			
+WB	WBGene00013894	ZC434.8			gene	taxon:6239			
+WB	WBGene00013895	ZC434.9			gene	taxon:6239			
+WB	WBGene00013896	ZC443.1			gene	taxon:6239			
+WB	WBGene00013898	ZC443.3			gene	taxon:6239			
+WB	WBGene00013899	ZC443.4			gene	taxon:6239			
+WB	WBGene00013900	ugt-18		ZC443.5	gene	taxon:6239			
+WB	WBGene00013901	ugt-16		ZC443.6	gene	taxon:6239			
+WB	WBGene00013903	ugt-3		ZC455.3	gene	taxon:6239			
+WB	WBGene00013904	ugt-6		ZC455.4	gene	taxon:6239			
+WB	WBGene00013905	ugt-4		ZC455.5	gene	taxon:6239			
+WB	WBGene00013906	ugt-5		ZC455.6	gene	taxon:6239			
+WB	WBGene00013907	sre-20		ZC455.7	gene	taxon:6239			
+WB	WBGene00013908	srbc-43		ZC455.8	gene	taxon:6239			
+WB	WBGene00013909	srbc-44		ZC455.9	gene	taxon:6239			
+WB	WBGene00013910	srbc-45		ZC455.11	gene	taxon:6239			
+WB	WBGene00013912	irld-19		ZC482.3	gene	taxon:6239			
+WB	WBGene00013914	lgc-37		ZC482.5	gene	taxon:6239			
+WB	WBGene00013915	irld-20		ZC482.7	gene	taxon:6239			
+WB	WBGene00013916	ZC504.1			gene	taxon:6239			
+WB	WBGene00013917	cdk-11.2		ZC504.3	gene	taxon:6239			
+WB	WBGene00013919	ZC506.1			gene	taxon:6239			
+WB	WBGene00013920	pssy-1		ZC506.3	gene	taxon:6239			
+WB	WBGene00013921	best-22		ZC518.1	gene	taxon:6239			
+WB	WBGene00013923	ghi-1		ZK20.1	gene	taxon:6239			
+WB	WBGene00013924	rad-23		ZK20.3	gene	taxon:6239			
+WB	WBGene00013926	nep-1		ZK20.6	gene	taxon:6239			
+WB	WBGene00013927	clec-95		ZK39.2	gene	taxon:6239			
+WB	WBGene00013928	clec-94		ZK39.3	gene	taxon:6239			
+WB	WBGene00013929	clec-93		ZK39.4	gene	taxon:6239			
+WB	WBGene00013930	clec-96		ZK39.5	gene	taxon:6239			
+WB	WBGene00013931	clec-97		ZK39.6	gene	taxon:6239			
+WB	WBGene00013932	clec-98		ZK39.7	gene	taxon:6239			
+WB	WBGene00013933	clec-99		ZK39.8	gene	taxon:6239			
+WB	WBGene00013938	ZK218.4			gene	taxon:6239			
+WB	WBGene00013940	nhr-248		ZK218.6	gene	taxon:6239			
+WB	WBGene00013947	ZK228.4			gene	taxon:6239			
+WB	WBGene00013949	ZK262.2			gene	taxon:6239			
+WB	WBGene00013950	txt-8		ZK262.3	gene	taxon:6239			
+WB	WBGene00013955	kri-1		ZK265.1	gene	taxon:6239			
+WB	WBGene00013957	sre-23		ZK265.5	gene	taxon:6239			
+WB	WBGene00013958	nol-16		ZK265.6|NOP16	gene	taxon:6239			
+WB	WBGene00013960	cutl-8		ZK265.8	gene	taxon:6239			
+WB	WBGene00013961	ZK285.2			gene	taxon:6239			
+WB	WBGene00013962	ZK287.1			gene	taxon:6239			
+WB	WBGene00013963	sulp-8		ZK287.2	gene	taxon:6239			
+WB	WBGene00013964	nlp-73		ZK287.3	gene	taxon:6239			
+WB	WBGene00013965	ZK287.4			gene	taxon:6239			
+WB	WBGene00013967	ZK287.7			gene	taxon:6239			
+WB	WBGene00013968	ZK287.9			gene	taxon:6239			
+WB	WBGene00013969	tep-1		ZK337.1	gene	taxon:6239			
+WB	WBGene00013973	asp-18		ZK384.3	gene	taxon:6239			
+WB	WBGene00013974	npr-9		ZK455.3	gene	taxon:6239			
+WB	WBGene00013975	ZK455.5			gene	taxon:6239			
+WB	WBGene00013976	hizr-1		ZK455.6|nhr-33	gene	taxon:6239			
+WB	WBGene00013978	ZK507.1			gene	taxon:6239			
+WB	WBGene00013982	ZK512.1			gene	taxon:6239			
+WB	WBGene00013983	ZK512.2			gene	taxon:6239			
+WB	WBGene00013984	ZK512.4			gene	taxon:6239			
+WB	WBGene00013985	sec-16A.1		ZK512.5|sec-16	gene	taxon:6239			
+WB	WBGene00013989	ZK512.11			gene	taxon:6239			
+WB	WBGene00013994	ZK524.4			gene	taxon:6239			
+WB	WBGene00013996	ZK550.2			gene	taxon:6239			
+WB	WBGene00013997	ZK550.3			gene	taxon:6239			
+WB	WBGene00013998	gtf-2E1		ZK550.4|TFIIE-alpha	gene	taxon:6239			
+WB	WBGene00014000	ZK550.6		yk151d7.3	gene	taxon:6239			
+WB	WBGene00014001	pyk-2		ZK593.1	gene	taxon:6239			
+WB	WBGene00014003	ZK593.3			gene	taxon:6239			
+WB	WBGene00014004	fic-1		ZK593.8	gene	taxon:6239			
+WB	WBGene00014007	ZK596.2			gene	taxon:6239			
+WB	WBGene00014008	ZK596.3			gene	taxon:6239			
+WB	WBGene00014009	lips-6		ZK617.2	gene	taxon:6239			
+WB	WBGene00014012	riok-3		ZK632.3	gene	taxon:6239			
+WB	WBGene00014013	ZK632.4			gene	taxon:6239			
+WB	WBGene00014014	gtap-2		ZK632.5	gene	taxon:6239			
+WB	WBGene00014015	panl-3		ZK632.7	gene	taxon:6239			
+WB	WBGene00014017	ZK632.10			gene	taxon:6239			
+WB	WBGene00014019	ZK632.12			gene	taxon:6239			
+WB	WBGene00014020	ZK632.14			gene	taxon:6239			
+WB	WBGene00014021	svop-1		ZK637.1|globin|ORF1	gene	taxon:6239			
+WB	WBGene00014022	ZK637.2			gene	taxon:6239			
+WB	WBGene00014023	lnkn-1		ZK637.3|tag-256	gene	taxon:6239			
+WB	WBGene00014025	asna-1		ZK637.5|tag-205	gene	taxon:6239			
+WB	WBGene00014027	tpk-1		ZK637.9|clk-8	gene	taxon:6239			
+WB	WBGene00014028	trxr-2		ZK637.10	gene	taxon:6239			
+WB	WBGene00014030	glb-1		ZK637.13	gene	taxon:6239			
+WB	WBGene00014031	ZK637.14			gene	taxon:6239			
+WB	WBGene00014033	arrd-15		ZK643.1	gene	taxon:6239			
+WB	WBGene00014034	ZK643.2			gene	taxon:6239			
+WB	WBGene00014035	seb-2		ZK643.3|secr-1	gene	taxon:6239			
+WB	WBGene00014040	ZK662.5			gene	taxon:6239			
+WB	WBGene00014043	clec-58		ZK666.3	gene	taxon:6239			
+WB	WBGene00014045	clec-59		ZK666.5	gene	taxon:6239			
+WB	WBGene00014046	clec-60		ZK666.6	gene	taxon:6239			
+WB	WBGene00014047	clec-61		ZK666.7	gene	taxon:6239			
+WB	WBGene00014048	ZK666.8			gene	taxon:6239			
+WB	WBGene00014050	ZK666.12			gene	taxon:6239			
+WB	WBGene00014051	spv-1		ZK669.1|rga-7|tag-341	gene	taxon:6239			
+WB	WBGene00014052	ZK669.2			gene	taxon:6239			
+WB	WBGene00014053	ZK669.3			gene	taxon:6239			
+WB	WBGene00014054	dbt-1		ZK669.4	gene	taxon:6239			
+WB	WBGene00014055	ZK669.5			gene	taxon:6239			
+WB	WBGene00014057	ZK673.1			gene	taxon:6239			
+WB	WBGene00014058	ZK673.2			gene	taxon:6239			
+WB	WBGene00014060	ZK673.4			gene	taxon:6239			
+WB	WBGene00014063	clec-143		ZK673.9	gene	taxon:6239			
+WB	WBGene00014065	ZK673.11			gene	taxon:6239			
+WB	WBGene00014066	rev-1		ZK675.2	gene	taxon:6239			
+WB	WBGene00014068	nhr-255		ZK678.2	gene	taxon:6239			
+WB	WBGene00014070	srxa-9		ZK678.4	gene	taxon:6239			
+WB	WBGene00014073	ZK757.1			gene	taxon:6239			
+WB	WBGene00014074	ZK757.2			gene	taxon:6239			
+WB	WBGene00014075	dhhc-4		ZK757.4	gene	taxon:6239			
+WB	WBGene00014076	ZK792.1			gene	taxon:6239			
+WB	WBGene00014078	ZK792.5			gene	taxon:6239			
+WB	WBGene00014079	ZK792.7			gene	taxon:6239			
+WB	WBGene00014080	atg-4.2		ZK792.8	gene	taxon:6239			
+WB	WBGene00014081	ipmk-1		ZK795.1	gene	taxon:6239			
+WB	WBGene00014082	ZK795.2			gene	taxon:6239			
+WB	WBGene00014083	ZK795.3			gene	taxon:6239			
+WB	WBGene00014084	snb-7		ZK795.4	gene	taxon:6239			
+WB	WBGene00014085	ZK809.1			gene	taxon:6239			
+WB	WBGene00014086	ZK809.3			gene	taxon:6239			
+WB	WBGene00014088	ZK809.8			gene	taxon:6239			
+WB	WBGene00014092	ZK822.5			gene	taxon:6239			
+WB	WBGene00014093	ZK829.1			gene	taxon:6239			
+WB	WBGene00014094	ZK829.3			gene	taxon:6239			
+WB	WBGene00014095	gdh-1		ZK829.4	gene	taxon:6239			
+WB	WBGene00014096	ZK829.7			gene	taxon:6239			
+WB	WBGene00014097	ZK829.9			gene	taxon:6239			
+WB	WBGene00014098	ogdh-2		ZK836.2	gene	taxon:6239			
+WB	WBGene00014099	ZK836.3			gene	taxon:6239			
+WB	WBGene00014100	ZK849.1			gene	taxon:6239			
+WB	WBGene00014101	gopc-1		ZK849.2	gene	taxon:6239			
+WB	WBGene00014102	best-25		ZK849.4	gene	taxon:6239			
+WB	WBGene00014103	best-26		ZK849.5	gene	taxon:6239			
+WB	WBGene00014104	ZK849.6			gene	taxon:6239			
+WB	WBGene00014106	ZK856.5			gene	taxon:6239			
+WB	WBGene00014109	chpf-1		ZK856.8	gene	taxon:6239			
+WB	WBGene00014111	rpc-25		ZK856.10	gene	taxon:6239			
+WB	WBGene00014112	ZK856.11			gene	taxon:6239			
+WB	WBGene00014113	hpo-40		ZK856.12	gene	taxon:6239			
+WB	WBGene00014114	tftc-3		ZK856.13|tag-315	gene	taxon:6239			
+WB	WBGene00014115	gld-4		ZK858.1	gene	taxon:6239			
+WB	WBGene00014117	clec-91		ZK858.3	gene	taxon:6239			
+WB	WBGene00014118	ZK858.5			gene	taxon:6239			
+WB	WBGene00014119	ZK858.6			gene	taxon:6239			
+WB	WBGene00014120	ZK858.7			gene	taxon:6239			
+WB	WBGene00014122	ZK863.1			gene	taxon:6239			
+WB	WBGene00014123	elpc-3		ZK863.3	gene	taxon:6239			
+WB	WBGene00014124	usip-1		ZK863.4	gene	taxon:6239			
+WB	WBGene00014125	ZK863.8			gene	taxon:6239			
+WB	WBGene00014127	ZK892.3			gene	taxon:6239			
+WB	WBGene00014128	ZK892.4			gene	taxon:6239			
+WB	WBGene00014129	ZK892.5			gene	taxon:6239			
+WB	WBGene00014137	clec-187		ZK896.6	gene	taxon:6239			
+WB	WBGene00014138	clec-186		ZK896.7	gene	taxon:6239			
+WB	WBGene00014139	nstp-5		ZK896.9	gene	taxon:6239			
+WB	WBGene00014141	ZK899.2			gene	taxon:6239			
+WB	WBGene00014151	vps-15		ZK930.1	gene	taxon:6239			
+WB	WBGene00014153	vab-23		ZK930.3	gene	taxon:6239			
+WB	WBGene00014156	ZK930.6			gene	taxon:6239			
+WB	WBGene00014158	ZK938.1			gene	taxon:6239			
+WB	WBGene00014160	ZK938.3			gene	taxon:6239			
+WB	WBGene00014162	chil-9		ZK938.6	gene	taxon:6239			
+WB	WBGene00014163	rnh-1.2		ZK938.7	gene	taxon:6239			
+WB	WBGene00014164	lact-2		ZK945.1	gene	taxon:6239			
+WB	WBGene00014165	puf-12		ZK945.3	gene	taxon:6239			
+WB	WBGene00014166	ZK945.4			gene	taxon:6239			
+WB	WBGene00014170	ZK945.8			gene	taxon:6239			
+WB	WBGene00014171	nep-26		ZK970.1	gene	taxon:6239			
+WB	WBGene00014172	clpp-1		ZK970.2|ClpP	gene	taxon:6239			
+WB	WBGene00014173	ZK970.7			gene	taxon:6239			
+WB	WBGene00014174	ZK970.8			gene	taxon:6239			
+WB	WBGene00014177	frg-1		ZK1010.3	gene	taxon:6239			
+WB	WBGene00014181	ZK1010.8			gene	taxon:6239			
+WB	WBGene00014182	ZK1025.2			gene	taxon:6239			
+WB	WBGene00014183	ZK1025.3			gene	taxon:6239			
+WB	WBGene00014184	ZK1025.4			gene	taxon:6239			
+WB	WBGene00014186	nhr-244		ZK1025.6	gene	taxon:6239			
+WB	WBGene00014188	ZK1025.8			gene	taxon:6239			
+WB	WBGene00014189	nhr-245		ZK1025.10	gene	taxon:6239			
+WB	WBGene00014191	srt-22		ZK1037.3	gene	taxon:6239			
+WB	WBGene00014193	nhr-247		ZK1037.5	gene	taxon:6239			
+WB	WBGene00014194	ZK1037.6			gene	taxon:6239			
+WB	WBGene00014195	srz-10		ZK1037.11	gene	taxon:6239			
+WB	WBGene00014196	ZK1053.1			gene	taxon:6239			
+WB	WBGene00014197	ZK1053.2			gene	taxon:6239			
+WB	WBGene00014198	ZK1053.3			gene	taxon:6239			
+WB	WBGene00014199	ZK1053.4			gene	taxon:6239			
+WB	WBGene00014200	scrm-2		ZK1053.5|plsc-3	gene	taxon:6239			
+WB	WBGene00014201	ZK1053.6			gene	taxon:6239			
+WB	WBGene00014202	mmcm-1		ZK1058.1	gene	taxon:6239			
+WB	WBGene00014203	ZK1058.3			gene	taxon:6239			
+WB	WBGene00014204	ccdc-47		ZK1058.4|tag-252	gene	taxon:6239			
+WB	WBGene00014205	metl-6		ZK1058.5	gene	taxon:6239			
+WB	WBGene00014206	nit-1		ZK1058.6	gene	taxon:6239			
+WB	WBGene00014208	znfx-1		ZK1067.2	gene	taxon:6239			
+WB	WBGene00014210	ZK1067.4			gene	taxon:6239			
+WB	WBGene00014214	ZK1073.2			gene	taxon:6239			
+WB	WBGene00014215	obr-3		ZK1086.1	gene	taxon:6239			
+WB	WBGene00014216	ZK1086.2			gene	taxon:6239			
+WB	WBGene00014218	prp-40		ZK1098.1	gene	taxon:6239			
+WB	WBGene00014220	ZK1098.3			gene	taxon:6239			
+WB	WBGene00014221	eif-2Balpha		ZK1098.4	gene	taxon:6239			
+WB	WBGene00014222	trpp-3		ZK1098.5	gene	taxon:6239			
+WB	WBGene00014224	mrps-23		ZK1098.7	gene	taxon:6239			
+WB	WBGene00014225	ZK1098.9			gene	taxon:6239			
+WB	WBGene00014226	ZK1098.11			gene	taxon:6239			
+WB	WBGene00014227	ZK1128.1			gene	taxon:6239			
+WB	WBGene00014228	mett-10		ZK1128.2|let-42|stu-18	gene	taxon:6239			
+WB	WBGene00014230	gtf-2H3		ZK1128.4	gene	taxon:6239			
+WB	WBGene00014232	ttll-4		ZK1128.6	gene	taxon:6239			
+WB	WBGene00014233	ZK1128.7			gene	taxon:6239			
+WB	WBGene00014234	vps-29		ZK1128.8	gene	taxon:6239			
+WB	WBGene00014236	ZK1225.2			gene	taxon:6239			
+WB	WBGene00014240	htas-1		ZK1251.1	gene	taxon:6239			
+WB	WBGene00014241	ZK1251.3			gene	taxon:6239			
+WB	WBGene00014243	dcaf-1		ZK1251.9	gene	taxon:6239			
+WB	WBGene00014248	ZK1307.7			gene	taxon:6239			
+WB	WBGene00014249	ZK1307.8			gene	taxon:6239			
+WB	WBGene00014250	ZK1307.9			gene	taxon:6239			
+WB	WBGene00014251	gstk-1		ZK1320.1	gene	taxon:6239			
+WB	WBGene00014252	ZK1320.2			gene	taxon:6239			
+WB	WBGene00014254	cyp-13A10		ZK1320.4	gene	taxon:6239			
+WB	WBGene00014255	ZK1320.5			gene	taxon:6239			
+WB	WBGene00014256	ZK1320.7			gene	taxon:6239			
+WB	WBGene00014258	ZK1320.9			gene	taxon:6239			
+WB	WBGene00014259	ZK1320.11			gene	taxon:6239			
+WB	WBGene00014260	ZK1321.1			gene	taxon:6239			
+WB	WBGene00014261	shk-1		ZK1321.2	gene	taxon:6239			
+WB	WBGene00014300	D2023.1			gene	taxon:6239			
+WB	WBGene00014569	bkip-1		Y39G8C.3|Y39G8C.d	gene	taxon:6239			
+WB	WBGene00014669	zipt-2.1		C06G8.3	gene	taxon:6239			
+WB	WBGene00014679	srz-25		C18D4.5	gene	taxon:6239			
+WB	WBGene00014697	cyp-25A3		C36A4.3	gene	taxon:6239			
+WB	WBGene00014813	M176.9			gene	taxon:6239			
+WB	WBGene00014848	VM106R.1			gene	taxon:6239			
+WB	WBGene00014924	Y57G11C.28			gene	taxon:6239			
+WB	WBGene00014926	Y57G11C.30			gene	taxon:6239			
+WB	WBGene00014938	mdt-9		Y62E10A.11	gene	taxon:6239			
+WB	WBGene00014953	Y81G3A.2			gene	taxon:6239			
+WB	WBGene00014965	Y106G6D.5			gene	taxon:6239			
+WB	WBGene00014989	best-23		ZK675.3	gene	taxon:6239			
+WB	WBGene00014998	AH9.1			gene	taxon:6239			
+WB	WBGene00015000	AH9.4			gene	taxon:6239			
+WB	WBGene00015001	B0025.4			gene	taxon:6239			
+WB	WBGene00015005	B0034.5			gene	taxon:6239			
+WB	WBGene00015007	ain-2		B0041.2	gene	taxon:6239			
+WB	WBGene00015009	B0041.5			gene	taxon:6239			
+WB	WBGene00015010	ptps-1		B0041.6	gene	taxon:6239			
+WB	WBGene00015018	srz-85		B0205.2	gene	taxon:6239			
+WB	WBGene00015019	B0205.4			gene	taxon:6239			
+WB	WBGene00015021	nfs-1		B0205.6	gene	taxon:6239			
+WB	WBGene00015022	B0205.8			gene	taxon:6239			
+WB	WBGene00015025	mrpl-9		B0205.11	gene	taxon:6239			
+WB	WBGene00015026	B0207.1			gene	taxon:6239			
+WB	WBGene00015027	B0207.2			gene	taxon:6239			
+WB	WBGene00015029	B0207.6			gene	taxon:6239			
+WB	WBGene00015030	B0207.7			gene	taxon:6239			
+WB	WBGene00015032	B0207.9			gene	taxon:6239			
+WB	WBGene00015033	B0207.10			gene	taxon:6239			
+WB	WBGene00015035	otpl-1		B0212.1	gene	taxon:6239			
+WB	WBGene00015036	sre-5		B0212.2	gene	taxon:6239			
+WB	WBGene00015038	nstp-6		B0212.4	gene	taxon:6239			
+WB	WBGene00015040	cyp-34A5		B0213.10	gene	taxon:6239			
+WB	WBGene00015041	cyp-34A6		B0213.11	gene	taxon:6239			
+WB	WBGene00015042	cyp-34A7		B0213.12	gene	taxon:6239			
+WB	WBGene00015043	cyp-34A8		B0213.14	gene	taxon:6239			
+WB	WBGene00015044	cyp-34A9		B0213.15|ccp-34A9|dod-16	gene	taxon:6239			
+WB	WBGene00015045	cyp-34A10		B0213.16	gene	taxon:6239			
+WB	WBGene00015046	nlp-34		B0213.17	gene	taxon:6239			
+WB	WBGene00015047	faah-1		B0218.1|svh-3	gene	taxon:6239			
+WB	WBGene00015049	B0218.5			gene	taxon:6239			
+WB	WBGene00015050	clec-51		B0218.6	gene	taxon:6239			
+WB	WBGene00015052	clec-52		B0218.8	gene	taxon:6239			
+WB	WBGene00015053	B0222.1			gene	taxon:6239			
+WB	WBGene00015054	pitr-2		B0222.2	gene	taxon:6239			
+WB	WBGene00015055	pitr-3		B0222.3	gene	taxon:6239			
+WB	WBGene00015056	B0222.5			gene	taxon:6239			
+WB	WBGene00015057	gad-3		B0222.9	gene	taxon:6239			
+WB	WBGene00015062	trx-1		B0228.5|B0228.c	gene	taxon:6239			
+WB	WBGene00015063	B0228.6			gene	taxon:6239			
+WB	WBGene00015064	B0228.7			gene	taxon:6239			
+WB	WBGene00015067	cest-35.1		B0238.1	gene	taxon:6239			
+WB	WBGene00015068	srt-68		B0238.3	gene	taxon:6239			
+WB	WBGene00015069	srt-67		B0238.5	gene	taxon:6239			
+WB	WBGene00015070	srt-70		B0238.6	gene	taxon:6239			
+WB	WBGene00015071	cest-30		B0238.7	gene	taxon:6239			
+WB	WBGene00015072	srt-69		B0238.8	gene	taxon:6239			
+WB	WBGene00015074	natc-2		B0238.10|CE07700	gene	taxon:6239			
+WB	WBGene00015076	B0238.12			gene	taxon:6239			
+WB	WBGene00015079	B0244.4			gene	taxon:6239			
+WB	WBGene00015080	B0244.5			gene	taxon:6239			
+WB	WBGene00015081	B0244.6			gene	taxon:6239			
+WB	WBGene00015082	B0244.7			gene	taxon:6239			
+WB	WBGene00015083	egg-1		B0244.8	gene	taxon:6239			
+WB	WBGene00015084	B0244.9			gene	taxon:6239			
+WB	WBGene00015085	B0244.10			gene	taxon:6239			
+WB	WBGene00015087	B0252.1			gene	taxon:6239			
+WB	WBGene00015088	B0252.3			gene	taxon:6239			
+WB	WBGene00015092	mrpl-47		B0261.4	gene	taxon:6239			
+WB	WBGene00015093	B0261.5			gene	taxon:6239			
+WB	WBGene00015095	B0261.7			gene	taxon:6239			
+WB	WBGene00015098	snpc-3.1		B0273.3	gene	taxon:6239			
+WB	WBGene00015099	ggtb-1		B0280.1	gene	taxon:6239			
+WB	WBGene00015101	rpia-1		B0280.3	gene	taxon:6239			
+WB	WBGene00015102	cpg-2		B0280.5	gene	taxon:6239			
+WB	WBGene00015104	B0280.9			gene	taxon:6239			
+WB	WBGene00015105	pot-1		B0280.10|CeOB2	gene	taxon:6239			
+WB	WBGene00015106	B0280.11			gene	taxon:6239			
+WB	WBGene00015110	B0281.3			gene	taxon:6239			
+WB	WBGene00015112	B0281.5			gene	taxon:6239			
+WB	WBGene00015113	B0281.6			gene	taxon:6239			
+WB	WBGene00015114	B0281.8			gene	taxon:6239			
+WB	WBGene00015116	paic-1		B0286.3|pacs-1	gene	taxon:6239			
+WB	WBGene00015124	anmt-1		B0303.2	gene	taxon:6239			
+WB	WBGene00015125	B0303.3			gene	taxon:6239			
+WB	WBGene00015126	B0303.4			gene	taxon:6239			
+WB	WBGene00015128	B0303.7			gene	taxon:6239			
+WB	WBGene00015129	sdz-1		B0303.8	gene	taxon:6239			
+WB	WBGene00015130	vps-33.1		B0303.9	gene	taxon:6239			
+WB	WBGene00015131	B0303.11			gene	taxon:6239			
+WB	WBGene00015133	mrpl-11		B0303.15	gene	taxon:6239			
+WB	WBGene00015135	cyp-23A1		B0304.3	gene	taxon:6239			
+WB	WBGene00015137	B0310.1			gene	taxon:6239			
+WB	WBGene00015138	B0310.2			gene	taxon:6239			
+WB	WBGene00015139	B0310.3			gene	taxon:6239			
+WB	WBGene00015141	ugt-46		B0310.5	gene	taxon:6239			
+WB	WBGene00015143	rbm-26		B0336.3	gene	taxon:6239			
+WB	WBGene00015146	abi-1		B0336.6	gene	taxon:6239			
+WB	WBGene00015147	B0336.7			gene	taxon:6239			
+WB	WBGene00015148	hpo-28		B0336.11	gene	taxon:6239			
+WB	WBGene00015150	B0336.13			gene	taxon:6239			
+WB	WBGene00015151	B0348.1			gene	taxon:6239			
+WB	WBGene00015152	B0348.2			gene	taxon:6239			
+WB	WBGene00015158	B0361.4			gene	taxon:6239			
+WB	WBGene00015159	psd-1		B0361.5	gene	taxon:6239			
+WB	WBGene00015160	B0361.6			gene	taxon:6239			
+WB	WBGene00015161	pho-5		B0361.7	gene	taxon:6239			
+WB	WBGene00015162	algn-11		B0361.8	gene	taxon:6239			
+WB	WBGene00015164	ykt-6		B0361.10|Ce-Ykt6p	gene	taxon:6239			
+WB	WBGene00015165	B0361.11			gene	taxon:6239			
+WB	WBGene00015167	B0403.3			gene	taxon:6239			
+WB	WBGene00015168	pdi-6		B0403.4|tag-320	gene	taxon:6239			
+WB	WBGene00015171	vang-1		B0410.2|nde-1	gene	taxon:6239			
+WB	WBGene00015172	B0410.3			gene	taxon:6239			
+WB	WBGene00015173	trpp-11		B0412.3	gene	taxon:6239			
+WB	WBGene00015175	srz-4		B0414.1	gene	taxon:6239			
+WB	WBGene00015176	vps-51		B0414.8	gene	taxon:6239			
+WB	WBGene00015177	tmc-2		B0416.1	gene	taxon:6239			
+WB	WBGene00015179	B0416.3			gene	taxon:6239			
+WB	WBGene00015180	B0416.4			gene	taxon:6239			
+WB	WBGene00015181	B0416.5			gene	taxon:6239			
+WB	WBGene00015183	B0432.1			gene	taxon:6239			
+WB	WBGene00015184	djr-1.1		B0432.2	gene	taxon:6239			
+WB	WBGene00015185	mrpl-41		B0432.3	gene	taxon:6239			
+WB	WBGene00015186	misc-1		B0432.4|slc-25A11	gene	taxon:6239			
+WB	WBGene00015189	B0432.8			gene	taxon:6239			
+WB	WBGene00015192	B0432.11			gene	taxon:6239			
+WB	WBGene00015193	clec-117		B0432.12	gene	taxon:6239			
+WB	WBGene00015194	trul-1		B0432.13	gene	taxon:6239			
+WB	WBGene00015196	B0454.5			gene	taxon:6239			
+WB	WBGene00015197	B0454.6			gene	taxon:6239			
+WB	WBGene00015198	clec-2		B0454.7	gene	taxon:6239			
+WB	WBGene00015202	B0478.3			gene	taxon:6239			
+WB	WBGene00015203	cdk-11.1		B0495.2	gene	taxon:6239			
+WB	WBGene00015204	B0495.5			gene	taxon:6239			
+WB	WBGene00015206	B0495.7			gene	taxon:6239			
+WB	WBGene00015207	luc-7L		B0495.8	gene	taxon:6239			
+WB	WBGene00015208	B0495.9			gene	taxon:6239			
+WB	WBGene00015214	srtx-1		B0496.5	gene	taxon:6239			
+WB	WBGene00015215	B0496.6			gene	taxon:6239			
+WB	WBGene00015216	valv-1		B0496.7	gene	taxon:6239			
+WB	WBGene00015217	tes-1		B0496.8|tag-224	gene	taxon:6239			
+WB	WBGene00015218	B0507.1			gene	taxon:6239			
+WB	WBGene00015220	B0507.3			gene	taxon:6239			
+WB	WBGene00015230	tag-344		B0511.4	gene	taxon:6239			
+WB	WBGene00015232	B0511.6			gene	taxon:6239			
+WB	WBGene00015233	B0511.7			gene	taxon:6239			
+WB	WBGene00015235	cdc-26		B0511.9|mat-4|tag-265	gene	taxon:6239			
+WB	WBGene00015237	B0511.12			gene	taxon:6239			
+WB	WBGene00015238	mppe-1		B0511.13	gene	taxon:6239			
+WB	WBGene00015241	B0524.2			gene	taxon:6239			
+WB	WBGene00015246	scl-23		B0545.3	gene	taxon:6239			
+WB	WBGene00015247	B0545.4			gene	taxon:6239			
+WB	WBGene00015248	mai-2		B0546.1|4E151	gene	taxon:6239			
+WB	WBGene00015249	otub-4		B0546.2	gene	taxon:6239			
+WB	WBGene00015250	B0546.3			gene	taxon:6239			
+WB	WBGene00015251	B0546.4			gene	taxon:6239			
+WB	WBGene00015252	B0546.5			gene	taxon:6239			
+WB	WBGene00015258	B0554.5			gene	taxon:6239			
+WB	WBGene00015260	B0554.7			gene	taxon:6239			
+WB	WBGene00015263	B0563.6			gene	taxon:6239			
+WB	WBGene00015264	B0563.7			gene	taxon:6239			
+WB	WBGene00015266	BE0003N10.1			gene	taxon:6239			
+WB	WBGene00015267	chin-1		BE0003N10.2	gene	taxon:6239			
+WB	WBGene00015268	BE0003N10.3			gene	taxon:6239			
+WB	WBGene00015270	C01B4.6			gene	taxon:6239			
+WB	WBGene00015271	C01B4.7			gene	taxon:6239			
+WB	WBGene00015272	C01B4.8			gene	taxon:6239			
+WB	WBGene00015273	mct-2		C01B4.9	gene	taxon:6239			
+WB	WBGene00015278	C01B10.3			gene	taxon:6239			
+WB	WBGene00015279	cest-5.1		C01B10.4	gene	taxon:6239			
+WB	WBGene00015282	C01B10.8			gene	taxon:6239			
+WB	WBGene00015283	C01B10.9			gene	taxon:6239			
+WB	WBGene00015284	cest-5.2		C01B10.10	gene	taxon:6239			
+WB	WBGene00015285	gmeb-1		C01B12.2	gene	taxon:6239			
+WB	WBGene00015286	best-3		C01B12.3	gene	taxon:6239			
+WB	WBGene00015287	osta-1		C01B12.4	gene	taxon:6239			
+WB	WBGene00015288	best-4		C01B12.5	gene	taxon:6239			
+WB	WBGene00015293	C01C4.3			gene	taxon:6239			
+WB	WBGene00015295	acl-12		C01C10.3	gene	taxon:6239			
+WB	WBGene00015296	gtf-2F1		C01F1.1	gene	taxon:6239			
+WB	WBGene00015297	sco-1		C01F1.2	gene	taxon:6239			
+WB	WBGene00015299	C01F1.4			gene	taxon:6239			
+WB	WBGene00015300	C01F1.5			gene	taxon:6239			
+WB	WBGene00015301	C01F1.6			gene	taxon:6239			
+WB	WBGene00015303	rga-6		C01F4.2	gene	taxon:6239			
+WB	WBGene00015306	C01G5.4			gene	taxon:6239			
+WB	WBGene00015307	C01G5.5			gene	taxon:6239			
+WB	WBGene00015308	ddi-1		C01G5.6|vsm-1	gene	taxon:6239			
+WB	WBGene00015310	fan-1		C01G5.8	gene	taxon:6239			
+WB	WBGene00015311	C01G5.9			gene	taxon:6239			
+WB	WBGene00015315	srbc-29		C02A12.2	gene	taxon:6239			
+WB	WBGene00015316	srbc-30		C02A12.3	gene	taxon:6239			
+WB	WBGene00015317	srbc-32		C02A12.5	gene	taxon:6239			
+WB	WBGene00015318	srbc-36		C02A12.6	gene	taxon:6239			
+WB	WBGene00015323	frpr-1		C02B8.5	gene	taxon:6239			
+WB	WBGene00015324	C02B8.6			gene	taxon:6239			
+WB	WBGene00015326	ivd-1		C02B10.1	gene	taxon:6239			
+WB	WBGene00015327	snpn-1		C02B10.2	gene	taxon:6239			
+WB	WBGene00015328	C02B10.3			gene	taxon:6239			
+WB	WBGene00015329	C02B10.4			gene	taxon:6239			
+WB	WBGene00015331	C02B10.6		Y72A2B.a	gene	taxon:6239			
+WB	WBGene00015332	tyr-1		C02C2.1	gene	taxon:6239			
+WB	WBGene00015333	slc-17.3		C02C2.4	gene	taxon:6239			
+WB	WBGene00015334	sup-18		C02C2.5	gene	taxon:6239			
+WB	WBGene00015335	acdh-6		C02D5.1	gene	taxon:6239			
+WB	WBGene00015336	C02D5.2			gene	taxon:6239			
+WB	WBGene00015337	gsto-2		C02D5.3	gene	taxon:6239			
+WB	WBGene00015338	catp-2		C02E7.1	gene	taxon:6239			
+WB	WBGene00015342	C02E7.10			gene	taxon:6239			
+WB	WBGene00015344	nra-4		C02E11.1	gene	taxon:6239			
+WB	WBGene00015346	C02F5.3			gene	taxon:6239			
+WB	WBGene00015347	cids-1		C02F5.4	gene	taxon:6239			
+WB	WBGene00015349	henn-1		C02F5.6	gene	taxon:6239			
+WB	WBGene00015350	fbxl-1		C02F5.7|cfl-1	gene	taxon:6239			
+WB	WBGene00015352	C02F5.12			gene	taxon:6239			
+WB	WBGene00015353	C02F5.13			gene	taxon:6239			
+WB	WBGene00015354	snet-1		C02F12.3	gene	taxon:6239			
+WB	WBGene00015355	C02F12.5			gene	taxon:6239			
+WB	WBGene00015357	C02F12.8			gene	taxon:6239			
+WB	WBGene00015360	C02G6.2			gene	taxon:6239			
+WB	WBGene00015361	C02H6.1			gene	taxon:6239			
+WB	WBGene00015362	fbxa-105		C02H6.2	gene	taxon:6239			
+WB	WBGene00015364	npr-19		C02H7.2	gene	taxon:6239			
+WB	WBGene00015367	srt-64		C03A7.9	gene	taxon:6239			
+WB	WBGene00015368	srt-65		C03A7.10	gene	taxon:6239			
+WB	WBGene00015369	ugt-51		C03A7.11	gene	taxon:6239			
+WB	WBGene00015371	C03A7.13			gene	taxon:6239			
+WB	WBGene00015376	C03B1.5			gene	taxon:6239			
+WB	WBGene00015381	C03B1.13		T10E10.a	gene	taxon:6239			
+WB	WBGene00015386	C03B8.3			gene	taxon:6239			
+WB	WBGene00015387	kcnl-3		C03F11.1	gene	taxon:6239			
+WB	WBGene00015389	scav-1		C03F11.3	gene	taxon:6239			
+WB	WBGene00015391	sdha-1		C03G5.1	gene	taxon:6239			
+WB	WBGene00015393	exc-13		C03G6.5	gene	taxon:6239			
+WB	WBGene00015394	C03G6.6			gene	taxon:6239			
+WB	WBGene00015395	nhr-147		C03G6.8	gene	taxon:6239			
+WB	WBGene00015396	nhr-148		C03G6.10	gene	taxon:6239			
+WB	WBGene00015397	nhr-149		C03G6.12	gene	taxon:6239			
+WB	WBGene00015399	cyp-35A1		C03G6.14	gene	taxon:6239			
+WB	WBGene00015400	cyp-35A2		C03G6.15	gene	taxon:6239			
+WB	WBGene00015401	srsx-24		C03G6.16	gene	taxon:6239			
+WB	WBGene00015403	clec-10		C03H5.1	gene	taxon:6239			
+WB	WBGene00015404	nstp-4		C03H5.2	gene	taxon:6239			
+WB	WBGene00015406	C03H5.4			gene	taxon:6239			
+WB	WBGene00015407	C03H5.5			gene	taxon:6239			
+WB	WBGene00015409	C03H5.7			gene	taxon:6239			
+WB	WBGene00015411	srz-60		C04C3.1	gene	taxon:6239			
+WB	WBGene00015412	lgc-9		C04C3.2	gene	taxon:6239			
+WB	WBGene00015413	pdhb-1		C04C3.3	gene	taxon:6239			
+WB	WBGene00015416	C04C3.6			gene	taxon:6239			
+WB	WBGene00015417	C04C3.7			gene	taxon:6239			
+WB	WBGene00015418	pac-1		C04D8.1|CEGAP	gene	taxon:6239			
+WB	WBGene00015419	srsx-18		C04E6.2	gene	taxon:6239			
+WB	WBGene00015421	C04E6.4			gene	taxon:6239			
+WB	WBGene00015422	C04E6.5			gene	taxon:6239			
+WB	WBGene00015426	C04E6.12			gene	taxon:6239			
+WB	WBGene00015429	sor-3		C04E7.2	gene	taxon:6239			
+WB	WBGene00015434	C04E12.4			gene	taxon:6239			
+WB	WBGene00015435	C04E12.5			gene	taxon:6239			
+WB	WBGene00015437	scrm-3		C04E12.7|plsc-1	gene	taxon:6239			
+WB	WBGene00015438	srbc-2		C04E12.9	gene	taxon:6239			
+WB	WBGene00015442	C04F1.1			gene	taxon:6239			
+WB	WBGene00015444	C04F5.2			gene	taxon:6239			
+WB	WBGene00015446	srab-1		C04F5.4	gene	taxon:6239			
+WB	WBGene00015447	srab-2		C04F5.5	gene	taxon:6239			
+WB	WBGene00015448	srab-3		C04F5.6	gene	taxon:6239			
+WB	WBGene00015449	ugt-63		C04F5.7	gene	taxon:6239			
+WB	WBGene00015450	C04F5.8			gene	taxon:6239			
+WB	WBGene00015454	C04G6.4			gene	taxon:6239			
+WB	WBGene00015455	txt-9		C04G6.5	gene	taxon:6239			
+WB	WBGene00015459	C04G6.11			gene	taxon:6239			
+WB	WBGene00015460	C05C8.1			gene	taxon:6239			
+WB	WBGene00015461	krr-1		C05C8.2	gene	taxon:6239			
+WB	WBGene00015462	C05C8.5			gene	taxon:6239			
+WB	WBGene00015464	C05C8.7		phi-49	gene	taxon:6239			
+WB	WBGene00015465	C05C8.8			gene	taxon:6239			
+WB	WBGene00015466	hyls-1		C05C8.9	gene	taxon:6239			
+WB	WBGene00015467	basl-1		C05D2.3	gene	taxon:6239			
+WB	WBGene00015471	lmp-2		C05D9.2	gene	taxon:6239			
+WB	WBGene00015472	C05D9.3			gene	taxon:6239			
+WB	WBGene00015474	C05D9.7			gene	taxon:6239			
+WB	WBGene00015477	attf-4		C05D10.1	gene	taxon:6239			
+WB	WBGene00015478	mapk-15		C05D10.2|swip-13|swip-133	gene	taxon:6239			
+WB	WBGene00015479	wht-1		C05D10.3	gene	taxon:6239			
+WB	WBGene00015480	C05D10.4			gene	taxon:6239			
+WB	WBGene00015481	C05D11.1			gene	taxon:6239			
+WB	WBGene00015483	C05D11.5			gene	taxon:6239			
+WB	WBGene00015484	atgl-1		C05D11.7	gene	taxon:6239			
+WB	WBGene00015487	mrps-17		C05D11.10	gene	taxon:6239			
+WB	WBGene00015492	lnp-1		C05E11.1	gene	taxon:6239			
+WB	WBGene00015493	C05E11.2			gene	taxon:6239			
+WB	WBGene00015494	C05E11.3			gene	taxon:6239			
+WB	WBGene00015497	nhr-76		C05G6.1	gene	taxon:6239			
+WB	WBGene00015499	ints-1		C06A5.1|inst-1|let-384	gene	taxon:6239			
+WB	WBGene00015504	simr-1		C06A5.6	gene	taxon:6239			
+WB	WBGene00015505	C06A5.8			gene	taxon:6239			
+WB	WBGene00015508	mvb-12		C06A6.3	gene	taxon:6239			
+WB	WBGene00015509	C06A6.4			gene	taxon:6239			
+WB	WBGene00015510	erp-44.2		C06A6.5	gene	taxon:6239			
+WB	WBGene00015512	mthf-1		C06A8.1	gene	taxon:6239			
+WB	WBGene00015515	spdl-1		C06A8.5	gene	taxon:6239			
+WB	WBGene00015518	C06E1.1			gene	taxon:6239			
+WB	WBGene00015519	doxa-1		C06E1.3	gene	taxon:6239			
+WB	WBGene00015522	C06E1.7			gene	taxon:6239			
+WB	WBGene00015523	ztf-30		C06E1.8	gene	taxon:6239			
+WB	WBGene00015525	rha-2		C06E1.10	gene	taxon:6239			
+WB	WBGene00015532	C06E4.3			gene	taxon:6239			
+WB	WBGene00015534	C06E4.5			gene	taxon:6239			
+WB	WBGene00015535	C06E4.6			gene	taxon:6239			
+WB	WBGene00015536	glb-2		C06E4.7	gene	taxon:6239			
+WB	WBGene00015538	sams-3		C06E7.1	gene	taxon:6239			
+WB	WBGene00015540	sams-4		C06E7.3	gene	taxon:6239			
+WB	WBGene00015544	C06E8.5			gene	taxon:6239			
+WB	WBGene00015545	C06G1.1			gene	taxon:6239			
+WB	WBGene00015547	ain-1		C06G1.4	gene	taxon:6239			
+WB	WBGene00015551	adah-1		C06G3.5	gene	taxon:6239			
+WB	WBGene00015552	C06G3.6			gene	taxon:6239			
+WB	WBGene00015553	trxr-1		C06G3.7	gene	taxon:6239			
+WB	WBGene00015555	ufl-1		C06G3.9	gene	taxon:6239			
+WB	WBGene00015557	hrpk-2		C06G4.1	gene	taxon:6239			
+WB	WBGene00015559	npr-17		C06G4.5	gene	taxon:6239			
+WB	WBGene00015561	C07A12.7			gene	taxon:6239			
+WB	WBGene00015564	C07D8.5			gene	taxon:6239			
+WB	WBGene00015565	C07D8.6			gene	taxon:6239			
+WB	WBGene00015568	sre-3		C07D10.3	gene	taxon:6239			
+WB	WBGene00015574	irg-1		C07G3.2	gene	taxon:6239			
+WB	WBGene00015577	ugt-64		C07G3.9	gene	taxon:6239			
+WB	WBGene00015578	C07G3.10			gene	taxon:6239			
+WB	WBGene00015579	C07H6.2			gene	taxon:6239			
+WB	WBGene00015580	cls-1		C07H6.3	gene	taxon:6239			
+WB	WBGene00015581	sap-140		C07H6.4	gene	taxon:6239			
+WB	WBGene00015582	C07H6.9			gene	taxon:6239			
+WB	WBGene00015583	C08A9.3			gene	taxon:6239			
+WB	WBGene00015590	bath-15		C08C3.2	gene	taxon:6239			
+WB	WBGene00015591	cyk-7		C08C3.4	gene	taxon:6239			
+WB	WBGene00015592	C08D8.1		C08D8.c	gene	taxon:6239			
+WB	WBGene00015599	fbxa-164		C08E3.7	gene	taxon:6239			
+WB	WBGene00015601	fbxa-166		C08E3.9	gene	taxon:6239			
+WB	WBGene00015610	C08F1.6			gene	taxon:6239			
+WB	WBGene00015611	C08F1.8			gene	taxon:6239			
+WB	WBGene00015613	C08F1.10			gene	taxon:6239			
+WB	WBGene00015618	C08G5.6			gene	taxon:6239			
+WB	WBGene00015619	C08G9.1			gene	taxon:6239			
+WB	WBGene00015620	C08G9.2			gene	taxon:6239			
+WB	WBGene00015621	C09B7.2			gene	taxon:6239			
+WB	WBGene00015622	C09B8.3			gene	taxon:6239			
+WB	WBGene00015623	C09B8.4			gene	taxon:6239			
+WB	WBGene00015625	C09B8.8			gene	taxon:6239			
+WB	WBGene00015626	C09B9.1			gene	taxon:6239			
+WB	WBGene00015627	C09B9.2			gene	taxon:6239			
+WB	WBGene00015628	best-6		C09B9.3	gene	taxon:6239			
+WB	WBGene00015629	C09B9.4			gene	taxon:6239			
+WB	WBGene00015630	C09B9.7			gene	taxon:6239			
+WB	WBGene00015631	clec-89		C09D1.2	gene	taxon:6239			
+WB	WBGene00015632	C09D4.1			gene	taxon:6239			
+WB	WBGene00015634	C09D4.3			gene	taxon:6239			
+WB	WBGene00015636	C09D4.6			gene	taxon:6239			
+WB	WBGene00015637	srxa-5		C09E7.1|C09E7.g	gene	taxon:6239			
+WB	WBGene00015638	C09E7.4		C09E7.e	gene	taxon:6239			
+WB	WBGene00015642	C09E7.8		C09E7.a	gene	taxon:6239			
+WB	WBGene00015644	C09E8.1			gene	taxon:6239			
+WB	WBGene00015645	lips-7		C09E8.2	gene	taxon:6239			
+WB	WBGene00015646	mlt-10		C09E8.3|C09E8.a	gene	taxon:6239			
+WB	WBGene00015647	C09F5.1			gene	taxon:6239			
+WB	WBGene00015648	orai-1		C09F5.2	gene	taxon:6239			
+WB	WBGene00015649	C09F5.3			gene	taxon:6239			
+WB	WBGene00015650	pkg-2		C09G4.2	gene	taxon:6239			
+WB	WBGene00015651	ceh-53		C09G12.1	gene	taxon:6239			
+WB	WBGene00015652	srz-79		C09G12.2	gene	taxon:6239			
+WB	WBGene00015653	srz-78		C09G12.3	gene	taxon:6239			
+WB	WBGene00015656	srz-70		C09G12.6	gene	taxon:6239			
+WB	WBGene00015658	tsg-101		C09G12.9	gene	taxon:6239			
+WB	WBGene00015660	catp-3		C09H5.2	gene	taxon:6239			
+WB	WBGene00015661	C09H5.7			gene	taxon:6239			
+WB	WBGene00015662	C10A4.1			gene	taxon:6239			
+WB	WBGene00015663	C10A4.2			gene	taxon:6239			
+WB	WBGene00015664	C10A4.3			gene	taxon:6239			
+WB	WBGene00015665	C10A4.4			gene	taxon:6239			
+WB	WBGene00015666	gad-2		C10A4.5	gene	taxon:6239			
+WB	WBGene00015667	C10A4.6			gene	taxon:6239			
+WB	WBGene00015668	C10A4.7			gene	taxon:6239			
+WB	WBGene00015673	C10E2.2			gene	taxon:6239			
+WB	WBGene00015675	C10E2.5			gene	taxon:6239			
+WB	WBGene00015676	mct-6		C10E2.6	gene	taxon:6239			
+WB	WBGene00015678	mcp-1		C10F3.4	gene	taxon:6239			
+WB	WBGene00015680	egal-1		C10G6.1	gene	taxon:6239			
+WB	WBGene00015681	C10G8.2			gene	taxon:6239			
+WB	WBGene00015682	C10G8.3			gene	taxon:6239			
+WB	WBGene00015683	C10G8.4			gene	taxon:6239			
+WB	WBGene00015685	C10G11.1			gene	taxon:6239			
+WB	WBGene00015688	C10G11.8			gene	taxon:6239			
+WB	WBGene00015689	spch-2		C10G11.9	gene	taxon:6239			
+WB	WBGene00015690	C10G11.10			gene	taxon:6239			
+WB	WBGene00015691	viln-1		C10H11.1|C10H11.b	gene	taxon:6239			
+WB	WBGene00015692	ugt-25		C10H11.3	gene	taxon:6239			
+WB	WBGene00015693	ugt-28		C10H11.4	gene	taxon:6239			
+WB	WBGene00015694	ugt-27		C10H11.5	gene	taxon:6239			
+WB	WBGene00015695	ugt-26		C10H11.6	gene	taxon:6239			
+WB	WBGene00015696	C10H11.7			gene	taxon:6239			
+WB	WBGene00015697	mlst-8		C10H11.8|CeLST8|lst-8	gene	taxon:6239			
+WB	WBGene00015698	kca-1		C10H11.10|C10H11.a	gene	taxon:6239			
+WB	WBGene00015700	asp-9		C11D2.2	gene	taxon:6239			
+WB	WBGene00015703	C11D2.7			gene	taxon:6239			
+WB	WBGene00015704	tiam-1		C11D9.1|cgef-2	gene	taxon:6239			
+WB	WBGene00015705	nhr-152		C12D5.2	gene	taxon:6239			
+WB	WBGene00015709	cyp-33A1		C12D5.7	gene	taxon:6239			
+WB	WBGene00015712	sre-11		C12D5.11	gene	taxon:6239			
+WB	WBGene00015714	C12D12.3			gene	taxon:6239			
+WB	WBGene00015716	sox-4		C12D12.5	gene	taxon:6239			
+WB	WBGene00015718	C13A2.1			gene	taxon:6239			
+WB	WBGene00015720	C13A2.3			gene	taxon:6239			
+WB	WBGene00015721	C13A2.4			gene	taxon:6239			
+WB	WBGene00015722	C13A2.5			gene	taxon:6239			
+WB	WBGene00015723	C13A2.6			gene	taxon:6239			
+WB	WBGene00015724	C13A2.7			gene	taxon:6239			
+WB	WBGene00015725	C13A2.9			gene	taxon:6239			
+WB	WBGene00015726	C13A2.10			gene	taxon:6239			
+WB	WBGene00015728	C13A10.1			gene	taxon:6239			
+WB	WBGene00015730	srt-1		C13B7.1	gene	taxon:6239			
+WB	WBGene00015733	C13B9.2			gene	taxon:6239			
+WB	WBGene00015734	copd-1		C13B9.3|phi-30	gene	taxon:6239			
+WB	WBGene00015735	pdfr-1		C13B9.4|seb-1	gene	taxon:6239			
+WB	WBGene00015736	srsx-11		C13D9.4	gene	taxon:6239			
+WB	WBGene00015737	srsx-12		C13D9.5	gene	taxon:6239			
+WB	WBGene00015738	srsx-13		C13D9.6	gene	taxon:6239			
+WB	WBGene00015739	ugt-7		C13D9.9	gene	taxon:6239			
+WB	WBGene00015741	C13F10.1			gene	taxon:6239			
+WB	WBGene00015742	kxd-1		C13F10.2	gene	taxon:6239			
+WB	WBGene00015743	soap-1		C13F10.4	gene	taxon:6239			
+WB	WBGene00015744	C13F10.5			gene	taxon:6239			
+WB	WBGene00015746	C13F10.7			gene	taxon:6239			
+WB	WBGene00015752	C14B9.2			gene	taxon:6239			
+WB	WBGene00015753	C14B9.3			gene	taxon:6239			
+WB	WBGene00015754	C14B9.8			gene	taxon:6239			
+WB	WBGene00015755	C14B9.10			gene	taxon:6239			
+WB	WBGene00015757	C14C6.3			gene	taxon:6239			
+WB	WBGene00015758	nhr-155		C14C6.4	gene	taxon:6239			
+WB	WBGene00015759	C14C6.5			gene	taxon:6239			
+WB	WBGene00015760	C14C6.6			gene	taxon:6239			
+WB	WBGene00015762	C14C6.8			gene	taxon:6239			
+WB	WBGene00015767	hex-2		C14C11.3	gene	taxon:6239			
+WB	WBGene00015768	C14C11.4			gene	taxon:6239			
+WB	WBGene00015773	C14E2.4			gene	taxon:6239			
+WB	WBGene00015774	C14E2.5			gene	taxon:6239			
+WB	WBGene00015775	C14E2.6			gene	taxon:6239			
+WB	WBGene00015776	dct-1		C14F5.1|ceBNIP3	gene	taxon:6239			
+WB	WBGene00015777	sfxn-2		C14F5.4	gene	taxon:6239			
+WB	WBGene00015778	got-2.2		C14F11.1	gene	taxon:6239			
+WB	WBGene00015780	C14F11.4			gene	taxon:6239			
+WB	WBGene00015781	rml-3		C14F11.6	gene	taxon:6239			
+WB	WBGene00015783	C15B12.1		SOX	gene	taxon:6239			
+WB	WBGene00015784	C15B12.2			gene	taxon:6239			
+WB	WBGene00015787	actl-1		C15B12.6	gene	taxon:6239			
+WB	WBGene00015788	C15B12.8		SOX	gene	taxon:6239			
+WB	WBGene00015789	syx-6		C15C7.1	gene	taxon:6239			
+WB	WBGene00015792	C15C7.6			gene	taxon:6239			
+WB	WBGene00015793	pfut-1		C15C7.7|C. elegans POFUT1	gene	taxon:6239			
+WB	WBGene00015796	C15F1.5			gene	taxon:6239			
+WB	WBGene00015798	C15H9.2			gene	taxon:6239			
+WB	WBGene00015799	C15H9.3			gene	taxon:6239			
+WB	WBGene00015800	C15H9.4			gene	taxon:6239			
+WB	WBGene00015801	C15H9.5			gene	taxon:6239			
+WB	WBGene00015802	kynu-1		C15H9.7|flu-2|XG726	gene	taxon:6239			
+WB	WBGene00015803	C15H9.9			gene	taxon:6239			
+WB	WBGene00015806	smrc-1		C16A3.1	gene	taxon:6239			
+WB	WBGene00015807	C16A3.2			gene	taxon:6239			
+WB	WBGene00015809	znf-622		C16A3.4	gene	taxon:6239			
+WB	WBGene00015810	C16A3.5			gene	taxon:6239			
+WB	WBGene00015811	C16A3.6			gene	taxon:6239			
+WB	WBGene00015813	thoc-2		C16A3.8|tag-213	gene	taxon:6239			
+WB	WBGene00015814	oatr-1		C16A3.10|orn-1	gene	taxon:6239			
+WB	WBGene00015816	C16A11.3			gene	taxon:6239			
+WB	WBGene00015817	C16A11.4			gene	taxon:6239			
+WB	WBGene00015821	clec-135		C16A11.8	gene	taxon:6239			
+WB	WBGene00015823	C16B8.3			gene	taxon:6239			
+WB	WBGene00015824	C16B8.4			gene	taxon:6239			
+WB	WBGene00015830	fbxb-98		C16C4.6	gene	taxon:6239			
+WB	WBGene00015841	skpo-2		C16C8.2	gene	taxon:6239			
+WB	WBGene00015861	C16D9.6			gene	taxon:6239			
+WB	WBGene00015865	C16E9.1			gene	taxon:6239			
+WB	WBGene00015867	ncs-7		C16H3.1	gene	taxon:6239			
+WB	WBGene00015869	nhr-257		C17A2.1	gene	taxon:6239			
+WB	WBGene00015870	C17A2.2			gene	taxon:6239			
+WB	WBGene00015871	C17A2.3			gene	taxon:6239			
+WB	WBGene00015872	C17A2.4			gene	taxon:6239			
+WB	WBGene00015873	oac-4		C17A2.5	gene	taxon:6239			
+WB	WBGene00015879	C17B7.5			gene	taxon:6239			
+WB	WBGene00015887	C17C3.1			gene	taxon:6239			
+WB	WBGene00015889	C17C3.3			gene	taxon:6239			
+WB	WBGene00015894	acdh-2		C17C3.12	gene	taxon:6239			
+WB	WBGene00015897	nhr-156		C17E7.1|nhr-284|T20C7.a	gene	taxon:6239			
+WB	WBGene00015898	sre-9		C17E7.3	gene	taxon:6239			
+WB	WBGene00015899	C17E7.4			gene	taxon:6239			
+WB	WBGene00015900	nhr-157		C17E7.5	gene	taxon:6239			
+WB	WBGene00015901	nhr-158		C17E7.6	gene	taxon:6239			
+WB	WBGene00015902	nhr-159		C17E7.7	gene	taxon:6239			
+WB	WBGene00015903	C17E7.9			gene	taxon:6239			
+WB	WBGene00015905	C17E7.12			gene	taxon:6239			
+WB	WBGene00015906	C17E7.13			gene	taxon:6239			
+WB	WBGene00015907	C17F3.1			gene	taxon:6239			
+WB	WBGene00015909	clec-124		C17F4.1	gene	taxon:6239			
+WB	WBGene00015914	C17F4.8			gene	taxon:6239			
+WB	WBGene00015915	C17G10.1			gene	taxon:6239			
+WB	WBGene00015916	ttc-4		C17G10.2	gene	taxon:6239			
+WB	WBGene00015919	C17G10.7			gene	taxon:6239			
+WB	WBGene00015920	eif-3.L		C17G10.9	gene	taxon:6239			
+WB	WBGene00015921	C17H11.1		C17H11	gene	taxon:6239			
+WB	WBGene00015924	C17H11.4			gene	taxon:6239			
+WB	WBGene00015926	C17H11.6			gene	taxon:6239			
+WB	WBGene00015927	dyci-1		C17H12.1	gene	taxon:6239			
+WB	WBGene00015928	C17H12.2			gene	taxon:6239			
+WB	WBGene00015929	C17H12.3			gene	taxon:6239			
+WB	WBGene00015930	cest-4		C17H12.4	gene	taxon:6239			
+WB	WBGene00015931	C17H12.5			gene	taxon:6239			
+WB	WBGene00015932	C17H12.6			gene	taxon:6239			
+WB	WBGene00015934	ceh-48		C17H12.9	gene	taxon:6239			
+WB	WBGene00015935	C17H12.10			gene	taxon:6239			
+WB	WBGene00015938	anat-1		C17H12.13|CE37201	gene	taxon:6239			
+WB	WBGene00015939	damt-1		C18A3.1|metl-4	gene	taxon:6239			
+WB	WBGene00015940	zipt-3		C18A3.2	gene	taxon:6239			
+WB	WBGene00015941	C18A3.3			gene	taxon:6239			
+WB	WBGene00015942	osta-2		C18A3.4	gene	taxon:6239			
+WB	WBGene00015943	tiar-1		C18A3.5	gene	taxon:6239			
+WB	WBGene00015945	C18A3.9			gene	taxon:6239			
+WB	WBGene00015946	C18A3.10			gene	taxon:6239			
+WB	WBGene00015949	C18A11.3			gene	taxon:6239			
+WB	WBGene00015952	C18B2.1			gene	taxon:6239			
+WB	WBGene00015953	C18B2.2			gene	taxon:6239			
+WB	WBGene00015954	C18B2.3			gene	taxon:6239			
+WB	WBGene00015955	C18B2.4			gene	taxon:6239			
+WB	WBGene00015957	del-9		C18B2.6	gene	taxon:6239			
+WB	WBGene00015958	srbc-11		C18B10.1	gene	taxon:6239			
+WB	WBGene00015959	srbc-10		C18B10.2	gene	taxon:6239			
+WB	WBGene00015960	srbc-9		C18B10.3	gene	taxon:6239			
+WB	WBGene00015961	srbc-7		C18B10.4	gene	taxon:6239			
+WB	WBGene00015962	srbc-8		C18B10.5	gene	taxon:6239			
+WB	WBGene00015964	glb-5		C18C4.1	gene	taxon:6239			
+WB	WBGene00015965	ugt-48		C18C4.3	gene	taxon:6239			
+WB	WBGene00015969	glb-6		C18C4.9	gene	taxon:6239			
+WB	WBGene00015971	swsn-2.2		C18E3.2	gene	taxon:6239			
+WB	WBGene00015975	cas-2		C18E3.6	gene	taxon:6239			
+WB	WBGene00015978	C18F10.7			gene	taxon:6239			
+WB	WBGene00015980	C18G1.1			gene	taxon:6239			
+WB	WBGene00015981	elt-7		C18G1.2	gene	taxon:6239			
+WB	WBGene00015982	bgnt-1.4		C18G1.3	gene	taxon:6239			
+WB	WBGene00015984	C18G1.6			gene	taxon:6239			
+WB	WBGene00015985	C18G1.7			gene	taxon:6239			
+WB	WBGene00015986	C18G1.8			gene	taxon:6239			
+WB	WBGene00015988	lido-18		C18H2.1	gene	taxon:6239			
+WB	WBGene00015992	C18H2.5			gene	taxon:6239			
+WB	WBGene00015993	C18H7.1			gene	taxon:6239			
+WB	WBGene00015994	C18H7.4			gene	taxon:6239			
+WB	WBGene00015996	C18H7.6			gene	taxon:6239			
+WB	WBGene00015998	srt-59		C18H7.8	gene	taxon:6239			
+WB	WBGene00016003	C18H9.5			gene	taxon:6239			
+WB	WBGene00016005	ift-74		C18H9.8	gene	taxon:6239			
+WB	WBGene00016006	fln-2		C23F12.1|flna-1|flnb-1	gene	taxon:6239			
+WB	WBGene00016010	C23G10.1			gene	taxon:6239			
+WB	WBGene00016013	ugt-66		C23G10.6	gene	taxon:6239			
+WB	WBGene00016014	C23G10.7			gene	taxon:6239			
+WB	WBGene00016016	C23G10.10			gene	taxon:6239			
+WB	WBGene00016018	C23H3.2			gene	taxon:6239			
+WB	WBGene00016019	ascc-1		C23H3.3	gene	taxon:6239			
+WB	WBGene00016020	sptl-1		C23H3.4	gene	taxon:6239			
+WB	WBGene00016024	glb-7		C23H5.2	gene	taxon:6239			
+WB	WBGene00016028	flp-24		C24A1.1	gene	taxon:6239			
+WB	WBGene00016029	elf-1		C24A1.2|W02B3.g	gene	taxon:6239			
+WB	WBGene00016030	sel-15		C24A1.3	gene	taxon:6239			
+WB	WBGene00016033	C24A3.2			gene	taxon:6239			
+WB	WBGene00016034	C24A3.4			gene	taxon:6239			
+WB	WBGene00016037	dop-6		C24A8.1	gene	taxon:6239			
+WB	WBGene00016038	cst-2		C24A8.4|tag-306	gene	taxon:6239			
+WB	WBGene00016044	C24B5.1			gene	taxon:6239			
+WB	WBGene00016045	spas-1		C24B5.2|C. elegans spastin	gene	taxon:6239			
+WB	WBGene00016046	C24B5.4			gene	taxon:6239			
+WB	WBGene00016049	srt-28		C24B9.4	gene	taxon:6239			
+WB	WBGene00016050	srt-29		C24B9.5	gene	taxon:6239			
+WB	WBGene00016051	srt-27		C24B9.6	gene	taxon:6239			
+WB	WBGene00016052	dod-3		C24B9.9	gene	taxon:6239			
+WB	WBGene00016053	ptp-5.1		C24D10.1	gene	taxon:6239			
+WB	WBGene00016054	C24D10.2			gene	taxon:6239			
+WB	WBGene00016055	C24D10.4			gene	taxon:6239			
+WB	WBGene00016056	C24D10.5			gene	taxon:6239			
+WB	WBGene00016057	C24D10.6			gene	taxon:6239			
+WB	WBGene00016059	hir-1		C24G6.2	gene	taxon:6239			
+WB	WBGene00016060	mms-19		C24G6.3	gene	taxon:6239			
+WB	WBGene00016061	hpo-15		C24G6.6	gene	taxon:6239			
+WB	WBGene00016062	C24G6.8			gene	taxon:6239			
+WB	WBGene00016063	delm-2		C24G7.1	gene	taxon:6239			
+WB	WBGene00016064	acd-1		C24G7.2	gene	taxon:6239			
+WB	WBGene00016066	acd-2		C24G7.4	gene	taxon:6239			
+WB	WBGene00016067	clc-7		C24H10.1	gene	taxon:6239			
+WB	WBGene00016071	C24H12.1			gene	taxon:6239			
+WB	WBGene00016073	C24H12.4			gene	taxon:6239			
+WB	WBGene00016074	dnsn-1		C24H12.5	gene	taxon:6239			
+WB	WBGene00016081	C25A6.1		C25A6.b	gene	taxon:6239			
+WB	WBGene00016083	C25A8.2			gene	taxon:6239			
+WB	WBGene00016084	cht-3		C25A8.4	gene	taxon:6239			
+WB	WBGene00016085	C25A8.5			gene	taxon:6239			
+WB	WBGene00016088	clec-266		C25B8.4	gene	taxon:6239			
+WB	WBGene00016089	aexr-1		C25B8.5	gene	taxon:6239			
+WB	WBGene00016090	aexr-2		C25B8.7|cup-13	gene	taxon:6239			
+WB	WBGene00016091	nhr-30		C25E10.1	gene	taxon:6239			
+WB	WBGene00016092	cyp-33B1		C25E10.2	gene	taxon:6239			
+WB	WBGene00016093	srsx-34		C25E10.3	gene	taxon:6239			
+WB	WBGene00016094	C25E10.4			gene	taxon:6239			
+WB	WBGene00016095	C25E10.5			gene	taxon:6239			
+WB	WBGene00016096	C25E10.7			gene	taxon:6239			
+WB	WBGene00016097	C25E10.8			gene	taxon:6239			
+WB	WBGene00016099	C25E10.10			gene	taxon:6239			
+WB	WBGene00016100	C25E10.11			gene	taxon:6239			
+WB	WBGene00016101	C25E10.12			gene	taxon:6239			
+WB	WBGene00016103	dpyd-1		C25F6.3	gene	taxon:6239			
+WB	WBGene00016104	ddr-1		C25F6.4	gene	taxon:6239			
+WB	WBGene00016106	C25F6.7			gene	taxon:6239			
+WB	WBGene00016110	npr-11		C25G6.5	gene	taxon:6239			
+WB	WBGene00016111	C25H3.1			gene	taxon:6239			
+WB	WBGene00016112	C25H3.3			gene	taxon:6239			
+WB	WBGene00016113	eif-2D		C25H3.4	gene	taxon:6239			
+WB	WBGene00016114	flp-27		C25H3.5	gene	taxon:6239			
+WB	WBGene00016115	mdt-26		C25H3.6	gene	taxon:6239			
+WB	WBGene00016118	C25H3.9			gene	taxon:6239			
+WB	WBGene00016120	C25H3.11			gene	taxon:6239			
+WB	WBGene00016121	ift-43		C25H3.12	gene	taxon:6239			
+WB	WBGene00016123	C25H3.14			gene	taxon:6239			
+WB	WBGene00016124	dnc-4		C26B2.1	gene	taxon:6239			
+WB	WBGene00016126	nhr-258		C26B2.4	gene	taxon:6239			
+WB	WBGene00016128	elpc-4		C26B2.6	gene	taxon:6239			
+WB	WBGene00016129	C26B2.7			gene	taxon:6239			
+WB	WBGene00016131	C26B9.1			gene	taxon:6239			
+WB	WBGene00016134	C26B9.5			gene	taxon:6239			
+WB	WBGene00016135	C26B9.6			gene	taxon:6239			
+WB	WBGene00016137	C26E6.1			gene	taxon:6239			
+WB	WBGene00016138	flh-2		C26E6.2	gene	taxon:6239			
+WB	WBGene00016139	ntl-9		C26E6.3	gene	taxon:6239			
+WB	WBGene00016140	rpb-2		C26E6.4|phi-14	gene	taxon:6239			
+WB	WBGene00016142	mrps-18C		C26E6.6|mrpl-18C	gene	taxon:6239			
+WB	WBGene00016144	mmab-1		C26E6.11|C26E6.a|tag-339	gene	taxon:6239			
+WB	WBGene00016145	C26E6.12			gene	taxon:6239			
+WB	WBGene00016147	cyp-32A1		C26F1.2	gene	taxon:6239			
+WB	WBGene00016149	frpr-3		C26F1.6	gene	taxon:6239			
+WB	WBGene00016150	hint-3		C26F1.7	gene	taxon:6239			
+WB	WBGene00016151	smc-5		C27A2.1	gene	taxon:6239			
+WB	WBGene00016154	szy-5		C27A12.2	gene	taxon:6239			
+WB	WBGene00016156	ari-1.3		C27A12.6	gene	taxon:6239			
+WB	WBGene00016157	ari-1.2		C27A12.7	gene	taxon:6239			
+WB	WBGene00016158	ari-1.1		C27A12.8|ari-1	gene	taxon:6239			
+WB	WBGene00016159	pigo-1		C27A12.9	gene	taxon:6239			
+WB	WBGene00016161	C27D6.3			gene	taxon:6239			
+WB	WBGene00016162	crh-2		C27D6.4	gene	taxon:6239			
+WB	WBGene00016163	C27D9.1			gene	taxon:6239			
+WB	WBGene00016164	C27D9.2			gene	taxon:6239			
+WB	WBGene00016166	C27F2.4			gene	taxon:6239			
+WB	WBGene00016167	vps-22		C27F2.5	gene	taxon:6239			
+WB	WBGene00016168	C27F2.6			gene	taxon:6239			
+WB	WBGene00016170	tmem-131		C27F2.8	gene	taxon:6239			
+WB	WBGene00016172	C27H5.2			gene	taxon:6239			
+WB	WBGene00016173	fust-1		C27H5.3	gene	taxon:6239			
+WB	WBGene00016174	mfsd-13.2		C27H5.4	gene	taxon:6239			
+WB	WBGene00016175	C27H5.6			gene	taxon:6239			
+WB	WBGene00016177	C28C12.1			gene	taxon:6239			
+WB	WBGene00016181	C28C12.11			gene	taxon:6239			
+WB	WBGene00016184	glb-9		C28F5.2	gene	taxon:6239			
+WB	WBGene00016187	C28G1.2			gene	taxon:6239			
+WB	WBGene00016188	sec-15		C28G1.3	gene	taxon:6239			
+WB	WBGene00016190	rcs-1		C28G1.5	gene	taxon:6239			
+WB	WBGene00016191	C28G1.6			gene	taxon:6239			
+WB	WBGene00016192	bcl-7		C28H8.1	gene	taxon:6239			
+WB	WBGene00016194	C28H8.3			gene	taxon:6239			
+WB	WBGene00016195	erd-2.2		C28H8.4	gene	taxon:6239			
+WB	WBGene00016197	pxl-1		C28H8.6|tag-327	gene	taxon:6239			
+WB	WBGene00016200	dpff-1		C28H8.9	gene	taxon:6239			
+WB	WBGene00016201	tdo-2		C28H8.11	gene	taxon:6239			
+WB	WBGene00016202	kle-2		C29E4.2|tag-258	gene	taxon:6239			
+WB	WBGene00016203	tag-250		C29E4.5	gene	taxon:6239			
+WB	WBGene00016204	gsto-1		C29E4.7	gene	taxon:6239			
+WB	WBGene00016207	C29E4.10			gene	taxon:6239			
+WB	WBGene00016210	C29F5.1			gene	taxon:6239			
+WB	WBGene00016215	glb-10		C29F5.7	gene	taxon:6239			
+WB	WBGene00016218	pals-23		C29F9.3	gene	taxon:6239			
+WB	WBGene00016220	C29F9.5			gene	taxon:6239			
+WB	WBGene00016221	C29F9.6			gene	taxon:6239			
+WB	WBGene00016222	C29F9.8			gene	taxon:6239			
+WB	WBGene00016232	srt-4		C29G2.4	gene	taxon:6239			
+WB	WBGene00016233	nhr-290		C29G2.5|srt-58	gene	taxon:6239			
+WB	WBGene00016234	C29G2.6			gene	taxon:6239			
+WB	WBGene00016235	C29H12.2			gene	taxon:6239			
+WB	WBGene00016236	heri-1		C29H12.5|cec-9	gene	taxon:6239			
+WB	WBGene00016238	mob-4		C30A5.3	gene	taxon:6239			
+WB	WBGene00016242	C30A5.10			gene	taxon:6239			
+WB	WBGene00016244	C30B5.2			gene	taxon:6239			
+WB	WBGene00016245	rbmx-2		C30B5.4	gene	taxon:6239			
+WB	WBGene00016246	daf-37		C30B5.5|frpr-20	gene	taxon:6239			
+WB	WBGene00016247	C30B5.6			gene	taxon:6239			
+WB	WBGene00016248	C30B5.7			gene	taxon:6239			
+WB	WBGene00016249	mrpl-32		C30C11.1	gene	taxon:6239			
+WB	WBGene00016250	hsp-110		C30C11.4	gene	taxon:6239			
+WB	WBGene00016253	C30E1.4			gene	taxon:6239			
+WB	WBGene00016258	vha-16		C30F8.2|C30F8.a|C30F8.b	gene	taxon:6239			
+WB	WBGene00016260	rege-1		C30F12.1	gene	taxon:6239			
+WB	WBGene00016261	C30F12.2			gene	taxon:6239			
+WB	WBGene00016262	C30F12.3			gene	taxon:6239			
+WB	WBGene00016264	C30F12.5			gene	taxon:6239			
+WB	WBGene00016265	trhr-1		C30F12.6|nmur-4	gene	taxon:6239			
+WB	WBGene00016266	idhg-2		C30F12.7	gene	taxon:6239			
+WB	WBGene00016269	C30G4.4			gene	taxon:6239			
+WB	WBGene00016274	C30G12.2			gene	taxon:6239			
+WB	WBGene00016279	C31B8.1			gene	taxon:6239			
+WB	WBGene00016282	C31B8.7			gene	taxon:6239			
+WB	WBGene00016283	zmp-3		C31B8.8	gene	taxon:6239			
+WB	WBGene00016284	C31B8.9			gene	taxon:6239			
+WB	WBGene00016285	C31B8.12			gene	taxon:6239			
+WB	WBGene00016287	C31H1.2			gene	taxon:6239			
+WB	WBGene00016288	C31H1.5			gene	taxon:6239			
+WB	WBGene00016289	lntl-1		C31H1.6	gene	taxon:6239			
+WB	WBGene00016292	tbc-7		C31H2.1	gene	taxon:6239			
+WB	WBGene00016294	C31H2.4			gene	taxon:6239			
+WB	WBGene00016300	C32B5.7			gene	taxon:6239			
+WB	WBGene00016306	C32B5.13			gene	taxon:6239			
+WB	WBGene00016313	set-4		C32D5.5|tag-337	gene	taxon:6239			
+WB	WBGene00016314	C32D5.6			gene	taxon:6239			
+WB	WBGene00016317	C32D5.10			gene	taxon:6239			
+WB	WBGene00016318	C32D5.11			gene	taxon:6239			
+WB	WBGene00016319	C32D5.12		phi-45	gene	taxon:6239			
+WB	WBGene00016320	C32E8.1			gene	taxon:6239			
+WB	WBGene00016325	C32E8.9			gene	taxon:6239			
+WB	WBGene00016326	ubr-1		C32E8.11	gene	taxon:6239			
+WB	WBGene00016328	pde-5		C32E12.2	gene	taxon:6239			
+WB	WBGene00016331	obr-4		C32F10.1	gene	taxon:6239			
+WB	WBGene00016332	C32F10.4			gene	taxon:6239			
+WB	WBGene00016333	C32F10.8			gene	taxon:6239			
+WB	WBGene00016335	gba-1		C33C12.3	gene	taxon:6239			
+WB	WBGene00016336	C33C12.4			gene	taxon:6239			
+WB	WBGene00016340	gba-2		C33C12.8	gene	taxon:6239			
+WB	WBGene00016341	mtq-2		C33C12.9	gene	taxon:6239			
+WB	WBGene00016343	cnnm-3		C33D12.2	gene	taxon:6239			
+WB	WBGene00016344	rsef-1		C33D12.6|tag-312	gene	taxon:6239			
+WB	WBGene00016352	tbck-1		C33F10.2	gene	taxon:6239			
+WB	WBGene00016354	rig-6		C33F10.5|tag-227	gene	taxon:6239			
+WB	WBGene00016356	C33F10.8			gene	taxon:6239			
+WB	WBGene00016357	C33F10.11			gene	taxon:6239			
+WB	WBGene00016358	C33F10.12			gene	taxon:6239			
+WB	WBGene00016363	srab-4		C33G8.5	gene	taxon:6239			
+WB	WBGene00016364	nhr-161		C33G8.7	gene	taxon:6239			
+WB	WBGene00016365	nhr-139		C33G8.8	gene	taxon:6239			
+WB	WBGene00016366	nhr-140		C33G8.9	gene	taxon:6239			
+WB	WBGene00016367	nhr-162		C33G8.10	gene	taxon:6239			
+WB	WBGene00016368	nhr-163		C33G8.12	gene	taxon:6239			
+WB	WBGene00016369	C33G8.13			gene	taxon:6239			
+WB	WBGene00016370	C33H5.1			gene	taxon:6239			
+WB	WBGene00016371	C33H5.2			gene	taxon:6239			
+WB	WBGene00016374	swd-2.2		C33H5.7	gene	taxon:6239			
+WB	WBGene00016376	sec-10		C33H5.9	gene	taxon:6239			
+WB	WBGene00016378	imp-3		C33H5.11	gene	taxon:6239			
+WB	WBGene00016379	C33H5.13			gene	taxon:6239			
+WB	WBGene00016380	ntp-1		C33H5.14	gene	taxon:6239			
+WB	WBGene00016381	sgo-1		C33H5.15	gene	taxon:6239			
+WB	WBGene00016382	C33H5.16			gene	taxon:6239			
+WB	WBGene00016383	zgpa-1		C33H5.17	gene	taxon:6239			
+WB	WBGene00016384	cdgs-1		C33H5.18	gene	taxon:6239			
+WB	WBGene00016387	kbp-5		C34B2.2	gene	taxon:6239			
+WB	WBGene00016388	C34B2.3			gene	taxon:6239			
+WB	WBGene00016389	C34B2.4			gene	taxon:6239			
+WB	WBGene00016391	lonp-1		C34B2.6|lon	gene	taxon:6239			
+WB	WBGene00016392	sdha-2		C34B2.7	gene	taxon:6239			
+WB	WBGene00016393	C34B2.8			gene	taxon:6239			
+WB	WBGene00016394	C34B2.9			gene	taxon:6239			
+WB	WBGene00016395	spcs-1		C34B2.10|phi-56	gene	taxon:6239			
+WB	WBGene00016396	C34B2.11			gene	taxon:6239			
+WB	WBGene00016397	maph-9		C34D4.1	gene	taxon:6239			
+WB	WBGene00016398	C34D4.2			gene	taxon:6239			
+WB	WBGene00016400	C34D4.4			gene	taxon:6239			
+WB	WBGene00016404	mutd-1		C34D4.13	gene	taxon:6239			
+WB	WBGene00016405	hecd-1		C34D4.14	gene	taxon:6239			
+WB	WBGene00016406	C34D10.1			gene	taxon:6239			
+WB	WBGene00016407	unk-1		C34D10.2	gene	taxon:6239			
+WB	WBGene00016408	prmt-5		C34E10.5|tag-251	gene	taxon:6239			
+WB	WBGene00016409	sumv-1		C34E10.8	gene	taxon:6239			
+WB	WBGene00016411	C34E10.10			gene	taxon:6239			
+WB	WBGene00016412	mrps-26		C34E10.11	gene	taxon:6239			
+WB	WBGene00016413	C34F11.1			gene	taxon:6239			
+WB	WBGene00016415	ampd-1		C34F11.3	gene	taxon:6239			
+WB	WBGene00016416	C34F11.5			gene	taxon:6239			
+WB	WBGene00016419	tyr-4		C34G6.2	gene	taxon:6239			
+WB	WBGene00016421	cdc-7		C34G6.5	gene	taxon:6239			
+WB	WBGene00016422	noah-1		C34G6.6	gene	taxon:6239			
+WB	WBGene00016423	tag-275		C34H3.1	gene	taxon:6239			
+WB	WBGene00016424	C34H4.1			gene	taxon:6239			
+WB	WBGene00016428	dmsr-7		C35A11.1	gene	taxon:6239			
+WB	WBGene00016431	C35A11.4			gene	taxon:6239			
+WB	WBGene00016433	C35B1.3			gene	taxon:6239			
+WB	WBGene00016439	C35D10.1			gene	taxon:6239			
+WB	WBGene00016441	C35D10.3			gene	taxon:6239			
+WB	WBGene00016443	C35D10.6			gene	taxon:6239			
+WB	WBGene00016445	C35D10.8			gene	taxon:6239			
+WB	WBGene00016446	C35D10.10		C35D10.f	gene	taxon:6239			
+WB	WBGene00016447	msd-4		C35D10.11	gene	taxon:6239			
+WB	WBGene00016448	C35D10.12			gene	taxon:6239			
+WB	WBGene00016449	tost-1		C35D10.13	gene	taxon:6239			
+WB	WBGene00016450	clec-5		C35D10.14	gene	taxon:6239			
+WB	WBGene00016451	clec-6		C35D10.15	gene	taxon:6239			
+WB	WBGene00016452	C35D10.17			gene	taxon:6239			
+WB	WBGene00016453	vet-2		C35E7.1	gene	taxon:6239			
+WB	WBGene00016454	C35E7.2			gene	taxon:6239			
+WB	WBGene00016455	C35E7.3			gene	taxon:6239			
+WB	WBGene00016456	C35E7.4			gene	taxon:6239			
+WB	WBGene00016457	C35E7.5			gene	taxon:6239			
+WB	WBGene00016458	C35E7.6			gene	taxon:6239			
+WB	WBGene00016460	C35E7.8			gene	taxon:6239			
+WB	WBGene00016461	C35E7.9			gene	taxon:6239			
+WB	WBGene00016462	C35E7.10			gene	taxon:6239			
+WB	WBGene00016464	C36B7.1			gene	taxon:6239			
+WB	WBGene00016465	C36B7.2			gene	taxon:6239			
+WB	WBGene00016466	C36B7.3			gene	taxon:6239			
+WB	WBGene00016467	C36B7.4		Y1B5A.a	gene	taxon:6239			
+WB	WBGene00016469	C36B7.6			gene	taxon:6239			
+WB	WBGene00016471	srab-8		C36C5.2	gene	taxon:6239			
+WB	WBGene00016472	srbc-6		C36C5.3	gene	taxon:6239			
+WB	WBGene00016475	srab-9		C36C5.6	gene	taxon:6239			
+WB	WBGene00016476	srab-10		C36C5.7	gene	taxon:6239			
+WB	WBGene00016477	srab-11		C36C5.8	gene	taxon:6239			
+WB	WBGene00016479	srab-6		C36C5.10	gene	taxon:6239			
+WB	WBGene00016480	srab-7		C36C5.11	gene	taxon:6239			
+WB	WBGene00016481	C36C5.12			gene	taxon:6239			
+WB	WBGene00016485	meg-4		C36C9.1	gene	taxon:6239			
+WB	WBGene00016489	fubl-3		C36E6.1|fubl-3.3|fubp-3.3	gene	taxon:6239			
+WB	WBGene00016491	acdh-5		C37A2.3	gene	taxon:6239			
+WB	WBGene00016492	C37A2.6			gene	taxon:6239			
+WB	WBGene00016493	C37A2.7			gene	taxon:6239			
+WB	WBGene00016494	C37A2.8			gene	taxon:6239			
+WB	WBGene00016496	C37C3.2		phi-18	gene	taxon:6239			
+WB	WBGene00016499	txt-5		C37C3.7	gene	taxon:6239			
+WB	WBGene00016503	C37C3.11			gene	taxon:6239			
+WB	WBGene00016504	C37C3.12			gene	taxon:6239			
+WB	WBGene00016505	ttr-33		C37C3.13	gene	taxon:6239			
+WB	WBGene00016507	abhd-5.2		C37H5.3|C37H5.m|cgi-58	gene	taxon:6239			
+WB	WBGene00016508	C37H5.5			gene	taxon:6239			
+WB	WBGene00016509	adss-1		C37H5.6	gene	taxon:6239			
+WB	WBGene00016511	C37H5.13			gene	taxon:6239			
+WB	WBGene00016513	C38C3.4			gene	taxon:6239			
+WB	WBGene00016514	C38C3.6			gene	taxon:6239			
+WB	WBGene00016517	nhr-260		C38C3.9	gene	taxon:6239			
+WB	WBGene00016519	srz-56		C39B5.1	gene	taxon:6239			
+WB	WBGene00016523	C39B5.5			gene	taxon:6239			
+WB	WBGene00016524	C39B5.6			gene	taxon:6239			
+WB	WBGene00016531	pcyt-2.2		C39D10.3	gene	taxon:6239			
+WB	WBGene00016533	C39D10.6			gene	taxon:6239			
+WB	WBGene00016534	C39D10.7			gene	taxon:6239			
+WB	WBGene00016538	C39F7.1			gene	taxon:6239			
+WB	WBGene00016539	madd-2		C39F7.2|rax-1|trim-9|Y50D4A.a	gene	taxon:6239			
+WB	WBGene00016540	C39F7.5			gene	taxon:6239			
+WB	WBGene00016541	C39H7.1			gene	taxon:6239			
+WB	WBGene00016542	C39H7.4			gene	taxon:6239			
+WB	WBGene00016543	srsx-14		C39H7.5	gene	taxon:6239			
+WB	WBGene00016545	C40A11.2			gene	taxon:6239			
+WB	WBGene00016546	C40A11.3			gene	taxon:6239			
+WB	WBGene00016547	C40A11.4			gene	taxon:6239			
+WB	WBGene00016548	hpo-7		C40A11.5	gene	taxon:6239			
+WB	WBGene00016549	C40A11.6			gene	taxon:6239			
+WB	WBGene00016550	C40A11.7			gene	taxon:6239			
+WB	WBGene00016551	C40A11.8			gene	taxon:6239			
+WB	WBGene00016557	ceh-84		C40D2.4	gene	taxon:6239			
+WB	WBGene00016558	pks-1		C41A3.1	gene	taxon:6239			
+WB	WBGene00016562	C41D11.3			gene	taxon:6239			
+WB	WBGene00016565	sosi-1		C41D11.6	gene	taxon:6239			
+WB	WBGene00016566	eri-7		C41D11.7	gene	taxon:6239			
+WB	WBGene00016567	C41D11.9			gene	taxon:6239			
+WB	WBGene00016568	C41G11.1			gene	taxon:6239			
+WB	WBGene00016570	gnrr-4		C41G11.4	gene	taxon:6239			
+WB	WBGene00016577	clec-3		C41H7.7	gene	taxon:6239			
+WB	WBGene00016579	sre-14		C42C1.1	gene	taxon:6239			
+WB	WBGene00016580	ppm-1.H		C42C1.2	gene	taxon:6239			
+WB	WBGene00016583	tag-335		C42C1.5	gene	taxon:6239			
+WB	WBGene00016585	oac-59		C42C1.7	gene	taxon:6239			
+WB	WBGene00016586	C42C1.8			gene	taxon:6239			
+WB	WBGene00016588	hpo-12		C42C1.10	gene	taxon:6239			
+WB	WBGene00016589	ltah-1.1		C42C1.11|AP-1|cm01c7	gene	taxon:6239			
+WB	WBGene00016591	C42C1.13			gene	taxon:6239			
+WB	WBGene00016592	erl-1		C42C1.15	gene	taxon:6239			
+WB	WBGene00016595	cest-10		C42D4.2	gene	taxon:6239			
+WB	WBGene00016597	clec-179		C42D4.11	gene	taxon:6239			
+WB	WBGene00016599	C42D8.1			gene	taxon:6239			
+WB	WBGene00016600	ets-5		C42D8.4	gene	taxon:6239			
+WB	WBGene00016601	acin-1		C43E11.1	gene	taxon:6239			
+WB	WBGene00016602	mus-81		C43E11.2	gene	taxon:6239			
+WB	WBGene00016603	met-1		C43E11.3	gene	taxon:6239			
+WB	WBGene00016605	C43E11.5			gene	taxon:6239			
+WB	WBGene00016606	exoc-7		C43E11.8	gene	taxon:6239			
+WB	WBGene00016607	C43E11.9			gene	taxon:6239			
+WB	WBGene00016608	cogc-5		C43E11.11	gene	taxon:6239			
+WB	WBGene00016610	paqr-1		C43G2.1	gene	taxon:6239			
+WB	WBGene00016611	bicd-1		C43G2.2	gene	taxon:6239			
+WB	WBGene00016613	best-9		C43G2.4	gene	taxon:6239			
+WB	WBGene00016619	C43H6.6			gene	taxon:6239			
+WB	WBGene00016620	dhhc-9		C43H6.7	gene	taxon:6239			
+WB	WBGene00016621	arch-1		C43H8.1	gene	taxon:6239			
+WB	WBGene00016622	mafr-1		C43H8.2	gene	taxon:6239			
+WB	WBGene00016623	psmd-9		C44B7.1	gene	taxon:6239			
+WB	WBGene00016624	hrpl-1		C44B7.2	gene	taxon:6239			
+WB	WBGene00016625	aff-1		C44B7.3	gene	taxon:6239			
+WB	WBGene00016626	clhm-1		C44B7.4	gene	taxon:6239			
+WB	WBGene00016627	C44B7.5			gene	taxon:6239			
+WB	WBGene00016628	slc-36.5		C44B7.6	gene	taxon:6239			
+WB	WBGene00016629	C44B7.7			gene	taxon:6239			
+WB	WBGene00016630	acer-1		C44B7.10	gene	taxon:6239			
+WB	WBGene00016631	C44B7.11			gene	taxon:6239			
+WB	WBGene00016632	adal-1		C44B7.12	gene	taxon:6239			
+WB	WBGene00016633	C44B11.1			gene	taxon:6239			
+WB	WBGene00016639	C44B12.6			gene	taxon:6239			
+WB	WBGene00016641	C44C1.1			gene	taxon:6239			
+WB	WBGene00016642	chil-10		C44C1.2	gene	taxon:6239			
+WB	WBGene00016643	vps-45		C44C1.4	gene	taxon:6239			
+WB	WBGene00016644	abhd-3.2		C44C1.5	gene	taxon:6239			
+WB	WBGene00016650	ubr-4		C44E4.1	gene	taxon:6239			
+WB	WBGene00016652	got-2.1		C44E4.3	gene	taxon:6239			
+WB	WBGene00016653	ssb-1		C44E4.4	gene	taxon:6239			
+WB	WBGene00016654	C44E4.5			gene	taxon:6239			
+WB	WBGene00016655	acbp-1		C44E4.6	gene	taxon:6239			
+WB	WBGene00016657	C44E12.1			gene	taxon:6239			
+WB	WBGene00016661	C45B2.6			gene	taxon:6239			
+WB	WBGene00016664	C45E5.1			gene	taxon:6239			
+WB	WBGene00016665	chil-11		C45E5.2	gene	taxon:6239			
+WB	WBGene00016668	ilys-1		C45G7.1	gene	taxon:6239			
+WB	WBGene00016669	ilys-2		C45G7.2	gene	taxon:6239			
+WB	WBGene00016670	ilys-3		C45G7.3	gene	taxon:6239			
+WB	WBGene00016671	C45G7.4			gene	taxon:6239			
+WB	WBGene00016673	ttbk-6		C45G9.1	gene	taxon:6239			
+WB	WBGene00016674	C45G9.2			gene	taxon:6239			
+WB	WBGene00016678	txbp-3		C45G9.7	gene	taxon:6239			
+WB	WBGene00016684	nlp-43		C45G9.13	gene	taxon:6239			
+WB	WBGene00016685	srbc-16		C45H4.1	gene	taxon:6239			
+WB	WBGene00016686	cyp-33C1		C45H4.2	gene	taxon:6239			
+WB	WBGene00016687	srbc-17		C45H4.3	gene	taxon:6239			
+WB	WBGene00016689	srbc-21		C45H4.7	gene	taxon:6239			
+WB	WBGene00016690	srbc-22		C45H4.8	gene	taxon:6239			
+WB	WBGene00016691	srbc-23		C45H4.9	gene	taxon:6239			
+WB	WBGene00016692	srbc-24		C45H4.10	gene	taxon:6239			
+WB	WBGene00016693	srbc-20		C45H4.11	gene	taxon:6239			
+WB	WBGene00016696	srbc-19		C45H4.16	gene	taxon:6239			
+WB	WBGene00016697	cyp-33C2		C45H4.17|Y5H2B.f	gene	taxon:6239			
+WB	WBGene00016698	C46A5.1			gene	taxon:6239			
+WB	WBGene00016699	del-7		C46A5.2	gene	taxon:6239			
+WB	WBGene00016700	C46A5.4			gene	taxon:6239			
+WB	WBGene00016704	hosl-1		C46C11.1	gene	taxon:6239			
+WB	WBGene00016705	slcr-46.1		C46C11.2	gene	taxon:6239			
+WB	WBGene00016706	C46C11.3			gene	taxon:6239			
+WB	WBGene00016711	fbxc-53		C46E10.5	gene	taxon:6239			
+WB	WBGene00016716	acs-17		C46F4.2|dod-9	gene	taxon:6239			
+WB	WBGene00016721	C46G7.1			gene	taxon:6239			
+WB	WBGene00016722	C46G7.2			gene	taxon:6239			
+WB	WBGene00016728	C46H11.2			gene	taxon:6239			
+WB	WBGene00016729	C46H11.3			gene	taxon:6239			
+WB	WBGene00016732	phat-1		C46H11.8	gene	taxon:6239			
+WB	WBGene00016733	phat-2		C46H11.9	gene	taxon:6239			
+WB	WBGene00016739	pitr-1		C48A7.2|rme-10	gene	taxon:6239			
+WB	WBGene00016740	C48B6.2			gene	taxon:6239			
+WB	WBGene00016742	C48B6.4			gene	taxon:6239			
+WB	WBGene00016743	srb-15		C48B6.5	gene	taxon:6239			
+WB	WBGene00016744	bbs-9		C48B6.8	gene	taxon:6239			
+WB	WBGene00016745	C48B6.9		T10B11.g	gene	taxon:6239			
+WB	WBGene00016746	C48B6.10			gene	taxon:6239			
+WB	WBGene00016747	nmur-1		C48C5.1	gene	taxon:6239			
+WB	WBGene00016748	aexr-3		C48C5.3	gene	taxon:6239			
+WB	WBGene00016749	C48E7.1			gene	taxon:6239			
+WB	WBGene00016750	let-611		C48E7.2	gene	taxon:6239			
+WB	WBGene00016751	C48E7.6			gene	taxon:6239			
+WB	WBGene00016753	oac-9		C48E7.8	gene	taxon:6239			
+WB	WBGene00016754	cebp-2		C48E7.11	gene	taxon:6239			
+WB	WBGene00016761	tkr-2		C49A9.7	gene	taxon:6239			
+WB	WBGene00016762	ugt-24		C49A9.8	gene	taxon:6239			
+WB	WBGene00016765	C49C8.1			gene	taxon:6239			
+WB	WBGene00016766	C49C8.2			gene	taxon:6239			
+WB	WBGene00016768	cyp-33E1		C49C8.4	gene	taxon:6239			
+WB	WBGene00016769	C49C8.5			gene	taxon:6239			
+WB	WBGene00016772	nhr-166		C49D10.2	gene	taxon:6239			
+WB	WBGene00016773	oac-10		C49D10.4	gene	taxon:6239			
+WB	WBGene00016776	oac-11		C49D10.8	gene	taxon:6239			
+WB	WBGene00016777	nhr-261		C49D10.9	gene	taxon:6239			
+WB	WBGene00016778	nep-3		C49D10.10	gene	taxon:6239			
+WB	WBGene00016782	phat-3		C49G7.4|CEMSE03	gene	taxon:6239			
+WB	WBGene00016783	irg-2		C49G7.5	gene	taxon:6239			
+WB	WBGene00016786	cyp-35A4		C49G7.8	gene	taxon:6239			
+WB	WBGene00016788	C49G7.10			gene	taxon:6239			
+WB	WBGene00016789	djr-1.2		C49G7.11	gene	taxon:6239			
+WB	WBGene00016791	C49H3.4			gene	taxon:6239			
+WB	WBGene00016792	C49H3.6			gene	taxon:6239			
+WB	WBGene00016793	arp-11		C49H3.8	gene	taxon:6239			
+WB	WBGene00016794	C49H3.9			gene	taxon:6239			
+WB	WBGene00016797	C50A2.3			gene	taxon:6239			
+WB	WBGene00016798	ets-8		C50A2.4	gene	taxon:6239			
+WB	WBGene00016799	C50C3.1			gene	taxon:6239			
+WB	WBGene00016800	C50C3.2			gene	taxon:6239			
+WB	WBGene00016801	C50C3.5			gene	taxon:6239			
+WB	WBGene00016803	bath-42		C50C3.8	gene	taxon:6239			
+WB	WBGene00016806	C50D2.2			gene	taxon:6239			
+WB	WBGene00016808	sftb-6		C50D2.5	gene	taxon:6239			
+WB	WBGene00016810	C50D2.7			gene	taxon:6239			
+WB	WBGene00016811	luc-7L3		C50D2.8	gene	taxon:6239			
+WB	WBGene00016812	C50D2.9			gene	taxon:6239			
+WB	WBGene00016813	clec-214		C50E3.1	gene	taxon:6239			
+WB	WBGene00016815	clec-213		C50E3.3	gene	taxon:6239			
+WB	WBGene00016818	C50E3.7			gene	taxon:6239			
+WB	WBGene00016820	C50E3.9			gene	taxon:6239			
+WB	WBGene00016827	sre-53		C50E10.3	gene	taxon:6239			
+WB	WBGene00016828	sre-52		C50E10.5	gene	taxon:6239			
+WB	WBGene00016829	sre-54		C50E10.6	gene	taxon:6239			
+WB	WBGene00016830	sre-55		C50E10.7	gene	taxon:6239			
+WB	WBGene00016831	sre-56		C50E10.8	gene	taxon:6239			
+WB	WBGene00016832	sre-49		C50E10.9	gene	taxon:6239			
+WB	WBGene00016833	sre-51		C50E10.10	gene	taxon:6239			
+WB	WBGene00016834	sre-50		C50E10.11	gene	taxon:6239			
+WB	WBGene00016837	syf-1		C50F2.3|phi-4	gene	taxon:6239			
+WB	WBGene00016839	C50F2.5			gene	taxon:6239			
+WB	WBGene00016840	C50F2.7			gene	taxon:6239			
+WB	WBGene00016841	magu-3		C50F2.8	gene	taxon:6239			
+WB	WBGene00016842	npr-35		C50F7.1	gene	taxon:6239			
+WB	WBGene00016844	sucg-1		C50F7.4	gene	taxon:6239			
+WB	WBGene00016847	C50F7.9			gene	taxon:6239			
+WB	WBGene00016848	klo-1		C50F7.10	gene	taxon:6239			
+WB	WBGene00016850	srt-8		C50H11.2	gene	taxon:6239			
+WB	WBGene00016852	srt-7		C50H11.4	gene	taxon:6239			
+WB	WBGene00016856	srt-15		C50H11.10	gene	taxon:6239			
+WB	WBGene00016857	srt-16		C50H11.11	gene	taxon:6239			
+WB	WBGene00016858	C50H11.13			gene	taxon:6239			
+WB	WBGene00016859	srt-5		C50H11.14	gene	taxon:6239			
+WB	WBGene00016860	cyp-33C9		C50H11.15	gene	taxon:6239			
+WB	WBGene00016862	cest-32		C52A10.1	gene	taxon:6239			
+WB	WBGene00016863	cest-35.2		C52A10.2	gene	taxon:6239			
+WB	WBGene00016865	ets-9		C52B9.2	gene	taxon:6239			
+WB	WBGene00016867	C52B9.4			gene	taxon:6239			
+WB	WBGene00016868	C52B9.8			gene	taxon:6239			
+WB	WBGene00016871	inso-1		C52B11.2|tag-303	gene	taxon:6239			
+WB	WBGene00016872	dop-4		C52B11.3	gene	taxon:6239			
+WB	WBGene00016874	C52B11.5			gene	taxon:6239			
+WB	WBGene00016879	cnnm-1		C52D10.12	gene	taxon:6239			
+WB	WBGene00016886	fbxb-96		C52E2.7	gene	taxon:6239			
+WB	WBGene00016888	znf-598		C52E12.1	gene	taxon:6239			
+WB	WBGene00016889	lst-6		C52E12.4	gene	taxon:6239			
+WB	WBGene00016892	pgph-3		C53A3.2	gene	taxon:6239			
+WB	WBGene00016893	C53B7.2			gene	taxon:6239			
+WB	WBGene00016896	nep-4		C53B7.7	gene	taxon:6239			
+WB	WBGene00016900	C53C11.2			gene	taxon:6239			
+WB	WBGene00016902	C53D5.1			gene	taxon:6239			
+WB	WBGene00016903	marc-4		C53D5.2	gene	taxon:6239			
+WB	WBGene00016905	ztf-3		C53D5.4	gene	taxon:6239			
+WB	WBGene00016906	C53D5.5			gene	taxon:6239			
+WB	WBGene00016907	C53H9.2			gene	taxon:6239			
+WB	WBGene00016909	frpr-4		C54A12.2	gene	taxon:6239			
+WB	WBGene00016911	drn-1		C54A12.4	gene	taxon:6239			
+WB	WBGene00016912	clec-86		C54D1.2	gene	taxon:6239			
+WB	WBGene00016913	lam-2		C54D1.5	gene	taxon:6239			
+WB	WBGene00016918	test-1		C54E4.2	gene	taxon:6239			
+WB	WBGene00016919	C54E4.4			gene	taxon:6239			
+WB	WBGene00016920	C54E4.5			gene	taxon:6239			
+WB	WBGene00016921	C54F6.3			gene	taxon:6239			
+WB	WBGene00016922	swt-2		C54F6.4	gene	taxon:6239			
+WB	WBGene00016925	srb-18		C54F6.7	gene	taxon:6239			
+WB	WBGene00016926	nhr-171		C54F6.8	gene	taxon:6239			
+WB	WBGene00016927	nhr-172		C54F6.9	gene	taxon:6239			
+WB	WBGene00016928	srb-19		C54F6.11	gene	taxon:6239			
+WB	WBGene00016931	C54G6.2		C54G6.c	gene	taxon:6239			
+WB	WBGene00016932	C54G6.3		C54G6.b|C54G6.c	gene	taxon:6239			
+WB	WBGene00016934	mboa-3		C54G7.2	gene	taxon:6239			
+WB	WBGene00016935	ifta-1		C54G7.4|ift-121	gene	taxon:6239			
+WB	WBGene00016937	tag-294		C54H2.3	gene	taxon:6239			
+WB	WBGene00016939	C55B6.1			gene	taxon:6239			
+WB	WBGene00016942	C55B7.3			gene	taxon:6239			
+WB	WBGene00016943	acdh-1		C55B7.4|dod-12	gene	taxon:6239			
+WB	WBGene00016944	uri-1		C55B7.5	gene	taxon:6239			
+WB	WBGene00016945	sulp-1		C55B7.6	gene	taxon:6239			
+WB	WBGene00016946	C55B7.10			gene	taxon:6239			
+WB	WBGene00016949	C55C2.3			gene	taxon:6239			
+WB	WBGene00016950	C55C2.4			gene	taxon:6239			
+WB	WBGene00016951	C55C3.1			gene	taxon:6239			
+WB	WBGene00016953	C55C3.3			gene	taxon:6239			
+WB	WBGene00016954	C55C3.4			gene	taxon:6239			
+WB	WBGene00016955	perm-5		C55C3.5	gene	taxon:6239			
+WB	WBGene00016956	C55C3.6			gene	taxon:6239			
+WB	WBGene00016957	atic-1		C55F2.1	gene	taxon:6239			
+WB	WBGene00016958	ilys-4		C55F2.2	gene	taxon:6239			
+WB	WBGene00016960	vps-33.2		C56C10.1	gene	taxon:6239			
+WB	WBGene00016961	vps-32.1		C56C10.3|phi-27|tag-309	gene	taxon:6239			
+WB	WBGene00016963	C56C10.6			gene	taxon:6239			
+WB	WBGene00016965	C56C10.9			gene	taxon:6239			
+WB	WBGene00016968	epg-5		C56C10.12	gene	taxon:6239			
+WB	WBGene00016970	C56E6.2		C56E6.f	gene	taxon:6239			
+WB	WBGene00016971	toe-2		C56E6.3	gene	taxon:6239			
+WB	WBGene00016972	C56E6.4			gene	taxon:6239			
+WB	WBGene00016973	abch-1		C56E6.5	gene	taxon:6239			
+WB	WBGene00016975	nhr-173		C56E10.1	gene	taxon:6239			
+WB	WBGene00016977	akap-1		C56G2.1	gene	taxon:6239			
+WB	WBGene00016978	C56G2.3			gene	taxon:6239			
+WB	WBGene00016980	C56G2.5		F47D12.a	gene	taxon:6239			
+WB	WBGene00016981	rpn-13		C56G2.7	gene	taxon:6239			
+WB	WBGene00016983	C56G2.15			gene	taxon:6239			
+WB	WBGene00016984	npr-8		C56G3.1	gene	taxon:6239			
+WB	WBGene00016985	C56G3.2			gene	taxon:6239			
+WB	WBGene00016987	CC8.2		CC8.a	gene	taxon:6239			
+WB	WBGene00016988	CD4.1			gene	taxon:6239			
+WB	WBGene00016989	mrpl-48		CD4.3	gene	taxon:6239			
+WB	WBGene00016990	vps-37		CD4.4	gene	taxon:6239			
+WB	WBGene00016992	zhit-1		CD4.7	gene	taxon:6239			
+WB	WBGene00016995	acly-1		D1005.1	gene	taxon:6239			
+WB	WBGene00016996	D1005.2			gene	taxon:6239			
+WB	WBGene00016997	cebp-1		D1005.3|svh-8	gene	taxon:6239			
+WB	WBGene00016998	D1005.4			gene	taxon:6239			
+WB	WBGene00017001	D1007.3			gene	taxon:6239			
+WB	WBGene00017002	D1007.4			gene	taxon:6239			
+WB	WBGene00017003	tmem-39		D1007.5	gene	taxon:6239			
+WB	WBGene00017004	nrd-1		D1007.7	gene	taxon:6239			
+WB	WBGene00017007	D1007.10			gene	taxon:6239			
+WB	WBGene00017010	D1007.15		Y119C1B.k	gene	taxon:6239			
+WB	WBGene00017011	eaf-1		D1007.16	gene	taxon:6239			
+WB	WBGene00017012	acs-22		D1009.1	gene	taxon:6239			
+WB	WBGene00017013	ensh-1		D1009.3	gene	taxon:6239			
+WB	WBGene00017014	dylt-2		D1009.5|xbx-2	gene	taxon:6239			
+WB	WBGene00017015	D1014.2			gene	taxon:6239			
+WB	WBGene00017016	snap-1		D1014.3|phi-29	gene	taxon:6239			
+WB	WBGene00017018	D1014.5			gene	taxon:6239			
+WB	WBGene00017019	D1014.6			gene	taxon:6239			
+WB	WBGene00017020	D1014.7			gene	taxon:6239			
+WB	WBGene00017022	D1022.3			gene	taxon:6239			
+WB	WBGene00017023	D1022.4			gene	taxon:6239			
+WB	WBGene00017024	D1022.5			gene	taxon:6239			
+WB	WBGene00017025	D1037.1			gene	taxon:6239			
+WB	WBGene00017026	ipla-4		D1037.5	gene	taxon:6239			
+WB	WBGene00017027	D1044.1			gene	taxon:6239			
+WB	WBGene00017028	dex-1		D1044.2	gene	taxon:6239			
+WB	WBGene00017033	nekl-4		D1044.8	gene	taxon:6239			
+WB	WBGene00017034	otpl-2		D1065.1	gene	taxon:6239			
+WB	WBGene00017036	D1069.1			gene	taxon:6239			
+WB	WBGene00017037	D1069.3			gene	taxon:6239			
+WB	WBGene00017038	dmsr-4		D1069.4	gene	taxon:6239			
+WB	WBGene00017039	trk-1		D1073.1	gene	taxon:6239			
+WB	WBGene00017040	D1079.1			gene	taxon:6239			
+WB	WBGene00017041	D2007.1			gene	taxon:6239			
+WB	WBGene00017042	D2007.2			gene	taxon:6239			
+WB	WBGene00017044	mrpl-18		D2007.4	gene	taxon:6239			
+WB	WBGene00017045	atg-13		D2007.5|epg-1	gene	taxon:6239			
+WB	WBGene00017046	utx-1		D2021.1	gene	taxon:6239			
+WB	WBGene00017048	D2021.4			gene	taxon:6239			
+WB	WBGene00017050	D2024.1			gene	taxon:6239			
+WB	WBGene00017051	afmd-1		D2024.2	gene	taxon:6239			
+WB	WBGene00017053	D2024.5			gene	taxon:6239			
+WB	WBGene00017054	gstk-2		D2024.7	gene	taxon:6239			
+WB	WBGene00017056	D2062.4			gene	taxon:6239			
+WB	WBGene00017057	D2062.5			gene	taxon:6239			
+WB	WBGene00017059	msrp-5		D2062.7	gene	taxon:6239			
+WB	WBGene00017060	D2063.1		D2063.e	gene	taxon:6239			
+WB	WBGene00017061	oac-12		D2063.2	gene	taxon:6239			
+WB	WBGene00017062	glrx-3		D2063.3	gene	taxon:6239			
+WB	WBGene00017063	mctp-1		D2092.1	gene	taxon:6239			
+WB	WBGene00017064	ppfr-2		D2092.2	gene	taxon:6239			
+WB	WBGene00017065	D2092.4			gene	taxon:6239			
+WB	WBGene00017066	maco-1		D2092.5	gene	taxon:6239			
+WB	WBGene00017070	praf-3		D2096.2	gene	taxon:6239			
+WB	WBGene00017071	aagr-1		D2096.3	gene	taxon:6239			
+WB	WBGene00017073	D2096.6			gene	taxon:6239			
+WB	WBGene00017075	nap-1		D2096.8|nsbp-1	gene	taxon:6239			
+WB	WBGene00017078	D2096.11			gene	taxon:6239			
+WB	WBGene00017080	lec-12		DC2.3	gene	taxon:6239			
+WB	WBGene00017082	DC2.5			gene	taxon:6239			
+WB	WBGene00017083	kin-33		DC2.7	gene	taxon:6239			
+WB	WBGene00017084	E01A2.1			gene	taxon:6239			
+WB	WBGene00017085	E01A2.2			gene	taxon:6239			
+WB	WBGene00017087	dph-6		E01A2.5	gene	taxon:6239			
+WB	WBGene00017088	akir-1		E01A2.6	gene	taxon:6239			
+WB	WBGene00017089	poml-2		E01A2.7	gene	taxon:6239			
+WB	WBGene00017091	ttr-40		E02C12.4	gene	taxon:6239			
+WB	WBGene00017098	mek-5		E02D9.1|C37A2.a	gene	taxon:6239			
+WB	WBGene00017103	klo-2		E02H9.5	gene	taxon:6239			
+WB	WBGene00017104	E02H9.6			gene	taxon:6239			
+WB	WBGene00017107	srt-12		E03D2.4	gene	taxon:6239			
+WB	WBGene00017108	cyp-43A1		E03E2.1	gene	taxon:6239			
+WB	WBGene00017110	clec-176		E03H12.3	gene	taxon:6239			
+WB	WBGene00017113	srz-24		E03H12.6	gene	taxon:6239			
+WB	WBGene00017114	E03H12.7			gene	taxon:6239			
+WB	WBGene00017119	timm-17B.1		E04A4.5|tim-17|TIM17|timm-17	gene	taxon:6239			
+WB	WBGene00017120	tctn-1		E04A4.6	gene	taxon:6239			
+WB	WBGene00017121	cyc-2.1		E04A4.7	gene	taxon:6239			
+WB	WBGene00017123	maoc-1		E04F6.3	gene	taxon:6239			
+WB	WBGene00017124	E04F6.4			gene	taxon:6239			
+WB	WBGene00017125	acdh-12		E04F6.5	gene	taxon:6239			
+WB	WBGene00017129	E04F6.10			gene	taxon:6239			
+WB	WBGene00017131	E04F6.15			gene	taxon:6239			
+WB	WBGene00017132	tofu-6		EEED8.1|mel-2|mel-47	gene	taxon:6239			
+WB	WBGene00017133	EEED8.2			gene	taxon:6239			
+WB	WBGene00017135	EEED8.4			gene	taxon:6239			
+WB	WBGene00017136	ccpp-6		EEED8.6|CCP homologue|F09E5.a|Nnac2	gene	taxon:6239			
+WB	WBGene00017137	pink-1		EEED8.9	gene	taxon:6239			
+WB	WBGene00017138	EEED8.10			gene	taxon:6239			
+WB	WBGene00017140	EEED8.12			gene	taxon:6239			
+WB	WBGene00017144	brap-2		EEED8.16	gene	taxon:6239			
+WB	WBGene00017149	EGAP4.1			gene	taxon:6239			
+WB	WBGene00017151	EGAP9.3			gene	taxon:6239			
+WB	WBGene00017153	E_BE45912.2			gene	taxon:6239			
+WB	WBGene00017154	ugt-57		F01E11.1	gene	taxon:6239			
+WB	WBGene00017156	F01E11.3			gene	taxon:6239			
+WB	WBGene00017157	tyra-2		F01E11.5	gene	taxon:6239			
+WB	WBGene00017159	F01F1.2			gene	taxon:6239			
+WB	WBGene00017161	rabn-5		F01F1.4	gene	taxon:6239			
+WB	WBGene00017162	ddx-23		F01F1.7	gene	taxon:6239			
+WB	WBGene00017163	dnpp-1		F01F1.9	gene	taxon:6239			
+WB	WBGene00017164	eng-1		F01F1.10	gene	taxon:6239			
+WB	WBGene00017166	aldo-2		F01F1.12	gene	taxon:6239			
+WB	WBGene00017168	F01F1.14			gene	taxon:6239			
+WB	WBGene00017172	F02C9.1			gene	taxon:6239			
+WB	WBGene00017173	F02C9.2			gene	taxon:6239			
+WB	WBGene00017174	tat-6		F02C9.3	gene	taxon:6239			
+WB	WBGene00017175	irld-3		F02C9.4	gene	taxon:6239			
+WB	WBGene00017176	nmur-3		F02E8.2	gene	taxon:6239			
+WB	WBGene00017178	atg-16.1		F02E8.5	gene	taxon:6239			
+WB	WBGene00017179	wht-4		F02E11.1	gene	taxon:6239			
+WB	WBGene00017184	ncam-1		F02G3.1	gene	taxon:6239			
+WB	WBGene00017193	F07C3.2			gene	taxon:6239			
+WB	WBGene00017194	F07C3.3			gene	taxon:6239			
+WB	WBGene00017195	glo-4		F07C3.4	gene	taxon:6239			
+WB	WBGene00017197	F07C3.9			gene	taxon:6239			
+WB	WBGene00017198	nhr-36		F07C3.10	gene	taxon:6239			
+WB	WBGene00017199	clec-45		F07C4.2	gene	taxon:6239			
+WB	WBGene00017210	F07E5.5			gene	taxon:6239			
+WB	WBGene00017213	F07E5.8			gene	taxon:6239			
+WB	WBGene00017215	F07F6.1			gene	taxon:6239			
+WB	WBGene00017216	F07F6.2			gene	taxon:6239			
+WB	WBGene00017217	F07F6.4			gene	taxon:6239			
+WB	WBGene00017218	dct-5		F07F6.5	gene	taxon:6239			
+WB	WBGene00017219	F07F6.7			gene	taxon:6239			
+WB	WBGene00017220	F07F6.8			gene	taxon:6239			
+WB	WBGene00017221	dgn-3		F07G6.1	gene	taxon:6239			
+WB	WBGene00017228	F07G11.1			gene	taxon:6239			
+WB	WBGene00017230	F07G11.3			gene	taxon:6239			
+WB	WBGene00017231	F07G11.4			gene	taxon:6239			
+WB	WBGene00017233	lmd-4		F07G11.9	gene	taxon:6239			
+WB	WBGene00017236	nlp-60		F08B4.4	gene	taxon:6239			
+WB	WBGene00017237	pole-2		F08B4.5	gene	taxon:6239			
+WB	WBGene00017238	snrp-3		F08B4.7	gene	taxon:6239			
+WB	WBGene00017240	calu-2		F08B6.3	gene	taxon:6239			
+WB	WBGene00017241	pcyt-1		F08C6.2	gene	taxon:6239			
+WB	WBGene00017243	F08C6.5			gene	taxon:6239			
+WB	WBGene00017244	apy-1		F08C6.6	gene	taxon:6239			
+WB	WBGene00017245	srpa-72		F08D12.1	gene	taxon:6239			
+WB	WBGene00017257	F08F1.3			gene	taxon:6239			
+WB	WBGene00017261	acl-6		F08F3.2	gene	taxon:6239			
+WB	WBGene00017262	F08F3.4			gene	taxon:6239			
+WB	WBGene00017264	F08F3.8			gene	taxon:6239			
+WB	WBGene00017266	F08F3.10			gene	taxon:6239			
+WB	WBGene00017267	numr-2		F08F8.1	gene	taxon:6239			
+WB	WBGene00017268	hmgr-1		F08F8.2	gene	taxon:6239			
+WB	WBGene00017269	F08F8.4			gene	taxon:6239			
+WB	WBGene00017271	F08F8.6			gene	taxon:6239			
+WB	WBGene00017272	F08F8.7			gene	taxon:6239			
+WB	WBGene00017273	gos-28		F08F8.8|gosr-1	gene	taxon:6239			
+WB	WBGene00017274	F08F8.9			gene	taxon:6239			
+WB	WBGene00017277	F09C12.2			gene	taxon:6239			
+WB	WBGene00017278	F09C12.6			gene	taxon:6239			
+WB	WBGene00017280	usp-39		F09D1.1	gene	taxon:6239			
+WB	WBGene00017282	algn-2		F09E5.2	gene	taxon:6239			
+WB	WBGene00017283	F09E5.3			gene	taxon:6239			
+WB	WBGene00017284	sec-6		F09E5.5	gene	taxon:6239			
+WB	WBGene00017285	F09E5.7			gene	taxon:6239			
+WB	WBGene00017286	F09E5.8			gene	taxon:6239			
+WB	WBGene00017289	F09E5.11		F09E5.d	gene	taxon:6239			
+WB	WBGene00017292	F09E5.16			gene	taxon:6239			
+WB	WBGene00017293	bmy-1		F09E5.17	gene	taxon:6239			
+WB	WBGene00017296	F09E10.6			gene	taxon:6239			
+WB	WBGene00017298	toca-1		F09E10.8	gene	taxon:6239			
+WB	WBGene00017299	molo-1		F09F7.1	gene	taxon:6239			
+WB	WBGene00017300	rpc-2		F09F7.3	gene	taxon:6239			
+WB	WBGene00017301	hach-1		F09F7.4	gene	taxon:6239			
+WB	WBGene00017302	F09F7.5			gene	taxon:6239			
+WB	WBGene00017304	nmad-1		F09F7.7	gene	taxon:6239			
+WB	WBGene00017306	F09F9.1			gene	taxon:6239			
+WB	WBGene00017308	F09F9.3			gene	taxon:6239			
+WB	WBGene00017309	F09F9.4			gene	taxon:6239			
+WB	WBGene00017310	F09G2.1			gene	taxon:6239			
+WB	WBGene00017312	pitr-5		F09G2.3	gene	taxon:6239			
+WB	WBGene00017313	cpsf-2		F09G2.4	gene	taxon:6239			
+WB	WBGene00017314	lgc-39		F09G2.5	gene	taxon:6239			
+WB	WBGene00017315	ugt-36		F09G2.6	gene	taxon:6239			
+WB	WBGene00017316	F09G2.8			gene	taxon:6239			
+WB	WBGene00017317	attf-2		F09G2.9	gene	taxon:6239			
+WB	WBGene00017319	mrps-9		F09G8.3	gene	taxon:6239			
+WB	WBGene00017322	clec-160		F09G8.8	gene	taxon:6239			
+WB	WBGene00017323	mps-4		F09G8.9	gene	taxon:6239			
+WB	WBGene00017326	dmd-5		F10C1.5	gene	taxon:6239			
+WB	WBGene00017328	nemp-1		F10C5.2	gene	taxon:6239			
+WB	WBGene00017329	ugt-39		F10D2.2	gene	taxon:6239			
+WB	WBGene00017330	sre-10		F10D2.3	gene	taxon:6239			
+WB	WBGene00017331	ugt-40		F10D2.5	gene	taxon:6239			
+WB	WBGene00017332	ugt-37		F10D2.6	gene	taxon:6239			
+WB	WBGene00017333	ugt-38		F10D2.7	gene	taxon:6239			
+WB	WBGene00017334	F10D2.8			gene	taxon:6239			
+WB	WBGene00017336	ugt-41		F10D2.11	gene	taxon:6239			
+WB	WBGene00017338	npr-36		F10D7.1	gene	taxon:6239			
+WB	WBGene00017339	mfsd-10		F10D7.2	gene	taxon:6239			
+WB	WBGene00017340	F10D7.3			gene	taxon:6239			
+WB	WBGene00017342	F10D7.5			gene	taxon:6239			
+WB	WBGene00017343	F10E7.1			gene	taxon:6239			
+WB	WBGene00017344	F10E7.2			gene	taxon:6239			
+WB	WBGene00017347	F10E7.5			gene	taxon:6239			
+WB	WBGene00017348	F10E7.6			gene	taxon:6239			
+WB	WBGene00017349	farl-11		F10E7.8	gene	taxon:6239			
+WB	WBGene00017350	F10E7.9			gene	taxon:6239			
+WB	WBGene00017351	cutl-5		F10E7.10	gene	taxon:6239			
+WB	WBGene00017352	F10E7.11			gene	taxon:6239			
+WB	WBGene00017357	F10E9.5			gene	taxon:6239			
+WB	WBGene00017358	F10E9.7			gene	taxon:6239			
+WB	WBGene00017359	F10E9.10			gene	taxon:6239			
+WB	WBGene00017362	F10G2.1			gene	taxon:6239			
+WB	WBGene00017364	clec-7		F10G2.3	gene	taxon:6239			
+WB	WBGene00017367	nhr-263		F10G2.9	gene	taxon:6239			
+WB	WBGene00017369	F10G7.5			gene	taxon:6239			
+WB	WBGene00017371	sre-39		F10G7.7	gene	taxon:6239			
+WB	WBGene00017372	F10G7.9			gene	taxon:6239			
+WB	WBGene00017373	F10G7.10			gene	taxon:6239			
+WB	WBGene00017374	ttr-41		F10G7.11	gene	taxon:6239			
+WB	WBGene00017375	pbo-6		F11C7.1|lgc-3	gene	taxon:6239			
+WB	WBGene00017381	ddr-2		F11D5.3|svh-4	gene	taxon:6239			
+WB	WBGene00017382	F11D5.5			gene	taxon:6239			
+WB	WBGene00017384	F11G11.4			gene	taxon:6239			
+WB	WBGene00017385	F11G11.5			gene	taxon:6239			
+WB	WBGene00017387	mpst-4		F11G11.9	gene	taxon:6239			
+WB	WBGene00017388	F11G11.13			gene	taxon:6239			
+WB	WBGene00017389	lgc-38		F11H8.2	gene	taxon:6239			
+WB	WBGene00017390	F12A10.1			gene	taxon:6239			
+WB	WBGene00017393	nep-5		F12A10.4	gene	taxon:6239			
+WB	WBGene00017394	cal-8		F12A10.5	gene	taxon:6239			
+WB	WBGene00017398	slc-17.6		F12B6.2	gene	taxon:6239			
+WB	WBGene00017399	lgc-51		F12B6.3	gene	taxon:6239			
+WB	WBGene00017400	stg-2		F12D9.1	gene	taxon:6239			
+WB	WBGene00017406	sdz-12		F12E12.5|F12E12.e	gene	taxon:6239			
+WB	WBGene00017413	F13A2.4			gene	taxon:6239			
+WB	WBGene00017419	sec-16A.2		F13B9.1	gene	taxon:6239			
+WB	WBGene00017421	cutl-29		F13B9.6	gene	taxon:6239			
+WB	WBGene00017426	F13C5.5			gene	taxon:6239			
+WB	WBGene00017427	acp-5		F13D11.1	gene	taxon:6239			
+WB	WBGene00017428	F13D11.3			gene	taxon:6239			
+WB	WBGene00017429	F13D11.4			gene	taxon:6239			
+WB	WBGene00017431	cest-33		F13H6.3	gene	taxon:6239			
+WB	WBGene00017433	F13H6.5			gene	taxon:6239			
+WB	WBGene00017437	nmgp-1		F13H8.4	gene	taxon:6239			
+WB	WBGene00017440	upb-1		F13H8.7	gene	taxon:6239			
+WB	WBGene00017442	F13H8.9			gene	taxon:6239			
+WB	WBGene00017443	F13H8.11			gene	taxon:6239			
+WB	WBGene00017445	sid-5		F14B8.2	gene	taxon:6239			
+WB	WBGene00017447	F14B8.5			gene	taxon:6239			
+WB	WBGene00017448	F14B8.6			gene	taxon:6239			
+WB	WBGene00017449	otpl-3		F14B8.7	gene	taxon:6239			
+WB	WBGene00017463	F14D12.1			gene	taxon:6239			
+WB	WBGene00017464	sulp-2		F14D12.5	gene	taxon:6239			
+WB	WBGene00017468	F14F9.5			gene	taxon:6239			
+WB	WBGene00017472	cst-1		F14H12.4|cMST	gene	taxon:6239			
+WB	WBGene00017473	F14H12.6			gene	taxon:6239			
+WB	WBGene00017474	F14H12.7			gene	taxon:6239			
+WB	WBGene00017475	F14H12.8			gene	taxon:6239			
+WB	WBGene00017476	F15A8.1			gene	taxon:6239			
+WB	WBGene00017478	cest-26		F15A8.6	gene	taxon:6239			
+WB	WBGene00017480	nstp-2		F15B10.1	gene	taxon:6239			
+WB	WBGene00017482	set-9		F15E6.1	gene	taxon:6239			
+WB	WBGene00017483	lgc-22		F15E6.2	gene	taxon:6239			
+WB	WBGene00017487	F15E6.6			gene	taxon:6239			
+WB	WBGene00017503	nhr-177		F16B4.1	gene	taxon:6239			
+WB	WBGene00017508	F16B4.6			gene	taxon:6239			
+WB	WBGene00017510	nhr-178		F16B4.9|F16B4.c	gene	taxon:6239			
+WB	WBGene00017511	srbc-41		F16B4.10	gene	taxon:6239			
+WB	WBGene00017512	nhr-179		F16B4.11	gene	taxon:6239			
+WB	WBGene00017513	F16F9.1			gene	taxon:6239			
+WB	WBGene00017515	F16F9.4			gene	taxon:6239			
+WB	WBGene00017519	hpo-25		F16G10.4	gene	taxon:6239			
+WB	WBGene00017530	mfsd-12		F16H11.1	gene	taxon:6239			
+WB	WBGene00017532	ent-5		F16H11.3	gene	taxon:6239			
+WB	WBGene00017534	cwf-19L1		F17A9.2	gene	taxon:6239			
+WB	WBGene00017535	atf-8		F17A9.3	gene	taxon:6239			
+WB	WBGene00017536	F17A9.4			gene	taxon:6239			
+WB	WBGene00017537	F17A9.5			gene	taxon:6239			
+WB	WBGene00017538	ceh-49		F17A9.6	gene	taxon:6239			
+WB	WBGene00017540	F17E9.3			gene	taxon:6239			
+WB	WBGene00017542	F17E9.5			gene	taxon:6239			
+WB	WBGene00017543	lgc-5		F17E9.7	gene	taxon:6239			
+WB	WBGene00017544	lgc-6		F17E9.8	gene	taxon:6239			
+WB	WBGene00017545	F18A1.1			gene	taxon:6239			
+WB	WBGene00017546	rpa-1		F18A1.5|CeRPA|CeRPA73	gene	taxon:6239			
+WB	WBGene00017547	alfa-1		F18A1.6	gene	taxon:6239			
+WB	WBGene00017549	pid-1		F18A1.8	gene	taxon:6239			
+WB	WBGene00017550	nep-6		F18A12.1	gene	taxon:6239			
+WB	WBGene00017551	F18A12.2			gene	taxon:6239			
+WB	WBGene00017553	nep-8		F18A12.4	gene	taxon:6239			
+WB	WBGene00017554	nep-9		F18A12.5	gene	taxon:6239			
+WB	WBGene00017555	nep-10		F18A12.6	gene	taxon:6239			
+WB	WBGene00017557	nep-11		F18A12.8	gene	taxon:6239			
+WB	WBGene00017563	F18C5.10			gene	taxon:6239			
+WB	WBGene00017564	srxa-4		F18E3.1	gene	taxon:6239			
+WB	WBGene00017565	ddo-2		F18E3.7	gene	taxon:6239			
+WB	WBGene00017566	F18E3.10			gene	taxon:6239			
+WB	WBGene00017571	jmjd-3.1		F18E9.5|tag-279	gene	taxon:6239			
+WB	WBGene00017576	cdh-8		F18F11.3	gene	taxon:6239			
+WB	WBGene00017577	F18F11.4			gene	taxon:6239			
+WB	WBGene00017578	drl-1		F18F11.5|mekk-3	gene	taxon:6239			
+WB	WBGene00017580	lgc-4		F18G5.4	gene	taxon:6239			
+WB	WBGene00017582	F18G5.6			gene	taxon:6239			
+WB	WBGene00017591	nspg-10		F19C7.1	gene	taxon:6239			
+WB	WBGene00017592	F19C7.2			gene	taxon:6239			
+WB	WBGene00017594	F19C7.4			gene	taxon:6239			
+WB	WBGene00017598	F19F10.1			gene	taxon:6239			
+WB	WBGene00017600	ttr-10		F19F10.4	gene	taxon:6239			
+WB	WBGene00017601	ets-7		F19F10.5	gene	taxon:6239			
+WB	WBGene00017603	clec-212		F19F10.7	gene	taxon:6239			
+WB	WBGene00017605	snu-66		F19F10.9|sart-1	gene	taxon:6239			
+WB	WBGene00017606	ets-6		F19F10.10	gene	taxon:6239			
+WB	WBGene00017607	F19F10.11			gene	taxon:6239			
+WB	WBGene00017608	ints-9		F19F10.12	gene	taxon:6239			
+WB	WBGene00017609	F19G12.1			gene	taxon:6239			
+WB	WBGene00017614	F20A1.2			gene	taxon:6239			
+WB	WBGene00017615	srsx-32		F20A1.3	gene	taxon:6239			
+WB	WBGene00017616	F20A1.4			gene	taxon:6239			
+WB	WBGene00017620	tofu-2		F20A1.9	gene	taxon:6239			
+WB	WBGene00017625	cgt-2		F20B4.6	gene	taxon:6239			
+WB	WBGene00017628	F20B6.4			gene	taxon:6239			
+WB	WBGene00017636	F20D6.6			gene	taxon:6239			
+WB	WBGene00017637	F20D6.8			gene	taxon:6239			
+WB	WBGene00017638	F20D6.9			gene	taxon:6239			
+WB	WBGene00017639	F20D6.10			gene	taxon:6239			
+WB	WBGene00017640	F20D6.11			gene	taxon:6239			
+WB	WBGene00017641	csr-1		F20D12.1	gene	taxon:6239			
+WB	WBGene00017643	czw-1		F20D12.4	gene	taxon:6239			
+WB	WBGene00017644	exc-9		F20D12.5|tag-291	gene	taxon:6239			
+WB	WBGene00017645	F20D12.7			gene	taxon:6239			
+WB	WBGene00017646	F20H11.1			gene	taxon:6239			
+WB	WBGene00017647	F20H11.4			gene	taxon:6239			
+WB	WBGene00017648	ddo-3		F20H11.5	gene	taxon:6239			
+WB	WBGene00017651	F21A9.2		F21A9.a	gene	taxon:6239			
+WB	WBGene00017652	F21C10.1			gene	taxon:6239			
+WB	WBGene00017653	F21C10.3			gene	taxon:6239			
+WB	WBGene00017654	F21C10.4			gene	taxon:6239			
+WB	WBGene00017656	F21C10.6			gene	taxon:6239			
+WB	WBGene00017658	F21C10.9			gene	taxon:6239			
+WB	WBGene00017659	F21C10.10			gene	taxon:6239			
+WB	WBGene00017661	frpr-6		F21C10.12	gene	taxon:6239			
+WB	WBGene00017663	F21D12.3			gene	taxon:6239			
+WB	WBGene00017664	npax-1		F21D12.5	gene	taxon:6239			
+WB	WBGene00017666	F21E9.2			gene	taxon:6239			
+WB	WBGene00017667	ttr-37		F21E9.3	gene	taxon:6239			
+WB	WBGene00017671	pgal-1		F21F3.1	gene	taxon:6239			
+WB	WBGene00017672	F21F3.2			gene	taxon:6239			
+WB	WBGene00017673	icmt-1		F21F3.3|droe-1	gene	taxon:6239			
+WB	WBGene00017675	F21F3.6			gene	taxon:6239			
+WB	WBGene00017676	F21F3.7			gene	taxon:6239			
+WB	WBGene00017678	asp-12		F21F8.4	gene	taxon:6239			
+WB	WBGene00017681	slc-17.5		F21F8.11	gene	taxon:6239			
+WB	WBGene00017683	rbbp-5		F21H12.1|lsy-15	gene	taxon:6239			
+WB	WBGene00017686	tpp-2		F21H12.6	gene	taxon:6239			
+WB	WBGene00017687	ets-4		F22A3.1	gene	taxon:6239			
+WB	WBGene00017688	ttr-35		F22A3.2	gene	taxon:6239			
+WB	WBGene00017690	ceh-60		F22A3.5|tag-186	gene	taxon:6239			
+WB	WBGene00017691	ilys-5		F22A3.6	gene	taxon:6239			
+WB	WBGene00017693	flp-23		F22B7.2	gene	taxon:6239			
+WB	WBGene00017696	polk-1		F22B7.6	gene	taxon:6239			
+WB	WBGene00017699	flcn-1		F22D3.2	gene	taxon:6239			
+WB	WBGene00017703	F22E5.1			gene	taxon:6239			
+WB	WBGene00017705	F22E5.6			gene	taxon:6239			
+WB	WBGene00017707	F22E5.8			gene	taxon:6239			
+WB	WBGene00017708	F22E5.9			gene	taxon:6239			
+WB	WBGene00017709	F22E5.11			gene	taxon:6239			
+WB	WBGene00017710	F22E5.12			gene	taxon:6239			
+WB	WBGene00017714	F22F1.2			gene	taxon:6239			
+WB	WBGene00017715	F22F1.3			gene	taxon:6239			
+WB	WBGene00017719	ldp-1		F22F7.1	gene	taxon:6239			
+WB	WBGene00017720	F22F7.2			gene	taxon:6239			
+WB	WBGene00017721	F22F7.3			gene	taxon:6239			
+WB	WBGene00017722	F22F7.4			gene	taxon:6239			
+WB	WBGene00017723	bgnt-1.2		F22F7.6	gene	taxon:6239			
+WB	WBGene00017724	F22F7.7			gene	taxon:6239			
+WB	WBGene00017725	F22H10.1			gene	taxon:6239			
+WB	WBGene00017726	F22H10.2			gene	taxon:6239			
+WB	WBGene00017733	ubxn-1		F23C8.4	gene	taxon:6239			
+WB	WBGene00017734	F23C8.5			gene	taxon:6239			
+WB	WBGene00017735	did-2		F23C8.6|phi-24	gene	taxon:6239			
+WB	WBGene00017736	F23C8.7			gene	taxon:6239			
+WB	WBGene00017737	F23C8.8			gene	taxon:6239			
+WB	WBGene00017738	tipn-1		F23C8.9	gene	taxon:6239			
+WB	WBGene00017742	nfyc-1		F23F1.1	gene	taxon:6239			
+WB	WBGene00017743	F23F1.2			gene	taxon:6239			
+WB	WBGene00017746	F23F1.5			gene	taxon:6239			
+WB	WBGene00017747	F23F1.6			gene	taxon:6239			
+WB	WBGene00017749	rpoa-49		F23F1.9	gene	taxon:6239			
+WB	WBGene00017751	F23F12.3			gene	taxon:6239			
+WB	WBGene00017752	sdz-15		F23F12.4	gene	taxon:6239			
+WB	WBGene00017755	zip-8		F23F12.9	gene	taxon:6239			
+WB	WBGene00017758	F23H11.2		T24C4.h	gene	taxon:6239			
+WB	WBGene00017759	sucl-2		F23H11.3	gene	taxon:6239			
+WB	WBGene00017760	F23H11.4			gene	taxon:6239			
+WB	WBGene00017763	crls-1		F23H11.9	gene	taxon:6239			
+WB	WBGene00017764	F25A2.1		Y50D4A.d	gene	taxon:6239			
+WB	WBGene00017765	gcst-1		F25B4.1	gene	taxon:6239			
+WB	WBGene00017766	peli-1		F25B4.2	gene	taxon:6239			
+WB	WBGene00017768	prp-39		F25B4.5	gene	taxon:6239			
+WB	WBGene00017769	hmgs-1		F25B4.6|phi-50	gene	taxon:6239			
+WB	WBGene00017770	F25B4.7			gene	taxon:6239			
+WB	WBGene00017771	F25B4.8			gene	taxon:6239			
+WB	WBGene00017772	clec-1		F25B4.9	gene	taxon:6239			
+WB	WBGene00017774	nop-1		F25B5.2	gene	taxon:6239			
+WB	WBGene00017775	F25B5.3			gene	taxon:6239			
+WB	WBGene00017776	F25B5.5			gene	taxon:6239			
+WB	WBGene00017777	F25B5.6			gene	taxon:6239			
+WB	WBGene00017778	nono-1		F25B5.7|psf-1	gene	taxon:6239			
+WB	WBGene00017779	gtr-1		F25E2.1	gene	taxon:6239			
+WB	WBGene00017781	F25E2.3			gene	taxon:6239			
+WB	WBGene00017783	F25E5.2			gene	taxon:6239			
+WB	WBGene00017787	nhr-141		F25E5.6	gene	taxon:6239			
+WB	WBGene00017791	try-8		F25E5.10	gene	taxon:6239			
+WB	WBGene00017797	symk-1		F25G6.2	gene	taxon:6239			
+WB	WBGene00017798	slc-17.8		F25G6.7	gene	taxon:6239			
+WB	WBGene00017799	F25G6.8			gene	taxon:6239			
+WB	WBGene00017800	F25G6.9			gene	taxon:6239			
+WB	WBGene00017802	F26A1.3			gene	taxon:6239			
+WB	WBGene00017803	F26A1.4			gene	taxon:6239			
+WB	WBGene00017805	F26A1.7			gene	taxon:6239			
+WB	WBGene00017806	F26A1.8			gene	taxon:6239			
+WB	WBGene00017809	clec-156		F26A1.11	gene	taxon:6239			
+WB	WBGene00017810	clec-157		F26A1.12	gene	taxon:6239			
+WB	WBGene00017813	nlp-61		F26A10.1	gene	taxon:6239			
+WB	WBGene00017816	hrpk-1		F26B1.2	gene	taxon:6239			
+WB	WBGene00017817	F26B1.5			gene	taxon:6239			
+WB	WBGene00017818	F26D11.1			gene	taxon:6239			
+WB	WBGene00017822	clec-216		F26D11.5	gene	taxon:6239			
+WB	WBGene00017824	clec-217		F26D11.9	gene	taxon:6239			
+WB	WBGene00017825	cee-1		F26F4.1	gene	taxon:6239			
+WB	WBGene00017826	tag-340		F26F4.4	gene	taxon:6239			
+WB	WBGene00017829	F26F4.9			gene	taxon:6239			
+WB	WBGene00017830	rpb-8		F26F4.11	gene	taxon:6239			
+WB	WBGene00017832	kbp-2		F26F4.13	gene	taxon:6239			
+WB	WBGene00017835	F26F12.4			gene	taxon:6239			
+WB	WBGene00017836	F26F12.5			gene	taxon:6239			
+WB	WBGene00017837	F26G1.1			gene	taxon:6239			
+WB	WBGene00017839	F26G1.3			gene	taxon:6239			
+WB	WBGene00017840	ttm-2		F26G1.4	gene	taxon:6239			
+WB	WBGene00017842	nep-12		F26G1.6	gene	taxon:6239			
+WB	WBGene00017845	srsx-9		F26G5.10	gene	taxon:6239			
+WB	WBGene00017850	F27B10.1			gene	taxon:6239			
+WB	WBGene00017852	F27C1.2			gene	taxon:6239			
+WB	WBGene00017855	F27C1.6			gene	taxon:6239			
+WB	WBGene00017858	F27C1.11			gene	taxon:6239			
+WB	WBGene00017860	F27C1.13			gene	taxon:6239			
+WB	WBGene00017861	F27D9.2			gene	taxon:6239			
+WB	WBGene00017864	pcca-1		F27D9.5	gene	taxon:6239			
+WB	WBGene00017865	F27D9.7			gene	taxon:6239			
+WB	WBGene00017866	stn-2		F27D9.8	gene	taxon:6239			
+WB	WBGene00017867	slc-28.1		F27E11.1	gene	taxon:6239			
+WB	WBGene00017868	slc-28.2		F27E11.2	gene	taxon:6239			
+WB	WBGene00017871	F28A10.3			gene	taxon:6239			
+WB	WBGene00017874	acdh-9		F28A10.6	gene	taxon:6239			
+WB	WBGene00017875	F28A10.7			gene	taxon:6239			
+WB	WBGene00017879	acd-4		F28A12.1	gene	taxon:6239			
+WB	WBGene00017880	F28A12.3			gene	taxon:6239			
+WB	WBGene00017881	asp-13		F28A12.4	gene	taxon:6239			
+WB	WBGene00017886	mfsd-13.1		F28B3.5	gene	taxon:6239			
+WB	WBGene00017887	F28B3.6			gene	taxon:6239			
+WB	WBGene00017888	acl-11		F28B3.9	gene	taxon:6239			
+WB	WBGene00017889	F28B3.10			gene	taxon:6239			
+WB	WBGene00017890	F28B4.1			gene	taxon:6239			
+WB	WBGene00017891	rgl-1		F28B4.2	gene	taxon:6239			
+WB	WBGene00017893	F28B4.4			gene	taxon:6239			
+WB	WBGene00017895	vrk-1		F28B12.3|tag-223	gene	taxon:6239			
+WB	WBGene00017898	F28C10.3			gene	taxon:6239			
+WB	WBGene00017901	igeg-1		F28E10.2	gene	taxon:6239			
+WB	WBGene00017904	lim-8		F28F5.3|tag-204	gene	taxon:6239			
+WB	WBGene00017906	F28F9.2			gene	taxon:6239			
+WB	WBGene00017909	F28H1.4			gene	taxon:6239			
+WB	WBGene00017919	F29B9.1			gene	taxon:6239			
+WB	WBGene00017920	jmjd-1.2		F29B9.2|CeKDM7A	gene	taxon:6239			
+WB	WBGene00017922	F29B9.7			gene	taxon:6239			
+WB	WBGene00017923	F29B9.8			gene	taxon:6239			
+WB	WBGene00017924	mrps-21		F29B9.10	gene	taxon:6239			
+WB	WBGene00017925	F29B9.11			gene	taxon:6239			
+WB	WBGene00017926	cox-6C		F29C4.2	gene	taxon:6239			
+WB	WBGene00017928	tut-1		F29C4.6|ctu-1|tuc-1	gene	taxon:6239			
+WB	WBGene00017929	grld-1		F29C4.7	gene	taxon:6239			
+WB	WBGene00017931	picc-1		F29G9.2	gene	taxon:6239			
+WB	WBGene00017934	F30B5.4			gene	taxon:6239			
+WB	WBGene00017935	srbc-70		F30B5.6	gene	taxon:6239			
+WB	WBGene00017936	zipt-2.2		F30B5.7	gene	taxon:6239			
+WB	WBGene00017937	F30H5.3		F30H5.e	gene	taxon:6239			
+WB	WBGene00017944	F31D5.1			gene	taxon:6239			
+WB	WBGene00017945	F31D5.2			gene	taxon:6239			
+WB	WBGene00017947	mth-2		F31D5.4	gene	taxon:6239			
+WB	WBGene00017948	mth-1		F31D5.5	gene	taxon:6239			
+WB	WBGene00017950	F31E3.2			gene	taxon:6239			
+WB	WBGene00017951	panl-2		F31E3.4	gene	taxon:6239			
+WB	WBGene00017952	F31E3.6			gene	taxon:6239			
+WB	WBGene00017954	F31E8.4			gene	taxon:6239			
+WB	WBGene00017957	F31F4.1			gene	taxon:6239			
+WB	WBGene00017959	ugt-42		F31F4.7	gene	taxon:6239			
+WB	WBGene00017960	F31F4.11			gene	taxon:6239			
+WB	WBGene00017961	nhr-180		F31F4.12	gene	taxon:6239			
+WB	WBGene00017963	F31F4.17			gene	taxon:6239			
+WB	WBGene00017964	F31F7.1			gene	taxon:6239			
+WB	WBGene00017965	F31F7.2			gene	taxon:6239			
+WB	WBGene00017967	ada-2		F32A5.1	gene	taxon:6239			
+WB	WBGene00017968	skpo-3		F32A5.2	gene	taxon:6239			
+WB	WBGene00017969	ctsa-3.1		F32A5.3	gene	taxon:6239			
+WB	WBGene00017970	F32A5.4			gene	taxon:6239			
+WB	WBGene00017971	F32A5.8			gene	taxon:6239			
+WB	WBGene00017973	ift-81		F32A6.2	gene	taxon:6239			
+WB	WBGene00017974	vps-41		F32A6.3|Y34B4A.g	gene	taxon:6239			
+WB	WBGene00017975	F32B5.1			gene	taxon:6239			
+WB	WBGene00017977	F32B5.3			gene	taxon:6239			
+WB	WBGene00017981	figl-1		F32D1.1	gene	taxon:6239			
+WB	WBGene00017982	hpo-18		F32D1.2	gene	taxon:6239			
+WB	WBGene00017983	F32D1.3			gene	taxon:6239			
+WB	WBGene00017984	gmpr-1		F32D1.5	gene	taxon:6239			
+WB	WBGene00017985	neg-1		F32D1.6	gene	taxon:6239			
+WB	WBGene00017988	fipp-1		F32D1.9	gene	taxon:6239			
+WB	WBGene00017989	nol-10		F32E10.1	gene	taxon:6239			
+WB	WBGene00017990	cec-4		F32E10.2	gene	taxon:6239			
+WB	WBGene00017991	clec-180		F32E10.3|cpg-12	gene	taxon:6239			
+WB	WBGene00017993	cec-5		F32E10.6	gene	taxon:6239			
+WB	WBGene00017996	F33D4.4			gene	taxon:6239			
+WB	WBGene00017997	mrpl-1		F33D4.5	gene	taxon:6239			
+WB	WBGene00017999	emc-6		F33D4.7	gene	taxon:6239			
+WB	WBGene00018000	F33D11.1			gene	taxon:6239			
+WB	WBGene00018002	twk-47		F33D11.5	gene	taxon:6239			
+WB	WBGene00018004	F33D11.7			gene	taxon:6239			
+WB	WBGene00018005	nlp-62		F33D11.8	gene	taxon:6239			
+WB	WBGene00018006	gpaa-1		F33D11.9|hpo-3	gene	taxon:6239			
+WB	WBGene00018007	F33D11.10			gene	taxon:6239			
+WB	WBGene00018008	vpr-1		F33D11.11	gene	taxon:6239			
+WB	WBGene00018009	dhhc-3		F33D11.12	gene	taxon:6239			
+WB	WBGene00018013	phf-10		F33E11.6	gene	taxon:6239			
+WB	WBGene00018014	wdr-83		F33G12.2	gene	taxon:6239			
+WB	WBGene00018016	lrr-1		F33G12.4	gene	taxon:6239			
+WB	WBGene00018017	golg-2		F33G12.5	gene	taxon:6239			
+WB	WBGene00018018	F33G12.6			gene	taxon:6239			
+WB	WBGene00018022	ceh-87		F34D6.2	gene	taxon:6239			
+WB	WBGene00018023	set-11		F34D6.4	gene	taxon:6239			
+WB	WBGene00018024	F35A5.1			gene	taxon:6239			
+WB	WBGene00018030	F35B3.3			gene	taxon:6239			
+WB	WBGene00018034	sek-5		F35C8.1	gene	taxon:6239			
+WB	WBGene00018035	sek-4		F35C8.2	gene	taxon:6239			
+WB	WBGene00018036	F35C8.5			gene	taxon:6239			
+WB	WBGene00018037	chtl-1		F35C8.7	gene	taxon:6239			
+WB	WBGene00018041	F35D2.3			gene	taxon:6239			
+WB	WBGene00018042	mks-3		F35D2.4	gene	taxon:6239			
+WB	WBGene00018044	F35D11.3			gene	taxon:6239			
+WB	WBGene00018046	coa-3		F35D11.5	gene	taxon:6239			
+WB	WBGene00018047	clec-136		F35D11.7	gene	taxon:6239			
+WB	WBGene00018048	clec-137		F35D11.8	gene	taxon:6239			
+WB	WBGene00018049	clec-138		F35D11.9	gene	taxon:6239			
+WB	WBGene00018050	clec-139		F35D11.10	gene	taxon:6239			
+WB	WBGene00018051	che-10		F35D11.11|dyf-14	gene	taxon:6239			
+WB	WBGene00018052	F35F10.1			gene	taxon:6239			
+WB	WBGene00018053	srbc-3		F35F10.2	gene	taxon:6239			
+WB	WBGene00018056	F35F10.6			gene	taxon:6239			
+WB	WBGene00018057	F35F10.7			gene	taxon:6239			
+WB	WBGene00018058	srbc-1		F35F10.9	gene	taxon:6239			
+WB	WBGene00018063	F35F10.14			gene	taxon:6239			
+WB	WBGene00018064	cdc-73		F35F11.1	gene	taxon:6239			
+WB	WBGene00018067	npr-7		F35G8.1	gene	taxon:6239			
+WB	WBGene00018070	F35H10.5			gene	taxon:6239			
+WB	WBGene00018072	nprl-3		F35H10.7	gene	taxon:6239			
+WB	WBGene00018073	F35H10.10			gene	taxon:6239			
+WB	WBGene00018075	tbc-11		F35H12.2	gene	taxon:6239			
+WB	WBGene00018076	pifk-1		F35H12.4	gene	taxon:6239			
+WB	WBGene00018077	F35H12.5			gene	taxon:6239			
+WB	WBGene00018078	F35H12.6			gene	taxon:6239			
+WB	WBGene00018085	ttr-20		F36A4.8	gene	taxon:6239			
+WB	WBGene00018088	trpp-4		F36D4.2	gene	taxon:6239			
+WB	WBGene00018089	F36D4.4			gene	taxon:6239			
+WB	WBGene00018090	F36D4.5			gene	taxon:6239			
+WB	WBGene00018091	F36D4.6			gene	taxon:6239			
+WB	WBGene00018092	F36F12.1			gene	taxon:6239			
+WB	WBGene00018093	F36F12.2			gene	taxon:6239			
+WB	WBGene00018094	F36F12.3			gene	taxon:6239			
+WB	WBGene00018096	clec-207		F36F12.5	gene	taxon:6239			
+WB	WBGene00018097	clec-208		F36F12.6	gene	taxon:6239			
+WB	WBGene00018103	F36H5.4			gene	taxon:6239			
+WB	WBGene00018104	fbxb-53		F36H5.5	gene	taxon:6239			
+WB	WBGene00018105	clec-19		F36H5.6	gene	taxon:6239			
+WB	WBGene00018108	F36H5.10			gene	taxon:6239			
+WB	WBGene00018110	F36H9.1			gene	taxon:6239			
+WB	WBGene00018112	F36H9.4			gene	taxon:6239			
+WB	WBGene00018113	F36H9.5			gene	taxon:6239			
+WB	WBGene00018114	srt-41		F36H9.6	gene	taxon:6239			
+WB	WBGene00018115	F36H9.7			gene	taxon:6239			
+WB	WBGene00018117	nlp-47		F36H12.1	gene	taxon:6239			
+WB	WBGene00018119	F36H12.3			gene	taxon:6239			
+WB	WBGene00018122	ttbk-2		F36H12.8	gene	taxon:6239			
+WB	WBGene00018123	F36H12.9			gene	taxon:6239			
+WB	WBGene00018124	F36H12.10			gene	taxon:6239			
+WB	WBGene00018130	F36H12.17			gene	taxon:6239			
+WB	WBGene00018131	F37A4.1			gene	taxon:6239			
+WB	WBGene00018132	F37A4.2			gene	taxon:6239			
+WB	WBGene00018135	F37A4.5			gene	taxon:6239			
+WB	WBGene00018137	bath-41		F37A4.9	gene	taxon:6239			
+WB	WBGene00018138	folt-2		F37B4.7	gene	taxon:6239			
+WB	WBGene00018139	sre-24		F37B4.9	gene	taxon:6239			
+WB	WBGene00018141	oac-21		F37C4.1	gene	taxon:6239			
+WB	WBGene00018142	oac-22		F37C4.2	gene	taxon:6239			
+WB	WBGene00018143	oac-23		F37C4.3	gene	taxon:6239			
+WB	WBGene00018144	F37C4.4			gene	taxon:6239			
+WB	WBGene00018145	F37C4.5			gene	taxon:6239			
+WB	WBGene00018146	F37C4.6			gene	taxon:6239			
+WB	WBGene00018148	F37C4.8			gene	taxon:6239			
+WB	WBGene00018149	yju-2		F37C12.1	gene	taxon:6239			
+WB	WBGene00018150	epg-4		F37C12.2|eip-24	gene	taxon:6239			
+WB	WBGene00018151	F37C12.3			gene	taxon:6239			
+WB	WBGene00018152	acs-4		F37C12.7	gene	taxon:6239			
+WB	WBGene00018154	exos-9		F37C12.13	gene	taxon:6239			
+WB	WBGene00018156	ncbp-1		F37E3.1|let-608	gene	taxon:6239			
+WB	WBGene00018157	lron-6		F37E3.2	gene	taxon:6239			
+WB	WBGene00018158	comp-1		F37E3.3	gene	taxon:6239			
+WB	WBGene00018159	F37F2.2			gene	taxon:6239			
+WB	WBGene00018160	odr-8		F38A5.1|ufsp-2	gene	taxon:6239			
+WB	WBGene00018163	F38A5.6			gene	taxon:6239			
+WB	WBGene00018164	sup-36		F38A5.7	gene	taxon:6239			
+WB	WBGene00018165	F38A5.8			gene	taxon:6239			
+WB	WBGene00018168	irld-7		F38A5.11	gene	taxon:6239			
+WB	WBGene00018173	F38B6.3			gene	taxon:6239			
+WB	WBGene00018174	F38B6.4			gene	taxon:6239			
+WB	WBGene00018175	F38B6.6			gene	taxon:6239			
+WB	WBGene00018178	F38E1.3			gene	taxon:6239			
+WB	WBGene00018179	F38E1.6			gene	taxon:6239			
+WB	WBGene00018180	srsx-22		F38E1.8	gene	taxon:6239			
+WB	WBGene00018181	mpdu-1		F38E1.9	gene	taxon:6239			
+WB	WBGene00018184	F38E9.1			gene	taxon:6239			
+WB	WBGene00018187	twf-2		F38E9.5	gene	taxon:6239			
+WB	WBGene00018189	nhr-181		F38H12.3	gene	taxon:6239			
+WB	WBGene00018190	F38H12.5			gene	taxon:6239			
+WB	WBGene00018191	frpr-7		F39B3.2	gene	taxon:6239			
+WB	WBGene00018196	nep-13		F39E9.4	gene	taxon:6239			
+WB	WBGene00018202	F39F10.2			gene	taxon:6239			
+WB	WBGene00018203	F39F10.3			gene	taxon:6239			
+WB	WBGene00018205	F39F10.5			gene	taxon:6239			
+WB	WBGene00018206	ugt-61		F39G3.1	gene	taxon:6239			
+WB	WBGene00018207	F39G3.2			gene	taxon:6239			
+WB	WBGene00018209	F39G3.4			gene	taxon:6239			
+WB	WBGene00018210	F39G3.5			gene	taxon:6239			
+WB	WBGene00018211	oac-24		F39G3.6	gene	taxon:6239			
+WB	WBGene00018215	igcm-1		F39H12.4	gene	taxon:6239			
+WB	WBGene00018216	F40A3.1			gene	taxon:6239			
+WB	WBGene00018217	F40A3.2			gene	taxon:6239			
+WB	WBGene00018218	F40A3.3			gene	taxon:6239			
+WB	WBGene00018219	F40A3.4			gene	taxon:6239			
+WB	WBGene00018222	F40A3.7			gene	taxon:6239			
+WB	WBGene00018226	F40B5.2			gene	taxon:6239			
+WB	WBGene00018227	nep-15		F40B5.3	gene	taxon:6239			
+WB	WBGene00018228	F40C5.1			gene	taxon:6239			
+WB	WBGene00018232	F40E3.5			gene	taxon:6239			
+WB	WBGene00018237	irg-7		F40F4.6|drd-2|upr-1	gene	taxon:6239			
+WB	WBGene00018238	F40F4.7			gene	taxon:6239			
+WB	WBGene00018239	sec-20		F40G9.1	gene	taxon:6239			
+WB	WBGene00018240	cox-17		F40G9.2	gene	taxon:6239			
+WB	WBGene00018241	F40G9.5			gene	taxon:6239			
+WB	WBGene00018242	F40G9.6			gene	taxon:6239			
+WB	WBGene00018244	F40G9.8			gene	taxon:6239			
+WB	WBGene00018245	F40G9.9			gene	taxon:6239			
+WB	WBGene00018246	clec-148		F40G9.10	gene	taxon:6239			
+WB	WBGene00018247	F40G9.12			gene	taxon:6239			
+WB	WBGene00018248	F40G9.14			gene	taxon:6239			
+WB	WBGene00018253	F40H6.1			gene	taxon:6239			
+WB	WBGene00018255	F40H6.5			gene	taxon:6239			
+WB	WBGene00018256	cutl-28		F41A4.1	gene	taxon:6239			
+WB	WBGene00018257	F41B4.1			gene	taxon:6239			
+WB	WBGene00018259	F41B4.3			gene	taxon:6239			
+WB	WBGene00018260	cyp-33C7		F41B5.2	gene	taxon:6239			
+WB	WBGene00018261	cyp-33C5		F41B5.3	gene	taxon:6239			
+WB	WBGene00018262	cyp-33C3		F41B5.4	gene	taxon:6239			
+WB	WBGene00018264	cyp-33C6		F41B5.7	gene	taxon:6239			
+WB	WBGene00018265	nhr-182		F41B5.9	gene	taxon:6239			
+WB	WBGene00018266	nhr-183		F41B5.10	gene	taxon:6239			
+WB	WBGene00018268	F41C3.2			gene	taxon:6239			
+WB	WBGene00018269	acs-11		F41C3.3	gene	taxon:6239			
+WB	WBGene00018270	eas-1		F41C3.4	gene	taxon:6239			
+WB	WBGene00018271	ctsa-1.1		F41C3.5	gene	taxon:6239			
+WB	WBGene00018274	F41C3.8			gene	taxon:6239			
+WB	WBGene00018275	F41C3.11			gene	taxon:6239			
+WB	WBGene00018278	F41C6.4			gene	taxon:6239			
+WB	WBGene00018280	F41C6.7			gene	taxon:6239			
+WB	WBGene00018283	sulp-3		F41D9.5	gene	taxon:6239			
+WB	WBGene00018284	F41E6.1			gene	taxon:6239			
+WB	WBGene00018285	smk-1		F41E6.4|rad-2	gene	taxon:6239			
+WB	WBGene00018286	F41E6.5			gene	taxon:6239			
+WB	WBGene00018290	vps-60		F41E6.9	gene	taxon:6239			
+WB	WBGene00018292	F41E6.11			gene	taxon:6239			
+WB	WBGene00018294	atg-18		F41E6.13|atgr-18|tag-283	gene	taxon:6239			
+WB	WBGene00018295	oac-29		F41E6.14	gene	taxon:6239			
+WB	WBGene00018296	F41F3.1			gene	taxon:6239			
+WB	WBGene00018298	nlp-50		F41G3.1	gene	taxon:6239			
+WB	WBGene00018301	F41G3.5			gene	taxon:6239			
+WB	WBGene00018304	agr-1		F41G3.12	gene	taxon:6239			
+WB	WBGene00018305	exos-8		F41G3.14	gene	taxon:6239			
+WB	WBGene00018312	F41H8.1			gene	taxon:6239			
+WB	WBGene00018313	F41H8.2			gene	taxon:6239			
+WB	WBGene00018314	F41H10.1			gene	taxon:6239			
+WB	WBGene00018318	F41H10.5			gene	taxon:6239			
+WB	WBGene00018319	hda-6		F41H10.6|hdac-6|Y4C6B.a	gene	taxon:6239			
+WB	WBGene00018321	sand-1		F41H10.11	gene	taxon:6239			
+WB	WBGene00018323	F42A6.1			gene	taxon:6239			
+WB	WBGene00018327	F42A6.5			gene	taxon:6239			
+WB	WBGene00018330	elks-1		F42A6.9	gene	taxon:6239			
+WB	WBGene00018332	F42A9.3			gene	taxon:6239			
+WB	WBGene00018333	cyp-33E3		F42A9.4	gene	taxon:6239			
+WB	WBGene00018334	cyp-33E2		F42A9.5	gene	taxon:6239			
+WB	WBGene00018335	F42A9.6			gene	taxon:6239			
+WB	WBGene00018336	F42A9.7		F42A9.e	gene	taxon:6239			
+WB	WBGene00018337	F42A9.8			gene	taxon:6239			
+WB	WBGene00018338	F42A9.9			gene	taxon:6239			
+WB	WBGene00018339	abcf-3		F42A10.1	gene	taxon:6239			
+WB	WBGene00018340	anmt-2		F42A10.3	gene	taxon:6239			
+WB	WBGene00018344	npr-27		F42C5.2	gene	taxon:6239			
+WB	WBGene00018346	F42C5.4			gene	taxon:6239			
+WB	WBGene00018347	F42C5.5			gene	taxon:6239			
+WB	WBGene00018348	F42C5.6			gene	taxon:6239			
+WB	WBGene00018349	F42C5.9			gene	taxon:6239			
+WB	WBGene00018352	fbxc-20		F42G2.3	gene	taxon:6239			
+WB	WBGene00018354	F42G2.5			gene	taxon:6239			
+WB	WBGene00018355	ceh-86		F42G2.6	gene	taxon:6239			
+WB	WBGene00018356	islo-1		F42G8.5	gene	taxon:6239			
+WB	WBGene00018357	moc-3		F42G8.6|uba-4	gene	taxon:6239			
+WB	WBGene00018358	erp-44.3		F42G8.7	gene	taxon:6239			
+WB	WBGene00018359	F42G8.8			gene	taxon:6239			
+WB	WBGene00018360	irld-8		F42G8.9	gene	taxon:6239			
+WB	WBGene00018361	F42G8.10			gene	taxon:6239			
+WB	WBGene00018362	ppm-1.G		F42G9.1	gene	taxon:6239			
+WB	WBGene00018363	nlp-52		F42G9.4	gene	taxon:6239			
+WB	WBGene00018364	dagl-2		F42G9.6|dagl-1	gene	taxon:6239			
+WB	WBGene00018365	tpst-2		F42G9.8	gene	taxon:6239			
+WB	WBGene00018366	F42H10.2			gene	taxon:6239			
+WB	WBGene00018367	F42H10.3			gene	taxon:6239			
+WB	WBGene00018369	mig-39		F42H10.5	gene	taxon:6239			
+WB	WBGene00018370	F42H10.6			gene	taxon:6239			
+WB	WBGene00018371	ess-2		F42H10.7	gene	taxon:6239			
+WB	WBGene00018373	F43B10.1			gene	taxon:6239			
+WB	WBGene00018374	tag-343		F43B10.2	gene	taxon:6239			
+WB	WBGene00018376	F43C9.2			gene	taxon:6239			
+WB	WBGene00018377	hum-10		F43C9.3|F43C9.c	gene	taxon:6239			
+WB	WBGene00018383	F43C11.6			gene	taxon:6239			
+WB	WBGene00018384	F43C11.7			gene	taxon:6239			
+WB	WBGene00018385	F43C11.8			gene	taxon:6239			
+WB	WBGene00018391	rpb-4		F43E2.2	gene	taxon:6239			
+WB	WBGene00018392	insc-1		F43E2.3	gene	taxon:6239			
+WB	WBGene00018393	msra-1		F43E2.5	gene	taxon:6239			
+WB	WBGene00018395	mtch-1		F43E2.7	gene	taxon:6239			
+WB	WBGene00018398	sptl-2		F43H9.2	gene	taxon:6239			
+WB	WBGene00018399	F43H9.3			gene	taxon:6239			
+WB	WBGene00018400	F43H9.4			gene	taxon:6239			
+WB	WBGene00018402	kvs-3		F44A2.2	gene	taxon:6239			
+WB	WBGene00018403	F44A2.3			gene	taxon:6239			
+WB	WBGene00018404	nhr-39		F44A2.4	gene	taxon:6239			
+WB	WBGene00018405	F44A2.5			gene	taxon:6239			
+WB	WBGene00018408	F44B9.5			gene	taxon:6239			
+WB	WBGene00018409	F44B9.8			gene	taxon:6239			
+WB	WBGene00018410	F44B9.9			gene	taxon:6239			
+WB	WBGene00018411	F44B9.10			gene	taxon:6239			
+WB	WBGene00018412	nhr-37		F44C4.2	gene	taxon:6239			
+WB	WBGene00018413	cyp-33C4		F44C8.1|F44C8.g	gene	taxon:6239			
+WB	WBGene00018414	nstp-8		F44C8.7	gene	taxon:6239			
+WB	WBGene00018415	nhr-184		F44C8.9|F44C8.b|F44C8.c	gene	taxon:6239			
+WB	WBGene00018418	F44E2.4			gene	taxon:6239			
+WB	WBGene00018419	F44E2.6			gene	taxon:6239			
+WB	WBGene00018420	F44E2.7			gene	taxon:6239			
+WB	WBGene00018423	F44E2.10			gene	taxon:6239			
+WB	WBGene00018424	pgph-2		F44E7.2	gene	taxon:6239			
+WB	WBGene00018426	F44E7.4			gene	taxon:6239			
+WB	WBGene00018429	F44E7.7			gene	taxon:6239			
+WB	WBGene00018430	nhr-142		F44E7.8	gene	taxon:6239			
+WB	WBGene00018431	F44E7.9			gene	taxon:6239			
+WB	WBGene00018433	ceh-82		F45C12.2	gene	taxon:6239			
+WB	WBGene00018434	ceh-81		F45C12.3	gene	taxon:6239			
+WB	WBGene00018437	btb-8		F45C12.6	gene	taxon:6239			
+WB	WBGene00018446	ceh-83		F45C12.15	gene	taxon:6239			
+WB	WBGene00018467	sdpn-1		F45E1.7	gene	taxon:6239			
+WB	WBGene00018468	cla-1		F45E4.3|F32E10.7|F45E4.4|tag-80|tag-199	gene	taxon:6239			
+WB	WBGene00018470	F45E4.5			gene	taxon:6239			
+WB	WBGene00018471	F45E4.6			gene	taxon:6239			
+WB	WBGene00018472	nep-16		F45E4.7	gene	taxon:6239			
+WB	WBGene00018473	cima-1		F45E4.11|slc-17.10	gene	taxon:6239			
+WB	WBGene00018474	cnep-1		F45E12.1|scpl-2	gene	taxon:6239			
+WB	WBGene00018475	mrpl-14		F45E12.5	gene	taxon:6239			
+WB	WBGene00018477	otpl-4		F45F2.1	gene	taxon:6239			
+WB	WBGene00018478	otpl-5		F45F2.5	gene	taxon:6239			
+WB	WBGene00018479	otpl-6		F45F2.6	gene	taxon:6239			
+WB	WBGene00018480	otpl-7		F45F2.7	gene	taxon:6239			
+WB	WBGene00018481	F45F2.9			gene	taxon:6239			
+WB	WBGene00018484	F46C8.1			gene	taxon:6239			
+WB	WBGene00018485	F46C8.3			gene	taxon:6239			
+WB	WBGene00018486	glb-16		F46C8.7	gene	taxon:6239			
+WB	WBGene00018488	acs-1		F46E10.1	gene	taxon:6239			
+WB	WBGene00018491	mdh-1		F46E10.10|F46E10.g	gene	taxon:6239			
+WB	WBGene00018496	F46F5.5			gene	taxon:6239			
+WB	WBGene00018498	F46F5.7			gene	taxon:6239			
+WB	WBGene00018501	F46F5.10			gene	taxon:6239			
+WB	WBGene00018502	F46F5.11			gene	taxon:6239			
+WB	WBGene00018505	F46F5.14			gene	taxon:6239			
+WB	WBGene00018507	F46F5.16			gene	taxon:6239			
+WB	WBGene00018508	F46F11.1			gene	taxon:6239			
+WB	WBGene00018509	xrep-4		F46F11.6	gene	taxon:6239			
+WB	WBGene00018513	F46F11.10			gene	taxon:6239			
+WB	WBGene00018514	twnk-1		F46G11.1	gene	taxon:6239			
+WB	WBGene00018516	gakh-1		F46G11.3|tag-257	gene	taxon:6239			
+WB	WBGene00018518	F46H5.2			gene	taxon:6239			
+WB	WBGene00018519	F46H5.3			gene	taxon:6239			
+WB	WBGene00018520	F46H5.4			gene	taxon:6239			
+WB	WBGene00018522	F46H5.7			gene	taxon:6239			
+WB	WBGene00018525	F47B3.1			gene	taxon:6239			
+WB	WBGene00018526	F47B3.2			gene	taxon:6239			
+WB	WBGene00018527	F47B3.3			gene	taxon:6239			
+WB	WBGene00018528	F47B3.4			gene	taxon:6239			
+WB	WBGene00018530	F47B3.6			gene	taxon:6239			
+WB	WBGene00018531	F47B3.7			gene	taxon:6239			
+WB	WBGene00018532	F47B7.1			gene	taxon:6239			
+WB	WBGene00018533	F47B7.2			gene	taxon:6239			
+WB	WBGene00018539	nhr-185		F47C10.1	gene	taxon:6239			
+WB	WBGene00018541	nhr-186		F47C10.3	gene	taxon:6239			
+WB	WBGene00018542	nhr-187		F47C10.4	gene	taxon:6239			
+WB	WBGene00018543	ugt-32		F47C10.6	gene	taxon:6239			
+WB	WBGene00018544	nhr-188		F47C10.7	gene	taxon:6239			
+WB	WBGene00018545	nhr-189		F47C10.8	gene	taxon:6239			
+WB	WBGene00018547	clec-78		F47C12.2	gene	taxon:6239			
+WB	WBGene00018548	clec-79		F47C12.4	gene	taxon:6239			
+WB	WBGene00018552	srt-19		F47D2.1	gene	taxon:6239			
+WB	WBGene00018554	srt-3		F47D2.3	gene	taxon:6239			
+WB	WBGene00018555	srt-35		F47D2.4	gene	taxon:6239			
+WB	WBGene00018556	srt-36		F47D2.5	gene	taxon:6239			
+WB	WBGene00018557	srt-38		F47D2.6	gene	taxon:6239			
+WB	WBGene00018558	srt-20		F47D2.7	gene	taxon:6239			
+WB	WBGene00018559	srt-37		F47D2.8	gene	taxon:6239			
+WB	WBGene00018560	F47D12.3			gene	taxon:6239			
+WB	WBGene00018561	gadr-3		F47D12.5	gene	taxon:6239			
+WB	WBGene00018566	F47E1.2			gene	taxon:6239			
+WB	WBGene00018568	F47E1.4			gene	taxon:6239			
+WB	WBGene00018569	F47F2.1			gene	taxon:6239			
+WB	WBGene00018572	lin-42		F47F6.1	gene	taxon:6239			
+WB	WBGene00018573	oac-30		F47F6.3	gene	taxon:6239			
+WB	WBGene00018575	clec-119		F47F6.5	gene	taxon:6239			
+WB	WBGene00018576	F47G3.1			gene	taxon:6239			
+WB	WBGene00018580	F47G6.3			gene	taxon:6239			
+WB	WBGene00018586	ubxn-3		F48A11.5	gene	taxon:6239			
+WB	WBGene00018589	F48B9.3			gene	taxon:6239			
+WB	WBGene00018591	npax-2		F48B9.5	gene	taxon:6239			
+WB	WBGene00018594	aman-3		F48C1.1	gene	taxon:6239			
+WB	WBGene00018595	fbxa-145		F48C1.2	gene	taxon:6239			
+WB	WBGene00018596	F48C1.3			gene	taxon:6239			
+WB	WBGene00018599	F48C1.6			gene	taxon:6239			
+WB	WBGene00018603	F48E3.2			gene	taxon:6239			
+WB	WBGene00018604	uggt-1		F48E3.3	gene	taxon:6239			
+WB	WBGene00018605	F48E3.4			gene	taxon:6239			
+WB	WBGene00018606	F48E3.6			gene	taxon:6239			
+WB	WBGene00018607	F48E3.8			gene	taxon:6239			
+WB	WBGene00018610	F48E8.3			gene	taxon:6239			
+WB	WBGene00018611	F48E8.4			gene	taxon:6239			
+WB	WBGene00018612	disl-2		F48E8.6|susi-1	gene	taxon:6239			
+WB	WBGene00018617	srt-17		F48G7.6	gene	taxon:6239			
+WB	WBGene00018620	F48G7.9			gene	taxon:6239			
+WB	WBGene00018621	F48G7.10			gene	taxon:6239			
+WB	WBGene00018622	nhr-190		F48G7.11	gene	taxon:6239			
+WB	WBGene00018625	prp-17		F49D11.1	gene	taxon:6239			
+WB	WBGene00018627	F49D11.3			gene	taxon:6239			
+WB	WBGene00018630	F49D11.6			gene	taxon:6239			
+WB	WBGene00018632	tag-296		F49D11.9	gene	taxon:6239			
+WB	WBGene00018634	pigx-1		F49E7.2	gene	taxon:6239			
+WB	WBGene00018638	F49E8.7			gene	taxon:6239			
+WB	WBGene00018640	F49E10.2			gene	taxon:6239			
+WB	WBGene00018641	F49E10.4			gene	taxon:6239			
+WB	WBGene00018643	drd-50		F49F1.1	gene	taxon:6239			
+WB	WBGene00018646	mul-1		F49F1.6	gene	taxon:6239			
+WB	WBGene00018649	F49F1.9			gene	taxon:6239			
+WB	WBGene00018650	F49F1.10			gene	taxon:6239			
+WB	WBGene00018651	F49F1.11			gene	taxon:6239			
+WB	WBGene00018652	F49F1.12			gene	taxon:6239			
+WB	WBGene00018654	F49H12.3			gene	taxon:6239			
+WB	WBGene00018655	F49H12.4			gene	taxon:6239			
+WB	WBGene00018656	txdc-12.2		F49H12.5	gene	taxon:6239			
+WB	WBGene00018657	acl-4		F49H12.6	gene	taxon:6239			
+WB	WBGene00018660	F52C6.3		F52C6.l|phi-32	gene	taxon:6239			
+WB	WBGene00018672	sorf-2		F52C9.1|wdr-81	gene	taxon:6239			
+WB	WBGene00018674	F52C9.3			gene	taxon:6239			
+WB	WBGene00018678	tdpo-1		F52C12.1	gene	taxon:6239			
+WB	WBGene00018679	F52C12.2			gene	taxon:6239			
+WB	WBGene00018680	tsen-54		F52C12.3	gene	taxon:6239			
+WB	WBGene00018682	aagr-4		F52D1.1	gene	taxon:6239			
+WB	WBGene00018687	F52D2.5			gene	taxon:6239			
+WB	WBGene00018692	F52E1.2			gene	taxon:6239			
+WB	WBGene00018694	F52E1.5			gene	taxon:6239			
+WB	WBGene00018697	F52E1.9			gene	taxon:6239			
+WB	WBGene00018698	vha-18		F52E1.10	gene	taxon:6239			
+WB	WBGene00018700	lmd-3		F52E1.13|oxr1	gene	taxon:6239			
+WB	WBGene00018701	pccb-1		F52E4.1	gene	taxon:6239			
+WB	WBGene00018703	sec-3		F52E4.7	gene	taxon:6239			
+WB	WBGene00018706	F52F10.2			gene	taxon:6239			
+WB	WBGene00018707	oac-31		F52F10.3	gene	taxon:6239			
+WB	WBGene00018708	oac-32		F52F10.4	gene	taxon:6239			
+WB	WBGene00018709	srsx-8		F52F10.5	gene	taxon:6239			
+WB	WBGene00018716	F52H2.4			gene	taxon:6239			
+WB	WBGene00018718	dhcr-24		F52H2.6	gene	taxon:6239			
+WB	WBGene00018719	ccd-5		F52H2.7	gene	taxon:6239			
+WB	WBGene00018720	F53A3.1			gene	taxon:6239			
+WB	WBGene00018721	polh-1		F53A3.2	gene	taxon:6239			
+WB	WBGene00018723	F53A3.7			gene	taxon:6239			
+WB	WBGene00018724	F53A9.1			gene	taxon:6239			
+WB	WBGene00018725	kreg-1		F53A9.2	gene	taxon:6239			
+WB	WBGene00018727	jbts-14		F53A9.4	gene	taxon:6239			
+WB	WBGene00018728	frpr-8		F53A9.5	gene	taxon:6239			
+WB	WBGene00018729	F53A9.6			gene	taxon:6239			
+WB	WBGene00018730	F53A9.7			gene	taxon:6239			
+WB	WBGene00018731	F53A9.8			gene	taxon:6239			
+WB	WBGene00018734	F53A10.2			gene	taxon:6239			
+WB	WBGene00018735	F53B1.2			gene	taxon:6239			
+WB	WBGene00018736	F53B1.3			gene	taxon:6239			
+WB	WBGene00018737	WBGene00018737			gene	taxon:6239			
+WB	WBGene00018739	F53B1.8			gene	taxon:6239			
+WB	WBGene00018740	tra-4		F53B3.1|F53B3.e	gene	taxon:6239			
+WB	WBGene00018741	comt-1		F53B3.2	gene	taxon:6239			
+WB	WBGene00018742	F53B3.3			gene	taxon:6239			
+WB	WBGene00018743	F53B3.5			gene	taxon:6239			
+WB	WBGene00018745	F53C3.1			gene	taxon:6239			
+WB	WBGene00018747	F53C3.3			gene	taxon:6239			
+WB	WBGene00018748	F53C3.4			gene	taxon:6239			
+WB	WBGene00018750	F53C3.6			gene	taxon:6239			
+WB	WBGene00018754	F53C3.11			gene	taxon:6239			
+WB	WBGene00018755	bcmo-2		F53C3.12	gene	taxon:6239			
+WB	WBGene00018756	plpp-1.1		F53C3.13	gene	taxon:6239			
+WB	WBGene00018757	gid-8		F53E2.1|tag-304	gene	taxon:6239			
+WB	WBGene00018758	F53E10.1			gene	taxon:6239			
+WB	WBGene00018760	irg-3		F53E10.4|nspg-2	gene	taxon:6239			
+WB	WBGene00018762	F53E10.6			gene	taxon:6239			
+WB	WBGene00018763	F53F10.1			gene	taxon:6239			
+WB	WBGene00018764	F53F10.2			gene	taxon:6239			
+WB	WBGene00018765	mpc-2		F53F10.3	gene	taxon:6239			
+WB	WBGene00018769	mnat-1		F53G2.7	gene	taxon:6239			
+WB	WBGene00018771	duox-2		F53G12.3	gene	taxon:6239			
+WB	WBGene00018772	F53G12.4			gene	taxon:6239			
+WB	WBGene00018773	F53G12.8			gene	taxon:6239			
+WB	WBGene00018776	ddx-46		F53H1.1	gene	taxon:6239			
+WB	WBGene00018777	F53H1.3			gene	taxon:6239			
+WB	WBGene00018778	F53H1.4			gene	taxon:6239			
+WB	WBGene00018779	F53H8.3			gene	taxon:6239			
+WB	WBGene00018781	F54A3.2		F54A3.a|F54A3.g|F54A3.h	gene	taxon:6239			
+WB	WBGene00018782	cct-3		F54A3.3|F54A3.f	gene	taxon:6239			
+WB	WBGene00018784	F54A3.5		F54A3.c	gene	taxon:6239			
+WB	WBGene00018786	hmbx-1		F54A5.1|C54G6.f	gene	taxon:6239			
+WB	WBGene00018788	shc-1		F54A5.3	gene	taxon:6239			
+WB	WBGene00018789	F54C1.1			gene	taxon:6239			
+WB	WBGene00018792	F54C1.8			gene	taxon:6239			
+WB	WBGene00018793	mrpl-40		F54C4.1	gene	taxon:6239			
+WB	WBGene00018797	ept-1		F54D7.2	gene	taxon:6239			
+WB	WBGene00018798	gnrr-1		F54D7.3	gene	taxon:6239			
+WB	WBGene00018808	F54D10.7			gene	taxon:6239			
+WB	WBGene00018809	F54D10.8			gene	taxon:6239			
+WB	WBGene00018811	pmt-2		F54D11.1	gene	taxon:6239			
+WB	WBGene00018819	rog-1		F54D12.6|eom-1|F54D12.d|F54D12.e	gene	taxon:6239			
+WB	WBGene00018823	F54E2.1			gene	taxon:6239			
+WB	WBGene00018824	F54E2.2			gene	taxon:6239			
+WB	WBGene00018825	F54E2.5			gene	taxon:6239			
+WB	WBGene00018826	srt-34		F54E2.6	gene	taxon:6239			
+WB	WBGene00018827	pst-2		F54E7.1	gene	taxon:6239			
+WB	WBGene00018828	sdz-21		F54E7.5	gene	taxon:6239			
+WB	WBGene00018831	F54E7.9			gene	taxon:6239			
+WB	WBGene00018833	ztf-1		F54F2.5	gene	taxon:6239			
+WB	WBGene00018836	F54F2.9			gene	taxon:6239			
+WB	WBGene00018839	F54H5.2		F54H5.d	gene	taxon:6239			
+WB	WBGene00018840	F54H5.3			gene	taxon:6239			
+WB	WBGene00018842	F54H12.2			gene	taxon:6239			
+WB	WBGene00018845	F54H12.5			gene	taxon:6239			
+WB	WBGene00018846	eef-1B.1		F54H12.6	gene	taxon:6239			
+WB	WBGene00018847	marc-6		F55A3.1	gene	taxon:6239			
+WB	WBGene00018849	spt-16		F55A3.3|F55A3.b|phi-16	gene	taxon:6239			
+WB	WBGene00018850	gpx-8		F55A3.5	gene	taxon:6239			
+WB	WBGene00018853	sec-22		F55A4.1	gene	taxon:6239			
+WB	WBGene00018855	F55A4.3			gene	taxon:6239			
+WB	WBGene00018857	stau-1		F55A4.5	gene	taxon:6239			
+WB	WBGene00018860	vpat-1		F55A4.8	gene	taxon:6239			
+WB	WBGene00018861	cutl-21		F55A4.10	gene	taxon:6239			
+WB	WBGene00018863	F55A12.2			gene	taxon:6239			
+WB	WBGene00018866	nath-10		F55A12.8|let-599	gene	taxon:6239			
+WB	WBGene00018867	zhp-1		F55A12.10|F55A12.c	gene	taxon:6239			
+WB	WBGene00018869	rfip-1		F55C12.1	gene	taxon:6239			
+WB	WBGene00018871	F55C12.4			gene	taxon:6239			
+WB	WBGene00018872	F55C12.5			gene	taxon:6239			
+WB	WBGene00018877	aman-1		F55D10.1	gene	taxon:6239			
+WB	WBGene00018878	glit-1		F55D10.3|cest-11	gene	taxon:6239			
+WB	WBGene00018879	F55D10.4			gene	taxon:6239			
+WB	WBGene00018880	acc-3		F55D10.5	gene	taxon:6239			
+WB	WBGene00018881	F55E10.1			gene	taxon:6239			
+WB	WBGene00018882	F55E10.2			gene	taxon:6239			
+WB	WBGene00018883	F55E10.4			gene	taxon:6239			
+WB	WBGene00018885	drd-5		F55E10.6	gene	taxon:6239			
+WB	WBGene00018886	npr-28		F55E10.7	gene	taxon:6239			
+WB	WBGene00018890	F55F8.2			gene	taxon:6239			
+WB	WBGene00018892	cir-1		F55F8.4|F55F8.i|tag-326	gene	taxon:6239			
+WB	WBGene00018893	wdr-12		F55F8.5|let-379|tag-345	gene	taxon:6239			
+WB	WBGene00018894	mff-2		F55F8.6	gene	taxon:6239			
+WB	WBGene00018895	F55F8.7			gene	taxon:6239			
+WB	WBGene00018897	zipt-2.4		F55F8.9	gene	taxon:6239			
+WB	WBGene00018898	F55F10.1		Y24D9A.e	gene	taxon:6239			
+WB	WBGene00018899	F55G1.1			gene	taxon:6239			
+WB	WBGene00018900	rod-1		F55G1.4	gene	taxon:6239			
+WB	WBGene00018901	slc-25A18.2		F55G1.5	gene	taxon:6239			
+WB	WBGene00018902	F55G1.6			gene	taxon:6239			
+WB	WBGene00018904	pycr-4		F55G1.9	gene	taxon:6239			
+WB	WBGene00018906	egas-4		F55G1.13	gene	taxon:6239			
+WB	WBGene00018907	F55G1.15			gene	taxon:6239			
+WB	WBGene00018909	slx-1		F56A3.2|giyd-1	gene	taxon:6239			
+WB	WBGene00018910	F56A4.2			gene	taxon:6239			
+WB	WBGene00018911	F56A4.3			gene	taxon:6239			
+WB	WBGene00018912	F56A4.4			gene	taxon:6239			
+WB	WBGene00018918	F56A4.10			gene	taxon:6239			
+WB	WBGene00018920	F56A4.12			gene	taxon:6239			
+WB	WBGene00018921	sago-2		F56A6.1|wago-6|Y65B4A.g	gene	taxon:6239			
+WB	WBGene00018923	eme-1		F56A6.4|Y65B4A.f	gene	taxon:6239			
+WB	WBGene00018924	F56A11.4			gene	taxon:6239			
+WB	WBGene00018925	F56A11.5			gene	taxon:6239			
+WB	WBGene00018926	F56A11.6			gene	taxon:6239			
+WB	WBGene00018930	F56B3.6			gene	taxon:6239			
+WB	WBGene00018931	ugt-52		F56B3.7	gene	taxon:6239			
+WB	WBGene00018932	mrpl-2		F56B3.8	gene	taxon:6239			
+WB	WBGene00018934	F56B3.11			gene	taxon:6239			
+WB	WBGene00018935	skr-18		F56B3.12	gene	taxon:6239			
+WB	WBGene00018940	F56C3.3			gene	taxon:6239			
+WB	WBGene00018941	F56C3.4			gene	taxon:6239			
+WB	WBGene00018943	dgn-2		F56C3.6	gene	taxon:6239			
+WB	WBGene00018944	F56C3.7			gene	taxon:6239			
+WB	WBGene00018948	F56C9.3		F56C9.f|F56C9.h	gene	taxon:6239			
+WB	WBGene00018949	acbp-4		F56C9.5	gene	taxon:6239			
+WB	WBGene00018951	nspg-6		F56C9.7	gene	taxon:6239			
+WB	WBGene00018952	F56C9.8			gene	taxon:6239			
+WB	WBGene00018955	F56C11.3			gene	taxon:6239			
+WB	WBGene00018957	F56C11.5			gene	taxon:6239			
+WB	WBGene00018958	cest-27		F56C11.6	gene	taxon:6239			
+WB	WBGene00018959	F56D1.1		F56D1.h	gene	taxon:6239			
+WB	WBGene00018960	ilcr-2		F56D1.2	gene	taxon:6239			
+WB	WBGene00018961	mrps-16		F56D1.3	gene	taxon:6239			
+WB	WBGene00018963	ucr-1		F56D2.1	gene	taxon:6239			
+WB	WBGene00018964	F56D2.2			gene	taxon:6239			
+WB	WBGene00018966	F56D2.5			gene	taxon:6239			
+WB	WBGene00018967	ddx-15		F56D2.6	gene	taxon:6239			
+WB	WBGene00018970	clec-68		F56D6.1	gene	taxon:6239			
+WB	WBGene00018971	clec-67		F56D6.2	gene	taxon:6239			
+WB	WBGene00018972	srz-19		F56D6.4	gene	taxon:6239			
+WB	WBGene00018973	srz-20		F56D6.5	gene	taxon:6239			
+WB	WBGene00018974	fcho-1		F56D12.6	gene	taxon:6239			
+WB	WBGene00018975	picd-1		F56E10.1	gene	taxon:6239			
+WB	WBGene00018976	daam-1		F56E10.2|fhod-2|Y38C9B.a	gene	taxon:6239			
+WB	WBGene00018978	ttr-58		F56F4.1|sdz-22	gene	taxon:6239			
+WB	WBGene00018979	ttr-55		F56F4.2	gene	taxon:6239			
+WB	WBGene00018980	F56F4.3			gene	taxon:6239			
+WB	WBGene00018984	F56F10.1			gene	taxon:6239			
+WB	WBGene00018986	cdo-1		F56F10.3	gene	taxon:6239			
+WB	WBGene00018987	lgl-1		F56F10.4	gene	taxon:6239			
+WB	WBGene00018990	klf-1		F56F11.3	gene	taxon:6239			
+WB	WBGene00018991	F56F11.4			gene	taxon:6239			
+WB	WBGene00018995	ccpp-1		F56H1.5|Nnac1	gene	taxon:6239			
+WB	WBGene00018996	F57B9.1			gene	taxon:6239			
+WB	WBGene00018997	F57B9.3		phi-2	gene	taxon:6239			
+WB	WBGene00018998	flap-1		F57B9.7	gene	taxon:6239			
+WB	WBGene00018999	F57B9.8			gene	taxon:6239			
+WB	WBGene00019001	ipgm-1		F57B10.3	gene	taxon:6239			
+WB	WBGene00019003	tmed-3		F57B10.5	gene	taxon:6239			
+WB	WBGene00019004	xpg-1		F57B10.6	gene	taxon:6239			
+WB	WBGene00019006	spg-20		F57B10.9	gene	taxon:6239			
+WB	WBGene00019007	ucr-11		F57B10.14	gene	taxon:6239			
+WB	WBGene00019008	pdxk-1		F57C9.1	gene	taxon:6239			
+WB	WBGene00019009	clec-90		F57C9.2	gene	taxon:6239			
+WB	WBGene00019010	glo-2		F57C9.3	gene	taxon:6239			
+WB	WBGene00019011	F57C9.4			gene	taxon:6239			
+WB	WBGene00019012	F57C9.6			gene	taxon:6239			
+WB	WBGene00019014	F57C12.2			gene	taxon:6239			
+WB	WBGene00019017	F57F4.4			gene	taxon:6239			
+WB	WBGene00019018	abts-3		F57F10.1	gene	taxon:6239			
+WB	WBGene00019019	frpr-10		F57H12.4	gene	taxon:6239			
+WB	WBGene00019020	F57H12.5			gene	taxon:6239			
+WB	WBGene00019022	F58A6.1			gene	taxon:6239			
+WB	WBGene00019023	F58A6.2			gene	taxon:6239			
+WB	WBGene00019024	F58A6.5			gene	taxon:6239			
+WB	WBGene00019025	srb-16		F58A6.6	gene	taxon:6239			
+WB	WBGene00019027	srb-12		F58A6.10	gene	taxon:6239			
+WB	WBGene00019028	srb-13		F58A6.11	gene	taxon:6239			
+WB	WBGene00019029	F58B6.1			gene	taxon:6239			
+WB	WBGene00019030	exc-6		F58B6.2|inft-1|tag-268	gene	taxon:6239			
+WB	WBGene00019032	srsx-17		F58D7.1	gene	taxon:6239			
+WB	WBGene00019036	irld-36		F58E1.4	gene	taxon:6239			
+WB	WBGene00019049	F58E2.5			gene	taxon:6239			
+WB	WBGene00019051	srz-23		F58E2.9	gene	taxon:6239			
+WB	WBGene00019053	F58F6.5			gene	taxon:6239			
+WB	WBGene00019054	F58F6.6			gene	taxon:6239			
+WB	WBGene00019060	acox-3		F58F9.7|acox-6	gene	taxon:6239			
+WB	WBGene00019061	F58F12.1		phi-38	gene	taxon:6239			
+WB	WBGene00019064	myo-5		F58G4.1	gene	taxon:6239			
+WB	WBGene00019066	sdz-23		F58G4.4	gene	taxon:6239			
+WB	WBGene00019069	lgc-30		F58H7.3	gene	taxon:6239			
+WB	WBGene00019074	cpd-1		F59A3.1	gene	taxon:6239			
+WB	WBGene00019076	mrpl-24		F59A3.3	gene	taxon:6239			
+WB	WBGene00019077	zipt-11		F59A3.4	gene	taxon:6239			
+WB	WBGene00019080	F59A3.7			gene	taxon:6239			
+WB	WBGene00019081	F59A3.8			gene	taxon:6239			
+WB	WBGene00019086	F59A6.4			gene	taxon:6239			
+WB	WBGene00019087	F59A6.5			gene	taxon:6239			
+WB	WBGene00019089	clec-206		F59A7.1	gene	taxon:6239			
+WB	WBGene00019090	F59A7.2			gene	taxon:6239			
+WB	WBGene00019091	srab-13		F59A7.3	gene	taxon:6239			
+WB	WBGene00019096	cysl-4		F59A7.9	gene	taxon:6239			
+WB	WBGene00019098	F59B1.4			gene	taxon:6239			
+WB	WBGene00019099	F59B1.6			gene	taxon:6239			
+WB	WBGene00019100	F59B1.8			gene	taxon:6239			
+WB	WBGene00019104	asp-7		F59D6.2	gene	taxon:6239			
+WB	WBGene00019105	asp-8		F59D6.3	gene	taxon:6239			
+WB	WBGene00019108	chpf-2		F59D6.7	gene	taxon:6239			
+WB	WBGene00019109	F59E11.2			gene	taxon:6239			
+WB	WBGene00019111	F59E11.5			gene	taxon:6239			
+WB	WBGene00019113	F59E11.7			gene	taxon:6239			
+WB	WBGene00019115	nhr-195		F59E11.10	gene	taxon:6239			
+WB	WBGene00019116	nhr-143		F59E11.11	gene	taxon:6239			
+WB	WBGene00019120	npl-4.1		F59E12.4	gene	taxon:6239			
+WB	WBGene00019121	npl-4.2		F59E12.5	gene	taxon:6239			
+WB	WBGene00019122	F59E12.6			gene	taxon:6239			
+WB	WBGene00019123	F59E12.8			gene	taxon:6239			
+WB	WBGene00019125	ddl-1		F59E12.10	gene	taxon:6239			
+WB	WBGene00019126	sam-4		F59E12.11|F59E12.c|F59E12.d|F59E12.n	gene	taxon:6239			
+WB	WBGene00019127	cgt-3		F59G1.1	gene	taxon:6239			
+WB	WBGene00019128	F59G1.4			gene	taxon:6239			
+WB	WBGene00019130	gbas-1		F59H5.1	gene	taxon:6239			
+WB	WBGene00019146	H02F09.3			gene	taxon:6239			
+WB	WBGene00019149	H03E18.2			gene	taxon:6239			
+WB	WBGene00019151	pck-3		H04M03.1	gene	taxon:6239			
+WB	WBGene00019153	H04M03.3			gene	taxon:6239			
+WB	WBGene00019154	glf-1		H04M03.4	gene	taxon:6239			
+WB	WBGene00019155	H04M03.11			gene	taxon:6239			
+WB	WBGene00019156	H04M03.12			gene	taxon:6239			
+WB	WBGene00019157	H05C05.1			gene	taxon:6239			
+WB	WBGene00019160	nlp-49		H05L03.3|crf-1	gene	taxon:6239			
+WB	WBGene00019162	eif-1.A		H06H21.3	gene	taxon:6239			
+WB	WBGene00019163	ubxn-6		H06H21.6	gene	taxon:6239			
+WB	WBGene00019166	tat-2		H06H21.10	gene	taxon:6239			
+WB	WBGene00019167	H06I04.1			gene	taxon:6239			
+WB	WBGene00019168	H06I04.3		H06I04.g	gene	taxon:6239			
+WB	WBGene00019182	H10E21.1			gene	taxon:6239			
+WB	WBGene00019183	npr-30		H10E21.2	gene	taxon:6239			
+WB	WBGene00019184	H10E21.4			gene	taxon:6239			
+WB	WBGene00019185	H10E21.5			gene	taxon:6239			
+WB	WBGene00019187	H11E01.2		H11E01.c	gene	taxon:6239			
+WB	WBGene00019190	H12I13.1			gene	taxon:6239			
+WB	WBGene00019196	H14A12.3			gene	taxon:6239			
+WB	WBGene00019198	strm-1		H14E04.1	gene	taxon:6239			
+WB	WBGene00019199	H14E04.2			gene	taxon:6239			
+WB	WBGene00019200	H14E04.3			gene	taxon:6239			
+WB	WBGene00019202	H14N18.2			gene	taxon:6239			
+WB	WBGene00019203	ttr-47		H14N18.3	gene	taxon:6239			
+WB	WBGene00019204	H14N18.4			gene	taxon:6239			
+WB	WBGene00019205	kcc-2		H16O14.1	gene	taxon:6239			
+WB	WBGene00019207	fgt-1		H17B01.1|Y51H7BL.a|Y51H7BL.b	gene	taxon:6239			
+WB	WBGene00019209	emc-1		H17B01.4	gene	taxon:6239			
+WB	WBGene00019211	H18N23.2		H18N23.a	gene	taxon:6239			
+WB	WBGene00019212	zmp-2		H19M22.3|H19M22.d	gene	taxon:6239			
+WB	WBGene00019213	H20E11.1			gene	taxon:6239			
+WB	WBGene00019215	H20E11.3			gene	taxon:6239			
+WB	WBGene00019216	H20J04.1			gene	taxon:6239			
+WB	WBGene00019217	athp-2		H20J04.2	gene	taxon:6239			
+WB	WBGene00019218	madf-3		H20J04.3	gene	taxon:6239			
+WB	WBGene00019219	H20J04.4			gene	taxon:6239			
+WB	WBGene00019220	pfd-2		H20J04.5|tag-355	gene	taxon:6239			
+WB	WBGene00019221	H20J04.6			gene	taxon:6239			
+WB	WBGene00019222	H20J04.7			gene	taxon:6239			
+WB	WBGene00019224	gnrr-5		H22D07.1	gene	taxon:6239			
+WB	WBGene00019225	bgal-2		H22K11.2	gene	taxon:6239			
+WB	WBGene00019227	sgca-1		H22K11.4	gene	taxon:6239			
+WB	WBGene00019228	H23L24.1			gene	taxon:6239			
+WB	WBGene00019229	ipla-5		H23L24.2	gene	taxon:6239			
+WB	WBGene00019230	ttll-11		H23L24.3	gene	taxon:6239			
+WB	WBGene00019231	H23L24.4			gene	taxon:6239			
+WB	WBGene00019232	ugt-13		H23N18.1	gene	taxon:6239			
+WB	WBGene00019233	ugt-14		H23N18.2	gene	taxon:6239			
+WB	WBGene00019234	ugt-8		H23N18.3	gene	taxon:6239			
+WB	WBGene00019235	H23N18.4			gene	taxon:6239			
+WB	WBGene00019236	H23N18.5			gene	taxon:6239			
+WB	WBGene00019240	adh-5		H24K24.3	gene	taxon:6239			
+WB	WBGene00019241	trm-2A		H24K24.4	gene	taxon:6239			
+WB	WBGene00019242	srbc-40		H24O09.1	gene	taxon:6239			
+WB	WBGene00019245	sacy-1		H27M09.1	gene	taxon:6239			
+WB	WBGene00019246	rpb-5		H27M09.2|let-397	gene	taxon:6239			
+WB	WBGene00019247	syp-4		H27M09.3	gene	taxon:6239			
+WB	WBGene00019248	H27M09.5			gene	taxon:6239			
+WB	WBGene00019249	hrpa-2		H28G03.1	gene	taxon:6239			
+WB	WBGene00019257	dhhc-13		H32C10.3	gene	taxon:6239			
+WB	WBGene00019259	H34C03.2			gene	taxon:6239			
+WB	WBGene00019262	dmsr-12		H34P18.1	gene	taxon:6239			
+WB	WBGene00019264	H35B03.2			gene	taxon:6239			
+WB	WBGene00019266	H35N09.2			gene	taxon:6239			
+WB	WBGene00019269	H41C03.2			gene	taxon:6239			
+WB	WBGene00019270	H41C03.3			gene	taxon:6239			
+WB	WBGene00019273	H43E16.1			gene	taxon:6239			
+WB	WBGene00019275	rpac-40		H43I07.2	gene	taxon:6239			
+WB	WBGene00019276	algn-5		H43I07.3	gene	taxon:6239			
+WB	WBGene00019277	sgcb-1		K01A2.1	gene	taxon:6239			
+WB	WBGene00019279	K01A2.4			gene	taxon:6239			
+WB	WBGene00019280	K01A2.5			gene	taxon:6239			
+WB	WBGene00019282	mps-2		K01A2.8	gene	taxon:6239			
+WB	WBGene00019283	K01A2.9			gene	taxon:6239			
+WB	WBGene00019285	cbn-1		K01A2.11	gene	taxon:6239			
+WB	WBGene00019286	K01A12.2			gene	taxon:6239			
+WB	WBGene00019287	K01A12.3			gene	taxon:6239			
+WB	WBGene00019288	K02A2.1			gene	taxon:6239			
+WB	WBGene00019289	kcc-3		K02A2.3	gene	taxon:6239			
+WB	WBGene00019295	pfkb-1.2		K02B2.1	gene	taxon:6239			
+WB	WBGene00019296	mcu-1		K02B2.3	gene	taxon:6239			
+WB	WBGene00019298	pnp-1		K02D7.1	gene	taxon:6239			
+WB	WBGene00019300	swt-1		K02D7.5	gene	taxon:6239			
+WB	WBGene00019301	K02D10.1			gene	taxon:6239			
+WB	WBGene00019305	snap-29		K02D10.5|phi-28	gene	taxon:6239			
+WB	WBGene00019314	K02E7.10			gene	taxon:6239			
+WB	WBGene00019315	K02E7.11			gene	taxon:6239			
+WB	WBGene00019317	K02E10.1			gene	taxon:6239			
+WB	WBGene00019318	K02E10.4			gene	taxon:6239			
+WB	WBGene00019319	K02E10.5			gene	taxon:6239			
+WB	WBGene00019321	K02E10.7			gene	taxon:6239			
+WB	WBGene00019322	ahcy-1		K02F2.2|CEAHH|K02F2.a|K02F2.h|let-534|S-adenosylhomocysteine hydrolase, AHH|SAHCE	gene	taxon:6239			
+WB	WBGene00019323	teg-4		K02F2.3|K02F2.e|K02F2.f|K02F2.g|let-385|phi-6|tag-203	gene	taxon:6239			
+WB	WBGene00019326	K02F3.2			gene	taxon:6239			
+WB	WBGene00019327	zip-2		K02F3.4	gene	taxon:6239			
+WB	WBGene00019328	clec-149		K02F3.5	gene	taxon:6239			
+WB	WBGene00019329	ceeh-1		K02F3.6	gene	taxon:6239			
+WB	WBGene00019333	moma-1		K02F3.10	gene	taxon:6239			
+WB	WBGene00019334	K02F3.12			gene	taxon:6239			
+WB	WBGene00019335	K02F6.1			gene	taxon:6239			
+WB	WBGene00019337	K02F6.3			gene	taxon:6239			
+WB	WBGene00019338	K02F6.4			gene	taxon:6239			
+WB	WBGene00019339	K02F6.5			gene	taxon:6239			
+WB	WBGene00019342	K02F6.8			gene	taxon:6239			
+WB	WBGene00019343	nep-18		K02F6.9|Y47G7C.b	gene	taxon:6239			
+WB	WBGene00019344	dhhc-10		K02G10.1	gene	taxon:6239			
+WB	WBGene00019345	tmem-135		K02G10.3	gene	taxon:6239			
+WB	WBGene00019346	K02G10.5			gene	taxon:6239			
+WB	WBGene00019347	mbl-1		K02H8.1	gene	taxon:6239			
+WB	WBGene00019348	K02H11.4			gene	taxon:6239			
+WB	WBGene00019351	lron-7		K03A1.2	gene	taxon:6239			
+WB	WBGene00019352	K03A1.4			gene	taxon:6239			
+WB	WBGene00019353	K03B4.1			gene	taxon:6239			
+WB	WBGene00019356	K03B4.6			gene	taxon:6239			
+WB	WBGene00019360	neto-1		K03E5.1	gene	taxon:6239			
+WB	WBGene00019362	cdk-2		K03E5.3	gene	taxon:6239			
+WB	WBGene00019364	mksr-1		K03E6.4|tza-2	gene	taxon:6239			
+WB	WBGene00019365	rei-2		K03E6.7	gene	taxon:6239			
+WB	WBGene00019367	K03H6.1		K03H6.e	gene	taxon:6239			
+WB	WBGene00019368	txt-4		K03H6.2	gene	taxon:6239			
+WB	WBGene00019369	K03H6.4			gene	taxon:6239			
+WB	WBGene00019370	K03H6.5			gene	taxon:6239			
+WB	WBGene00019373	K04A8.1			gene	taxon:6239			
+WB	WBGene00019376	lipl-4		K04A8.5	gene	taxon:6239			
+WB	WBGene00019380	K04C2.2		K04C2.a	gene	taxon:6239			
+WB	WBGene00019383	K04E7.1			gene	taxon:6239			
+WB	WBGene00019394	K04F10.1			gene	taxon:6239			
+WB	WBGene00019395	K04F10.2			gene	taxon:6239			
+WB	WBGene00019401	nuo-4		K04G7.4|K04G7.4a|K04G7.4b	gene	taxon:6239			
+WB	WBGene00019402	syf-2		K04G7.11	gene	taxon:6239			
+WB	WBGene00019404	K05B2.4			gene	taxon:6239			
+WB	WBGene00019405	K05F1.1			gene	taxon:6239			
+WB	WBGene00019406	acdh-8		K05F1.3	gene	taxon:6239			
+WB	WBGene00019407	lect-2		K05F1.5	gene	taxon:6239			
+WB	WBGene00019408	K05F1.6			gene	taxon:6239			
+WB	WBGene00019409	K05F1.8			gene	taxon:6239			
+WB	WBGene00019410	K05F1.9			gene	taxon:6239			
+WB	WBGene00019411	K05F1.10			gene	taxon:6239			
+WB	WBGene00019422	K05G3.1			gene	taxon:6239			
+WB	WBGene00019424	aptf-1		K06A1.1	gene	taxon:6239			
+WB	WBGene00019425	K06A1.2			gene	taxon:6239			
+WB	WBGene00019426	cutl-16		K06A1.3	gene	taxon:6239			
+WB	WBGene00019427	atg-16.2		K06A1.5	gene	taxon:6239			
+WB	WBGene00019428	dgk-5		K06A1.6	gene	taxon:6239			
+WB	WBGene00019429	uad-2		K06A5.1	gene	taxon:6239			
+WB	WBGene00019430	K06A5.2			gene	taxon:6239			
+WB	WBGene00019431	K06A5.3			gene	taxon:6239			
+WB	WBGene00019432	knl-2		K06A5.4|let-380	gene	taxon:6239			
+WB	WBGene00019433	acdh-3		K06A5.6	gene	taxon:6239			
+WB	WBGene00019435	K06A9.1			gene	taxon:6239			
+WB	WBGene00019437	K06A9.3			gene	taxon:6239			
+WB	WBGene00019438	cyp-25A6		K06B9.1	gene	taxon:6239			
+WB	WBGene00019444	frpr-11		K06C4.8	gene	taxon:6239			
+WB	WBGene00019445	frpr-12		K06C4.9	gene	taxon:6239			
+WB	WBGene00019448	frpr-13		K06C4.17	gene	taxon:6239			
+WB	WBGene00019449	K06H6.1			gene	taxon:6239			
+WB	WBGene00019450	K06H6.2			gene	taxon:6239			
+WB	WBGene00019451	nstp-7		K06H6.3	gene	taxon:6239			
+WB	WBGene00019452	K06H6.4			gene	taxon:6239			
+WB	WBGene00019453	K06H6.5			gene	taxon:6239			
+WB	WBGene00019457	vms-1		K06H7.3	gene	taxon:6239			
+WB	WBGene00019459	K06H7.8			gene	taxon:6239			
+WB	WBGene00019460	idi-1		K06H7.9	gene	taxon:6239			
+WB	WBGene00019461	K07A3.3			gene	taxon:6239			
+WB	WBGene00019464	K07B1.4			gene	taxon:6239			
+WB	WBGene00019465	acl-14		K07B1.5	gene	taxon:6239			
+WB	WBGene00019467	K07B1.7			gene	taxon:6239			
+WB	WBGene00019470	cyp-35B3		K07C6.2	gene	taxon:6239			
+WB	WBGene00019471	cyp-35B2		K07C6.3	gene	taxon:6239			
+WB	WBGene00019472	cyp-35B1		K07C6.4|ccp-35B1|dod-13	gene	taxon:6239			
+WB	WBGene00019473	cyp-35A5		K07C6.5	gene	taxon:6239			
+WB	WBGene00019476	timp-1		K07C11.3	gene	taxon:6239			
+WB	WBGene00019477	cest-17		K07C11.4	gene	taxon:6239			
+WB	WBGene00019478	cri-2		K07C11.5|5I683|tag-225	gene	taxon:6239			
+WB	WBGene00019479	K07C11.7		cm12g2	gene	taxon:6239			
+WB	WBGene00019481	cogc-6		K07C11.9	gene	taxon:6239			
+WB	WBGene00019482	K07C11.10			gene	taxon:6239			
+WB	WBGene00019483	K07D4.2			gene	taxon:6239			
+WB	WBGene00019487	ephx-1		K07D4.7|tag-154|tag-218|Y14H12A.a|Y14H12A.c	gene	taxon:6239			
+WB	WBGene00019489	K07E1.1			gene	taxon:6239			
+WB	WBGene00019492	K07E3.4			gene	taxon:6239			
+WB	WBGene00019493	catp-5		K07E3.7	gene	taxon:6239			
+WB	WBGene00019495	sdz-24		K07E8.3	gene	taxon:6239			
+WB	WBGene00019496	frpr-14		K07E8.5	gene	taxon:6239			
+WB	WBGene00019497	K07E8.6			gene	taxon:6239			
+WB	WBGene00019498	K07E8.7			gene	taxon:6239			
+WB	WBGene00019503	tbce-1		K07H8.1	gene	taxon:6239			
+WB	WBGene00019504	K07H8.2			gene	taxon:6239			
+WB	WBGene00019506	K07H8.5			gene	taxon:6239			
+WB	WBGene00019507	K07H8.7			gene	taxon:6239			
+WB	WBGene00019508	K07H8.8			gene	taxon:6239			
+WB	WBGene00019509	K07H8.9			gene	taxon:6239			
+WB	WBGene00019510	nucl-1		K07H8.10	gene	taxon:6239			
+WB	WBGene00019515	ugt-19		K08B4.3	gene	taxon:6239			
+WB	WBGene00019516	ugt-20		K08B4.4	gene	taxon:6239			
+WB	WBGene00019518	K08B5.1			gene	taxon:6239			
+WB	WBGene00019520	K08B12.1			gene	taxon:6239			
+WB	WBGene00019521	dmd-7		K08B12.2	gene	taxon:6239			
+WB	WBGene00019522	K08B12.3			gene	taxon:6239			
+WB	WBGene00019524	K08D9.2			gene	taxon:6239			
+WB	WBGene00019527	K08D9.6			gene	taxon:6239			
+WB	WBGene00019530	scrm-8		K08D10.7	gene	taxon:6239			
+WB	WBGene00019531	scrm-5		K08D10.8	gene	taxon:6239			
+WB	WBGene00019534	K08D10.11			gene	taxon:6239			
+WB	WBGene00019535	tsen-34		K08D10.12	gene	taxon:6239			
+WB	WBGene00019536	rpi-2		K08D12.2	gene	taxon:6239			
+WB	WBGene00019537	K08D12.3			gene	taxon:6239			
+WB	WBGene00019543	cif-1		K08F11.3	gene	taxon:6239			
+WB	WBGene00019544	miro-1		K08F11.5	gene	taxon:6239			
+WB	WBGene00019546	glct-6		W07G9.2|K09B3.2|W07G9.a	gene	taxon:6239			
+WB	WBGene00019547	K09C4.1			gene	taxon:6239			
+WB	WBGene00019548	K09C4.2			gene	taxon:6239			
+WB	WBGene00019549	K09C4.4			gene	taxon:6239			
+WB	WBGene00019550	K09C4.5			gene	taxon:6239			
+WB	WBGene00019556	K09C6.2			gene	taxon:6239			
+WB	WBGene00019558	srbc-12		K09C6.4	gene	taxon:6239			
+WB	WBGene00019559	srbc-13		K09C6.5	gene	taxon:6239			
+WB	WBGene00019564	K09D9.1			gene	taxon:6239			
+WB	WBGene00019565	cyp-35A3		K09D9.2	gene	taxon:6239			
+WB	WBGene00019566	K09D9.3			gene	taxon:6239			
+WB	WBGene00019579	oac-57		K09E10.1	gene	taxon:6239			
+WB	WBGene00019580	oac-58		K09E10.2	gene	taxon:6239			
+WB	WBGene00019583	K09F5.4			gene	taxon:6239			
+WB	WBGene00019584	set-12		K09F5.5	gene	taxon:6239			
+WB	WBGene00019586	K09F6.3			gene	taxon:6239			
+WB	WBGene00019590	K09F6.7			gene	taxon:6239			
+WB	WBGene00019595	dscc-1		K09H9.2	gene	taxon:6239			
+WB	WBGene00019599	acds-10		K09H11.1	gene	taxon:6239			
+WB	WBGene00019600	rga-3		K09H11.3	gene	taxon:6239			
+WB	WBGene00019603	K09H11.6			gene	taxon:6239			
+WB	WBGene00019604	pgph-1		K09H11.7	gene	taxon:6239			
+WB	WBGene00019605	ctsa-4.1		K10B2.2|ctsa-1|drd-7	gene	taxon:6239			
+WB	WBGene00019606	clec-88		K10B2.3|cpg-6	gene	taxon:6239			
+WB	WBGene00019607	K10B2.4			gene	taxon:6239			
+WB	WBGene00019608	ani-2		K10B2.5|tag-221	gene	taxon:6239			
+WB	WBGene00019612	gpcp-1		K10B3.6	gene	taxon:6239			
+WB	WBGene00019613	K10B4.1			gene	taxon:6239			
+WB	WBGene00019614	srt-54		K10B4.2	gene	taxon:6239			
+WB	WBGene00019615	K10B4.3			gene	taxon:6239			
+WB	WBGene00019616	nmur-2		K10B4.4	gene	taxon:6239			
+WB	WBGene00019617	ctsa-2		K10C2.1	gene	taxon:6239			
+WB	WBGene00019618	K10C2.2			gene	taxon:6239			
+WB	WBGene00019619	asp-14		K10C2.3	gene	taxon:6239			
+WB	WBGene00019620	fah-1		K10C2.4|phi-43	gene	taxon:6239			
+WB	WBGene00019624	rnst-2		K10C9.3	gene	taxon:6239			
+WB	WBGene00019625	K10C9.4			gene	taxon:6239			
+WB	WBGene00019627	hira-1		K10D2.1	gene	taxon:6239			
+WB	WBGene00019628	pup-2		K10D2.2	gene	taxon:6239			
+WB	WBGene00019629	cid-1		K10D2.3|cde-1|pup-1	gene	taxon:6239			
+WB	WBGene00019630	emb-1		K10D2.4|apc-16	gene	taxon:6239			
+WB	WBGene00019633	K10D2.7			gene	taxon:6239			
+WB	WBGene00019636	gsto-3		K10F12.4	gene	taxon:6239			
+WB	WBGene00019642	K11C4.1			gene	taxon:6239			
+WB	WBGene00019643	K11C4.2			gene	taxon:6239			
+WB	WBGene00019644	cpt-4		K11D12.4	gene	taxon:6239			
+WB	WBGene00019645	swt-7		K11D12.5	gene	taxon:6239			
+WB	WBGene00019646	K11D12.6			gene	taxon:6239			
+WB	WBGene00019647	K11D12.7			gene	taxon:6239			
+WB	WBGene00019648	K11D12.8			gene	taxon:6239			
+WB	WBGene00019649	exc-14		K11D12.9	gene	taxon:6239			
+WB	WBGene00019650	K11D12.11			gene	taxon:6239			
+WB	WBGene00019652	cest-34		K11G9.1	gene	taxon:6239			
+WB	WBGene00019653	cest-31		K11G9.2	gene	taxon:6239			
+WB	WBGene00019654	cest-28		K11G9.3	gene	taxon:6239			
+WB	WBGene00019655	K11G9.5			gene	taxon:6239			
+WB	WBGene00019656	slc-25A10		K11G12.5	gene	taxon:6239			
+WB	WBGene00019657	K11G12.6			gene	taxon:6239			
+WB	WBGene00019664	K11H12.8			gene	taxon:6239			
+WB	WBGene00019665	K11H12.9			gene	taxon:6239			
+WB	WBGene00019666	sago-1		K12B6.1|wago-8	gene	taxon:6239			
+WB	WBGene00019667	spe-49		K12B6.2|let-479	gene	taxon:6239			
+WB	WBGene00019668	fil-2		K12B6.3|lips-4	gene	taxon:6239			
+WB	WBGene00019669	K12B6.4			gene	taxon:6239			
+WB	WBGene00019673	K12C11.1			gene	taxon:6239			
+WB	WBGene00019674	K12C11.3		K12C11.c	gene	taxon:6239			
+WB	WBGene00019677	K12H4.2			gene	taxon:6239			
+WB	WBGene00019678	K12H4.3			gene	taxon:6239			
+WB	WBGene00019679	spcs-3		K12H4.4|phi-20	gene	taxon:6239			
+WB	WBGene00019682	K12H4.7			gene	taxon:6239			
+WB	WBGene00019683	K12H6.2			gene	taxon:6239			
+WB	WBGene00019686	K12H6.6			gene	taxon:6239			
+WB	WBGene00019692	fubl-4		M01A10.1|fubl-3.4|fubp-3.4	gene	taxon:6239			
+WB	WBGene00019693	ostd-1		M01A10.3	gene	taxon:6239			
+WB	WBGene00019698	riok-1		M01B12.5|M01B12.a|M01B12.b|susi-3	gene	taxon:6239			
+WB	WBGene00019710	M01E11.1			gene	taxon:6239			
+WB	WBGene00019711	ctnb-1		M01E11.2	gene	taxon:6239			
+WB	WBGene00019712	rmh-1		M01E11.3	gene	taxon:6239			
+WB	WBGene00019716	tmem-120		M01G5.3	gene	taxon:6239			
+WB	WBGene00019717	trx-3		M01H9.1	gene	taxon:6239			
+WB	WBGene00019722	M02A10.1			gene	taxon:6239			
+WB	WBGene00019724	M02B7.2			gene	taxon:6239			
+WB	WBGene00019725	algn-14		M02B7.4|hpo-16	gene	taxon:6239			
+WB	WBGene00019726	bris-1		M02B7.5	gene	taxon:6239			
+WB	WBGene00019727	zig-12		M02D8.1	gene	taxon:6239			
+WB	WBGene00019730	asns-2		M02D8.4	gene	taxon:6239			
+WB	WBGene00019734	nlp-64		M02E1.2	gene	taxon:6239			
+WB	WBGene00019738	clec-265		M02F4.7	gene	taxon:6239			
+WB	WBGene00019740	srt-31		M02H5.2|M02H5.g	gene	taxon:6239			
+WB	WBGene00019741	nhr-201		M02H5.3|M02H5.f	gene	taxon:6239			
+WB	WBGene00019742	nhr-202		M02H5.4	gene	taxon:6239			
+WB	WBGene00019743	nhr-203		M02H5.5	gene	taxon:6239			
+WB	WBGene00019745	srbc-57		M02H5.12|M02H5.a	gene	taxon:6239			
+WB	WBGene00019746	M03A1.3			gene	taxon:6239			
+WB	WBGene00019747	ipla-1		M03A1.6	gene	taxon:6239			
+WB	WBGene00019748	atg-2		M03A8.2	gene	taxon:6239			
+WB	WBGene00019753	M03E7.1			gene	taxon:6239			
+WB	WBGene00019754	M03E7.2			gene	taxon:6239			
+WB	WBGene00019755	M03E7.3			gene	taxon:6239			
+WB	WBGene00019756	M03E7.4			gene	taxon:6239			
+WB	WBGene00019757	memb-2		M03E7.5|gosr-2.2	gene	taxon:6239			
+WB	WBGene00019760	calu-1		M03F4.7	gene	taxon:6239			
+WB	WBGene00019761	M03F8.1			gene	taxon:6239			
+WB	WBGene00019762	syf-3		M03F8.3|phi-12	gene	taxon:6239			
+WB	WBGene00019763	galt-1		M03F8.4	gene	taxon:6239			
+WB	WBGene00019764	M03F8.5			gene	taxon:6239			
+WB	WBGene00019765	M03F8.6			gene	taxon:6239			
+WB	WBGene00019767	rpa-2		M04F3.1|CeRPA|CeRPA32	gene	taxon:6239			
+WB	WBGene00019769	kin-35		M04F3.3	gene	taxon:6239			
+WB	WBGene00019770	M04F3.4			gene	taxon:6239			
+WB	WBGene00019771	M04F3.5			gene	taxon:6239			
+WB	WBGene00019773	M04G7.2			gene	taxon:6239			
+WB	WBGene00019774	M04G7.3			gene	taxon:6239			
+WB	WBGene00019777	M57.1			gene	taxon:6239			
+WB	WBGene00019778	M57.2			gene	taxon:6239			
+WB	WBGene00019779	endu-2		M60.2	gene	taxon:6239			
+WB	WBGene00019780	M60.4			gene	taxon:6239			
+WB	WBGene00019781	M60.6			gene	taxon:6239			
+WB	WBGene00019782	M60.7			gene	taxon:6239			
+WB	WBGene00019783	M70.1		M70.f	gene	taxon:6239			
+WB	WBGene00019785	M70.3		M70.d	gene	taxon:6239			
+WB	WBGene00019786	M70.4		M70.b	gene	taxon:6239			
+WB	WBGene00019792	M116.5			gene	taxon:6239			
+WB	WBGene00019800	mtss-1		PAR2.1	gene	taxon:6239			
+WB	WBGene00019801	aak-1		PAR2.3|AMPK	gene	taxon:6239			
+WB	WBGene00019803	PDB1.1			gene	taxon:6239			
+WB	WBGene00019805	R01B10.3			gene	taxon:6239			
+WB	WBGene00019806	pgap-3		R01B10.4	gene	taxon:6239			
+WB	WBGene00019807	jamp-1		R01B10.5|5G528	gene	taxon:6239			
+WB	WBGene00019808	seip-1		R01B10.6	gene	taxon:6239			
+WB	WBGene00019811	egg-2		R01H2.3	gene	taxon:6239			
+WB	WBGene00019813	ger-1		R01H2.5	gene	taxon:6239			
+WB	WBGene00019814	R02C2.1			gene	taxon:6239			
+WB	WBGene00019815	kin-34		R02C2.2	gene	taxon:6239			
+WB	WBGene00019816	nhr-204		R02C2.4	gene	taxon:6239			
+WB	WBGene00019817	txt-2		R02C2.6	gene	taxon:6239			
+WB	WBGene00019819	aass-1		R02D3.1	gene	taxon:6239			
+WB	WBGene00019820	cogc-8		R02D3.2	gene	taxon:6239			
+WB	WBGene00019821	gtf-2H1		R02D3.3	gene	taxon:6239			
+WB	WBGene00019822	ints-13		R02D3.4	gene	taxon:6239			
+WB	WBGene00019823	fnta-1		R02D3.5	gene	taxon:6239			
+WB	WBGene00019825	R02D3.8			gene	taxon:6239			
+WB	WBGene00019827	mop-25.1		R02E12.2	gene	taxon:6239			
+WB	WBGene00019828	R02E12.4			gene	taxon:6239			
+WB	WBGene00019830	hrg-1		R02E12.6	gene	taxon:6239			
+WB	WBGene00019832	osg-1		R02F2.2	gene	taxon:6239			
+WB	WBGene00019833	R02F2.4			gene	taxon:6239			
+WB	WBGene00019834	R02F2.5			gene	taxon:6239			
+WB	WBGene00019837	R02F2.8			gene	taxon:6239			
+WB	WBGene00019838	R02F2.9			gene	taxon:6239			
+WB	WBGene00019840	R02F11.2			gene	taxon:6239			
+WB	WBGene00019841	R02F11.3			gene	taxon:6239			
+WB	WBGene00019843	R03E9.2			gene	taxon:6239			
+WB	WBGene00019844	abts-4		R03E9.3	gene	taxon:6239			
+WB	WBGene00019846	gpx-7		R03G5.5	gene	taxon:6239			
+WB	WBGene00019847	R03G5.6		R03G5.c	gene	taxon:6239			
+WB	WBGene00019849	oac-40		R03H4.1	gene	taxon:6239			
+WB	WBGene00019850	srt-18		R03H4.4	gene	taxon:6239			
+WB	WBGene00019851	oac-41		R03H4.5	gene	taxon:6239			
+WB	WBGene00019855	R03H10.2			gene	taxon:6239			
+WB	WBGene00019858	R03H10.6			gene	taxon:6239			
+WB	WBGene00019859	R03H10.7			gene	taxon:6239			
+WB	WBGene00019861	R04A9.1			gene	taxon:6239			
+WB	WBGene00019862	nrde-3		R04A9.2|wago-12	gene	taxon:6239			
+WB	WBGene00019864	ceh-93		R04A9.5	gene	taxon:6239			
+WB	WBGene00019867	R04B3.2			gene	taxon:6239			
+WB	WBGene00019869	cnnm-2		R04E5.2	gene	taxon:6239			
+WB	WBGene00019875	mca-2		R05C11.3	gene	taxon:6239			
+WB	WBGene00019878	R05D3.3			gene	taxon:6239			
+WB	WBGene00019880	R05D3.6			gene	taxon:6239			
+WB	WBGene00019881	R05D3.8			gene	taxon:6239			
+WB	WBGene00019883	met-2		R05D3.11	gene	taxon:6239			
+WB	WBGene00019884	R05D3.12			gene	taxon:6239			
+WB	WBGene00019885	R05D8.7			gene	taxon:6239			
+WB	WBGene00019886	R05D8.9			gene	taxon:6239			
+WB	WBGene00019888	btbd-10		R05F9.1|snpc-1.4	gene	taxon:6239			
+WB	WBGene00019890	R05F9.6			gene	taxon:6239			
+WB	WBGene00019891	R05F9.7			gene	taxon:6239			
+WB	WBGene00019893	sgt-1		R05F9.10	gene	taxon:6239			
+WB	WBGene00019895	aagr-2		R05F9.12	gene	taxon:6239			
+WB	WBGene00019898	R05G6.4			gene	taxon:6239			
+WB	WBGene00019900	vdac-1		R05G6.7	gene	taxon:6239			
+WB	WBGene00019901	R05G6.9			gene	taxon:6239			
+WB	WBGene00019902	R05G6.10			gene	taxon:6239			
+WB	WBGene00019904	twk-49		R05G9.2|R05G9.c	gene	taxon:6239			
+WB	WBGene00019905	R05G9.3		R05G9.b	gene	taxon:6239			
+WB	WBGene00019909	R06A10.1			gene	taxon:6239			
+WB	WBGene00019911	R06A10.4			gene	taxon:6239			
+WB	WBGene00019914	clec-150		R06B10.3	gene	taxon:6239			
+WB	WBGene00019917	clec-43		R07C3.1	gene	taxon:6239			
+WB	WBGene00019919	R07C3.3			gene	taxon:6239			
+WB	WBGene00019920	acs-15		R07C3.4	gene	taxon:6239			
+WB	WBGene00019937	R07E4.3			gene	taxon:6239			
+WB	WBGene00019939	lips-17		R07G3.2	gene	taxon:6239			
+WB	WBGene00019941	pgam-5		R07G3.5	gene	taxon:6239			
+WB	WBGene00019944	R07G3.8			gene	taxon:6239			
+WB	WBGene00019945	R08C7.1		4F223	gene	taxon:6239			
+WB	WBGene00019946	chat-1		R08C7.2	gene	taxon:6239			
+WB	WBGene00019947	htz-1		R08C7.3	gene	taxon:6239			
+WB	WBGene00019948	R08C7.4			gene	taxon:6239			
+WB	WBGene00019950	clec-175		R08C7.6	gene	taxon:6239			
+WB	WBGene00019951	R08C7.8			gene	taxon:6239			
+WB	WBGene00019953	wapl-1		R08C7.10	gene	taxon:6239			
+WB	WBGene00019960	ztf-16		R08E3.4	gene	taxon:6239			
+WB	WBGene00019962	cysl-3		R08E5.2	gene	taxon:6239			
+WB	WBGene00019965	R08F11.1			gene	taxon:6239			
+WB	WBGene00019966	srt-30		R08F11.2	gene	taxon:6239			
+WB	WBGene00019967	cyp-33C8		R08F11.3	gene	taxon:6239			
+WB	WBGene00019970	R08F11.7			gene	taxon:6239			
+WB	WBGene00019971	ergo-1		R09A1.1|eri-8	gene	taxon:6239			
+WB	WBGene00019977	fpn-1.2		R09B5.4	gene	taxon:6239			
+WB	WBGene00019978	hacd-1		R09B5.6	gene	taxon:6239			
+WB	WBGene00019979	R09B5.11			gene	taxon:6239			
+WB	WBGene00019981	srbc-59		R09E12.1	gene	taxon:6239			
+WB	WBGene00019982	srbc-58		R09E12.2	gene	taxon:6239			
+WB	WBGene00019983	sti-1		R09E12.3	gene	taxon:6239			
+WB	WBGene00019986	R09F10.1			gene	taxon:6239			
+WB	WBGene00019987	R09F10.3			gene	taxon:6239			
+WB	WBGene00019988	R09F10.5			gene	taxon:6239			
+WB	WBGene00019992	R10A10.1			gene	taxon:6239			
+WB	WBGene00019993	rbx-2		R10A10.2	gene	taxon:6239			
+WB	WBGene00019994	cdh-1		R10F2.1	gene	taxon:6239			
+WB	WBGene00019997	R10F2.6			gene	taxon:6239			
+WB	WBGene00020003	R11E3.1			gene	taxon:6239			
+WB	WBGene00020004	R11E3.2			gene	taxon:6239			
+WB	WBGene00020006	set-15		R11E3.4	gene	taxon:6239			
+WB	WBGene00020007	R11F4.1		R11F4.a	gene	taxon:6239			
+WB	WBGene00020008	R11F4.2		R11F4.b	gene	taxon:6239			
+WB	WBGene00020012	R11G1.6			gene	taxon:6239			
+WB	WBGene00020015	nhr-210		R11G11.12	gene	taxon:6239			
+WB	WBGene00020016	lipl-3		R11G11.14	gene	taxon:6239			
+WB	WBGene00020017	R12A1.3			gene	taxon:6239			
+WB	WBGene00020018	R12B2.2			gene	taxon:6239			
+WB	WBGene00020021	R12B2.7			gene	taxon:6239			
+WB	WBGene00020022	gldc-1		R12C12.1	gene	taxon:6239			
+WB	WBGene00020023	frpr-16		R12C12.3	gene	taxon:6239			
+WB	WBGene00020025	R12C12.5			gene	taxon:6239			
+WB	WBGene00020026	R12C12.6			gene	taxon:6239			
+WB	WBGene00020029	R12C12.9			gene	taxon:6239			
+WB	WBGene00020031	suco-1		R12E2.2|let-503	gene	taxon:6239			
+WB	WBGene00020035	egg-5		R12E2.10	gene	taxon:6239			
+WB	WBGene00020036	R12E2.11			gene	taxon:6239			
+WB	WBGene00020037	mrps-6		R12E2.12	gene	taxon:6239			
+WB	WBGene00020038	R12E2.13			gene	taxon:6239			
+WB	WBGene00020045	glb-23		R13A1.8	gene	taxon:6239			
+WB	WBGene00020046	best-16		R13A1.9|R13A1.c	gene	taxon:6239			
+WB	WBGene00020047	ttr-32		R13A5.3	gene	taxon:6239			
+WB	WBGene00020048	lgc-12		R13A5.4	gene	taxon:6239			
+WB	WBGene00020049	ttr-8		R13A5.6	gene	taxon:6239			
+WB	WBGene00020051	mfsd-6		R13A5.9	gene	taxon:6239			
+WB	WBGene00020052	R13A5.10			gene	taxon:6239			
+WB	WBGene00020053	R13A5.11			gene	taxon:6239			
+WB	WBGene00020055	srt-6		R13D7.10	gene	taxon:6239			
+WB	WBGene00020056	R13D11.1			gene	taxon:6239			
+WB	WBGene00020057	R13D11.3			gene	taxon:6239			
+WB	WBGene00020058	R13D11.4		CE45862	gene	taxon:6239			
+WB	WBGene00020060	srab-16		R13D11.6	gene	taxon:6239			
+WB	WBGene00020062	nhr-270		R13D11.8	gene	taxon:6239			
+WB	WBGene00020064	kbp-1		R13F6.1	gene	taxon:6239			
+WB	WBGene00020066	dhhc-5		R13F6.5	gene	taxon:6239			
+WB	WBGene00020068	cra-1		R13F6.10	gene	taxon:6239			
+WB	WBGene00020069	R13H7.2			gene	taxon:6239			
+WB	WBGene00020071	R13H9.5			gene	taxon:6239			
+WB	WBGene00020072	R13H9.6			gene	taxon:6239			
+WB	WBGene00020073	sdz-28		R52.1|bath-16	gene	taxon:6239			
+WB	WBGene00020082	gcp-2.1		R57.1	gene	taxon:6239			
+WB	WBGene00020086	npr-24		R106.2	gene	taxon:6239			
+WB	WBGene00020088	R119.2			gene	taxon:6239			
+WB	WBGene00020089	R119.3			gene	taxon:6239			
+WB	WBGene00020090	R119.5			gene	taxon:6239			
+WB	WBGene00020091	rnp-8		R119.7	gene	taxon:6239			
+WB	WBGene00020092	pcf-11		R144.2	gene	taxon:6239			
+WB	WBGene00020094	wip-1		R144.4	gene	taxon:6239			
+WB	WBGene00020095	smcr-8		R144.5	gene	taxon:6239			
+WB	WBGene00020096	R144.6			gene	taxon:6239			
+WB	WBGene00020097	larp-1		R144.7|R144.f	gene	taxon:6239			
+WB	WBGene00020099	R144.11			gene	taxon:6239			
+WB	WBGene00020101	lmtr-5		R148.2	gene	taxon:6239			
+WB	WBGene00020103	R148.4			gene	taxon:6239			
+WB	WBGene00020106	R151.1		R151.8A	gene	taxon:6239			
+WB	WBGene00020107	R151.2			gene	taxon:6239			
+WB	WBGene00020109	der-2		R151.6	gene	taxon:6239			
+WB	WBGene00020110	hsp-75		R151.7	gene	taxon:6239			
+WB	WBGene00020112	pfd-5		R151.9|3H288	gene	taxon:6239			
+WB	WBGene00020113	R151.10		R151.8A	gene	taxon:6239			
+WB	WBGene00020114	pde-4		R153.1	gene	taxon:6239			
+WB	WBGene00020115	mboa-6		R155.1	gene	taxon:6239			
+WB	WBGene00020116	moa-1		R155.2	gene	taxon:6239			
+WB	WBGene00020117	R155.3			gene	taxon:6239			
+WB	WBGene00020119	R160.2			gene	taxon:6239			
+WB	WBGene00020120	R160.3			gene	taxon:6239			
+WB	WBGene00020121	R160.4			gene	taxon:6239			
+WB	WBGene00020122	R160.5			gene	taxon:6239			
+WB	WBGene00020123	R160.6			gene	taxon:6239			
+WB	WBGene00020125	cest-19		R173.3	gene	taxon:6239			
+WB	WBGene00020126	flp-26		R173.4	gene	taxon:6239			
+WB	WBGene00020128	R193.2			gene	taxon:6239			
+WB	WBGene00020130	igcm-2		SSSD1.1	gene	taxon:6239			
+WB	WBGene00020131	gcy-28		T01A4.1|GCY-X1|T01A4.1a	gene	taxon:6239			
+WB	WBGene00020135	aakg-4		T01B6.3	gene	taxon:6239			
+WB	WBGene00020136	nlp-45		T01B6.4	gene	taxon:6239			
+WB	WBGene00020137	T01B10.5			gene	taxon:6239			
+WB	WBGene00020138	T01B11.1			gene	taxon:6239			
+WB	WBGene00020139	eppl-1		T01B11.2	gene	taxon:6239			
+WB	WBGene00020140	ant-1.4		T01B11.4|ant-1.44|tag-316|wan-3	gene	taxon:6239			
+WB	WBGene00020141	lmd-5		T01C4.1	gene	taxon:6239			
+WB	WBGene00020142	aak-2		T01C8.1|AMPK	gene	taxon:6239			
+WB	WBGene00020143	T01C8.2			gene	taxon:6239			
+WB	WBGene00020146	got-1.2		T01C8.5|got-1	gene	taxon:6239			
+WB	WBGene00020148	T01D1.3			gene	taxon:6239			
+WB	WBGene00020149	T01D1.4			gene	taxon:6239			
+WB	WBGene00020150	T01D1.5			gene	taxon:6239			
+WB	WBGene00020151	T01G6.1			gene	taxon:6239			
+WB	WBGene00020152	nhr-211		T01G6.5	gene	taxon:6239			
+WB	WBGene00020153	nhr-212		T01G6.6	gene	taxon:6239			
+WB	WBGene00020154	T01G6.10			gene	taxon:6239			
+WB	WBGene00020157	T02B11.6			gene	taxon:6239			
+WB	WBGene00020158	T02C5.1			gene	taxon:6239			
+WB	WBGene00020160	igcm-3		T02C5.3|tag-311	gene	taxon:6239			
+WB	WBGene00020166	T02G5.7			gene	taxon:6239			
+WB	WBGene00020168	mct-5		T02G5.12	gene	taxon:6239			
+WB	WBGene00020169	mmaa-1		T02G5.13	gene	taxon:6239			
+WB	WBGene00020172	thoc-1		T02H6.2	gene	taxon:6239			
+WB	WBGene00020181	T02H6.11		phi-44	gene	taxon:6239			
+WB	WBGene00020182	ugt-53		T03D3.1	gene	taxon:6239			
+WB	WBGene00020184	uba-5		T03F1.1	gene	taxon:6239			
+WB	WBGene00020185	pgk-1		T03F1.3	gene	taxon:6239			
+WB	WBGene00020187	gsp-4		T03F1.5	gene	taxon:6239			
+WB	WBGene00020189	tfbm-1		T03F1.7	gene	taxon:6239			
+WB	WBGene00020190	guk-1		T03F1.8	gene	taxon:6239			
+WB	WBGene00020191	clec-53		T03F1.10	gene	taxon:6239			
+WB	WBGene00020192	T03F1.11			gene	taxon:6239			
+WB	WBGene00020193	T03F1.12			gene	taxon:6239			
+WB	WBGene00020195	T03G6.3			gene	taxon:6239			
+WB	WBGene00020196	T03G11.3			gene	taxon:6239			
+WB	WBGene00020197	mans-3		T03G11.4	gene	taxon:6239			
+WB	WBGene00020199	metl-9		T03G11.6	gene	taxon:6239			
+WB	WBGene00020200	T04A6.1			gene	taxon:6239			
+WB	WBGene00020201	T04A6.2			gene	taxon:6239			
+WB	WBGene00020207	T04B8.5		T04B8.b|T04B8.c|T04B8.d	gene	taxon:6239			
+WB	WBGene00020209	T04C9.1			gene	taxon:6239			
+WB	WBGene00020210	T04C9.2			gene	taxon:6239			
+WB	WBGene00020215	T04G9.4			gene	taxon:6239			
+WB	WBGene00020216	trap-2		T04G9.5	gene	taxon:6239			
+WB	WBGene00020220	clec-140		T05A7.2	gene	taxon:6239			
+WB	WBGene00020222	fut-6		T05A7.5|ceft-3	gene	taxon:6239			
+WB	WBGene00020223	T05A7.6			gene	taxon:6239			
+WB	WBGene00020225	sre-40		T05A7.8	gene	taxon:6239			
+WB	WBGene00020228	T05A8.2			gene	taxon:6239			
+WB	WBGene00020230	nep-2		T05A8.4	gene	taxon:6239			
+WB	WBGene00020233	T05A8.7		Y47G7A.a|Y47G7A.b	gene	taxon:6239			
+WB	WBGene00020235	T05A12.4			gene	taxon:6239			
+WB	WBGene00020236	lgc-1		T05B4.1	gene	taxon:6239			
+WB	WBGene00020237	phat-4		T05B4.3|CEMSD85	gene	taxon:6239			
+WB	WBGene00020242	phat-5		T05B4.11	gene	taxon:6239			
+WB	WBGene00020246	clic-1		T05B11.3|clc-1	gene	taxon:6239			
+WB	WBGene00020247	T05B11.4			gene	taxon:6239			
+WB	WBGene00020251	camt-1		T05C1.4	gene	taxon:6239			
+WB	WBGene00020256	T05C3.6			gene	taxon:6239			
+WB	WBGene00020258	T05E7.1			gene	taxon:6239			
+WB	WBGene00020259	T05E7.3			gene	taxon:6239			
+WB	WBGene00020260	T05E7.4			gene	taxon:6239			
+WB	WBGene00020263	let-355		T05E8.3	gene	taxon:6239			
+WB	WBGene00020264	acl-8		T05H4.1	gene	taxon:6239			
+WB	WBGene00020265	fbxa-196		T05H4.2	gene	taxon:6239			
+WB	WBGene00020267	T05H4.4			gene	taxon:6239			
+WB	WBGene00020268	hpo-19		T05H4.5	gene	taxon:6239			
+WB	WBGene00020269	erfa-1		T05H4.6|etf-1|phi-21	gene	taxon:6239			
+WB	WBGene00020270	T05H4.7			gene	taxon:6239			
+WB	WBGene00020275	atp-4		T05H4.12	gene	taxon:6239			
+WB	WBGene00020277	T06A1.1			gene	taxon:6239			
+WB	WBGene00020279	glb-25		T06A1.4	gene	taxon:6239			
+WB	WBGene00020280	T06A1.5			gene	taxon:6239			
+WB	WBGene00020281	T06A4.1			gene	taxon:6239			
+WB	WBGene00020282	mps-3		T06A4.2	gene	taxon:6239			
+WB	WBGene00020283	T06A4.3			gene	taxon:6239			
+WB	WBGene00020284	mel-46		T06A10.1	gene	taxon:6239			
+WB	WBGene00020286	gtsf-1		T06A10.3	gene	taxon:6239			
+WB	WBGene00020287	lsy-13		T06A10.4	gene	taxon:6239			
+WB	WBGene00020288	srt-73		T06C10.2	gene	taxon:6239			
+WB	WBGene00020289	T06C10.3			gene	taxon:6239			
+WB	WBGene00020293	nep-20		T06D4.4	gene	taxon:6239			
+WB	WBGene00020294	T06F4.1			gene	taxon:6239			
+WB	WBGene00020296	rrp-8		T07A9.8|rram-1|susi-2	gene	taxon:6239			
+WB	WBGene00020297	nog-1		T07A9.9|phi-58	gene	taxon:6239			
+WB	WBGene00020298	T07A9.10			gene	taxon:6239			
+WB	WBGene00020299	T07A9.12			gene	taxon:6239			
+WB	WBGene00020301	gid-2		T07D1.2	gene	taxon:6239			
+WB	WBGene00020302	T07D1.3			gene	taxon:6239			
+WB	WBGene00020313	T07E3.2			gene	taxon:6239			
+WB	WBGene00020314	T07E3.3			gene	taxon:6239			
+WB	WBGene00020316	brc-2		T07E3.5|3H990	gene	taxon:6239			
+WB	WBGene00020319	npr-31		T07F8.2	gene	taxon:6239			
+WB	WBGene00020320	T07F8.4			gene	taxon:6239			
+WB	WBGene00020322	T07F12.2			gene	taxon:6239			
+WB	WBGene00020324	T07F12.4			gene	taxon:6239			
+WB	WBGene00020326	math-38		T07H3.3	gene	taxon:6239			
+WB	WBGene00020327	clec-21		T07H3.4	gene	taxon:6239			
+WB	WBGene00020328	clec-20		T07H3.5	gene	taxon:6239			
+WB	WBGene00020330	cest-16		T07H6.1	gene	taxon:6239			
+WB	WBGene00020333	sre-12		T07H8.7	gene	taxon:6239			
+WB	WBGene00020334	epg-7		T08A9.1|atg-11	gene	taxon:6239			
+WB	WBGene00020335	ttr-30		T08A9.2	gene	taxon:6239			
+WB	WBGene00020339	ttr-59		T08A9.11	gene	taxon:6239			
+WB	WBGene00020340	T08B1.1			gene	taxon:6239			
+WB	WBGene00020341	T08B1.4			gene	taxon:6239			
+WB	WBGene00020343	acs-3		T08B1.6	gene	taxon:6239			
+WB	WBGene00020346	rbm-5		T08B2.5	gene	taxon:6239			
+WB	WBGene00020347	ech-1.2		T08B2.7	gene	taxon:6239			
+WB	WBGene00020348	mrpl-23		T08B2.8	gene	taxon:6239			
+WB	WBGene00020353	T08B6.4			gene	taxon:6239			
+WB	WBGene00020354	sgnh-1		T08B6.5	gene	taxon:6239			
+WB	WBGene00020365	T08G2.2			gene	taxon:6239			
+WB	WBGene00020366	acdh-10		T08G2.3	gene	taxon:6239			
+WB	WBGene00020368	ast-1		T08H4.3	gene	taxon:6239			
+WB	WBGene00020369	exc-15		T08H10.1	gene	taxon:6239			
+WB	WBGene00020370	T08H10.3			gene	taxon:6239			
+WB	WBGene00020373	gpx-6		T09A12.2	gene	taxon:6239			
+WB	WBGene00020374	serp-1.2		T09A12.5|T09A12.d	gene	taxon:6239			
+WB	WBGene00020375	pigv-1		T09B4.1|mal-3	gene	taxon:6239			
+WB	WBGene00020376	T09B4.2			gene	taxon:6239			
+WB	WBGene00020378	T09B4.4			gene	taxon:6239			
+WB	WBGene00020379	T09B4.5			gene	taxon:6239			
+WB	WBGene00020382	T09B4.8			gene	taxon:6239			
+WB	WBGene00020383	tin-44		T09B4.9|let-602	gene	taxon:6239			
+WB	WBGene00020385	nhr-216		T09D3.4	gene	taxon:6239			
+WB	WBGene00020386	dach-1		T09H2.1|cyp-34A4	gene	taxon:6239			
+WB	WBGene00020389	T10B5.3			gene	taxon:6239			
+WB	WBGene00020390	T10B5.4			gene	taxon:6239			
+WB	WBGene00020391	cct-7		T10B5.5	gene	taxon:6239			
+WB	WBGene00020392	knl-3		T10B5.6	gene	taxon:6239			
+WB	WBGene00020393	T10B5.7			gene	taxon:6239			
+WB	WBGene00020394	T10B5.8			gene	taxon:6239			
+WB	WBGene00020396	T10B5.10			gene	taxon:6239			
+WB	WBGene00020397	pcbd-1		T10B11.1	gene	taxon:6239			
+WB	WBGene00020398	cerk-1		T10B11.2	gene	taxon:6239			
+WB	WBGene00020399	ztf-4		T10B11.3	gene	taxon:6239			
+WB	WBGene00020401	T10B11.5			gene	taxon:6239			
+WB	WBGene00020402	T10B11.6			gene	taxon:6239			
+WB	WBGene00020403	hrde-4		T10B11.7	gene	taxon:6239			
+WB	WBGene00020407	chil-24		T10D4.3	gene	taxon:6239			
+WB	WBGene00020414	T10E9.4			gene	taxon:6239			
+WB	WBGene00020415	T10E9.5			gene	taxon:6239			
+WB	WBGene00020416	T10E9.6			gene	taxon:6239			
+WB	WBGene00020417	nuo-2		T10E9.7|let-382|nduf-3	gene	taxon:6239			
+WB	WBGene00020418	T10E9.8			gene	taxon:6239			
+WB	WBGene00020419	acdh-4		T10E9.9	gene	taxon:6239			
+WB	WBGene00020420	T10E10.3		T10E10.c	gene	taxon:6239			
+WB	WBGene00020421	T10E10.4		T10E10.b	gene	taxon:6239			
+WB	WBGene00020422	T10F2.2			gene	taxon:6239			
+WB	WBGene00020423	prp-19		T10F2.4	gene	taxon:6239			
+WB	WBGene00020424	T10H9.1			gene	taxon:6239			
+WB	WBGene00020425	syx-18		T10H9.3	gene	taxon:6239			
+WB	WBGene00020426	T10H10.2			gene	taxon:6239			
+WB	WBGene00020427	sav-1		T10H10.3	gene	taxon:6239			
+WB	WBGene00020433	T11F8.1			gene	taxon:6239			
+WB	WBGene00020435	T11F8.4			gene	taxon:6239			
+WB	WBGene00020436	amdh-1		T12A2.1	gene	taxon:6239			
+WB	WBGene00020437	stt-3		T12A2.2	gene	taxon:6239			
+WB	WBGene00020441	bcas-2		T12A2.7	gene	taxon:6239			
+WB	WBGene00020442	gen-1		T12A2.8	gene	taxon:6239			
+WB	WBGene00020444	T12B3.1			gene	taxon:6239			
+WB	WBGene00020445	T12B3.2			gene	taxon:6239			
+WB	WBGene00020446	T12B3.3			gene	taxon:6239			
+WB	WBGene00020455	fbxa-59		T12B5.8	gene	taxon:6239			
+WB	WBGene00020456	fbxa-60		T12B5.10	gene	taxon:6239			
+WB	WBGene00020460	nhr-273		T12C9.1	gene	taxon:6239			
+WB	WBGene00020462	ari-2		T12E12.1	gene	taxon:6239			
+WB	WBGene00020464	tebp-2		T12E12.3|dtn-2	gene	taxon:6239			
+WB	WBGene00020465	T12E12.6			gene	taxon:6239			
+WB	WBGene00020467	T12F5.2			gene	taxon:6239			
+WB	WBGene00020468	T13A10.1			gene	taxon:6239			
+WB	WBGene00020469	T13A10.2			gene	taxon:6239			
+WB	WBGene00020472	lips-11		T13B5.5	gene	taxon:6239			
+WB	WBGene00020473	lips-12		T13B5.6	gene	taxon:6239			
+WB	WBGene00020474	lips-13		T13B5.7	gene	taxon:6239			
+WB	WBGene00020475	sut-1		T13B5.8	gene	taxon:6239			
+WB	WBGene00020476	T13B5.9			gene	taxon:6239			
+WB	WBGene00020480	ssup-72		T13C2.4	gene	taxon:6239			
+WB	WBGene00020481	T13C2.6			gene	taxon:6239			
+WB	WBGene00020482	T13C2.7			gene	taxon:6239			
+WB	WBGene00020485	ceh-54		T13C5.4	gene	taxon:6239			
+WB	WBGene00020486	T13C5.6			gene	taxon:6239			
+WB	WBGene00020489	hot-8		T13G4.2|T13G4.f	gene	taxon:6239			
+WB	WBGene00020490	tmc-1		T13G4.3|R193.f|T13G4.e	gene	taxon:6239			
+WB	WBGene00020491	T13G4.4		T13G4.d	gene	taxon:6239			
+WB	WBGene00020496	spat-3		T13H2.5	gene	taxon:6239			
+WB	WBGene00020498	T14B4.1			gene	taxon:6239			
+WB	WBGene00020499	mrps-18.C		T14B4.2	gene	taxon:6239			
+WB	WBGene00020500	T14B4.3			gene	taxon:6239			
+WB	WBGene00020501	T14B4.5			gene	taxon:6239			
+WB	WBGene00020503	T14B4.9			gene	taxon:6239			
+WB	WBGene00020504	svh-2		T14E8.1	gene	taxon:6239			
+WB	WBGene00020505	T14E8.2			gene	taxon:6239			
+WB	WBGene00020506	dop-3		T14E8.3	gene	taxon:6239			
+WB	WBGene00020507	vha-15		T14F9.1|phi-52	gene	taxon:6239			
+WB	WBGene00020509	hex-1		T14F9.3	gene	taxon:6239			
+WB	WBGene00020510	T14G11.1			gene	taxon:6239			
+WB	WBGene00020511	immt-1		T14G11.3	gene	taxon:6239			
+WB	WBGene00020517	hpo-8		T15B7.2	gene	taxon:6239			
+WB	WBGene00020520	T15B7.8			gene	taxon:6239			
+WB	WBGene00020523	dmsr-14		T15B7.11	gene	taxon:6239			
+WB	WBGene00020524	dmsr-13		T15B7.12	gene	taxon:6239			
+WB	WBGene00020525	dmsr-15		T15B7.13	gene	taxon:6239			
+WB	WBGene00020526	T15B7.14			gene	taxon:6239			
+WB	WBGene00020528	lgc-54		T15B7.16	gene	taxon:6239			
+WB	WBGene00020530	T15B12.1			gene	taxon:6239			
+WB	WBGene00020531	T15B12.2			gene	taxon:6239			
+WB	WBGene00020533	T16A1.2			gene	taxon:6239			
+WB	WBGene00020546	zig-13		T17A3.10	gene	taxon:6239			
+WB	WBGene00020549	nmt-1		T17E9.2	gene	taxon:6239			
+WB	WBGene00020555	nhr-219		T19A5.5	gene	taxon:6239			
+WB	WBGene00020556	pamn-1		T19B4.1	gene	taxon:6239			
+WB	WBGene00020557	T19B4.3		1G247	gene	taxon:6239			
+WB	WBGene00020559	best-17		T19C3.1	gene	taxon:6239			
+WB	WBGene00020562	T19C3.4			gene	taxon:6239			
+WB	WBGene00020563	T19C3.5			gene	taxon:6239			
+WB	WBGene00020566	ttr-7		T19C3.9|T19C3.i	gene	taxon:6239			
+WB	WBGene00020567	adt-3		T19D2.1	gene	taxon:6239			
+WB	WBGene00020568	T19D2.3			gene	taxon:6239			
+WB	WBGene00020569	lgc-32		T19D7.1	gene	taxon:6239			
+WB	WBGene00020571	lpr-7		T19D7.3	gene	taxon:6239			
+WB	WBGene00020572	rund-1		T19D7.4	gene	taxon:6239			
+WB	WBGene00020573	T19D7.5			gene	taxon:6239			
+WB	WBGene00020575	T19D7.7		Y9C12A.b	gene	taxon:6239			
+WB	WBGene00020576	T19D12.1			gene	taxon:6239			
+WB	WBGene00020579	T19D12.4			gene	taxon:6239			
+WB	WBGene00020580	T19D12.5			gene	taxon:6239			
+WB	WBGene00020582	oig-8		T19D12.7	gene	taxon:6239			
+WB	WBGene00020583	T19D12.9			gene	taxon:6239			
+WB	WBGene00020584	T19D12.10			gene	taxon:6239			
+WB	WBGene00020585	clec-178		T19E7.1	gene	taxon:6239			
+WB	WBGene00020586	frpr-18		T19F4.1	gene	taxon:6239			
+WB	WBGene00020587	ugt-9		T19H12.1	gene	taxon:6239			
+WB	WBGene00020590	T19H12.6			gene	taxon:6239			
+WB	WBGene00020592	ugt-12		T19H12.9	gene	taxon:6239			
+WB	WBGene00020593	ugt-11		T19H12.10	gene	taxon:6239			
+WB	WBGene00020594	ugt-10		T19H12.11	gene	taxon:6239			
+WB	WBGene00020596	oga-1		T20B5.3	gene	taxon:6239			
+WB	WBGene00020600	trd-1		T20B12.1	gene	taxon:6239			
+WB	WBGene00020601	T20B12.3			gene	taxon:6239			
+WB	WBGene00020604	T20B12.7			gene	taxon:6239			
+WB	WBGene00020605	lgc-50		T20B12.9|T20B12.a	gene	taxon:6239			
+WB	WBGene00020607	srab-20		T20D4.1	gene	taxon:6239			
+WB	WBGene00020608	srab-22		T20D4.2	gene	taxon:6239			
+WB	WBGene00020609	T20D4.3			gene	taxon:6239			
+WB	WBGene00020611	txt-11		T20D4.5	gene	taxon:6239			
+WB	WBGene00020613	T20D4.7			gene	taxon:6239			
+WB	WBGene00020623	srab-21		T20D4.18	gene	taxon:6239			
+WB	WBGene00020625	mrrf-1		T20F5.3	gene	taxon:6239			
+WB	WBGene00020627	T20F5.5			gene	taxon:6239			
+WB	WBGene00020628	T20F5.6			gene	taxon:6239			
+WB	WBGene00020629	T20F5.7			gene	taxon:6239			
+WB	WBGene00020631	T20F7.3			gene	taxon:6239			
+WB	WBGene00020633	aakg-2		T20F7.6	gene	taxon:6239			
+WB	WBGene00020636	T20H4.5			gene	taxon:6239			
+WB	WBGene00020645	T21D9.2			gene	taxon:6239			
+WB	WBGene00020646	zmp-6		T21D11.1	gene	taxon:6239			
+WB	WBGene00020647	pqbp-1.1		T21D12.3	gene	taxon:6239			
+WB	WBGene00020648	T21D12.7			gene	taxon:6239			
+WB	WBGene00020649	sma-10		T21D12.9	gene	taxon:6239			
+WB	WBGene00020650	T21D12.11			gene	taxon:6239			
+WB	WBGene00020651	T21D12.12			gene	taxon:6239			
+WB	WBGene00020652	egg-4		T21E3.1	gene	taxon:6239			
+WB	WBGene00020655	T21E12.3			gene	taxon:6239			
+WB	WBGene00020656	T21E12.5			gene	taxon:6239			
+WB	WBGene00020657	lgc-53		T21F2.1	gene	taxon:6239			
+WB	WBGene00020658	argn-1		T21F4.1	gene	taxon:6239			
+WB	WBGene00020659	T21G5.1			gene	taxon:6239			
+WB	WBGene00020660	T21G5.2			gene	taxon:6239			
+WB	WBGene00020661	smz-2		T21G5.4	gene	taxon:6239			
+WB	WBGene00020662	T21H3.1			gene	taxon:6239			
+WB	WBGene00020663	cutl-22		T21H3.4	gene	taxon:6239			
+WB	WBGene00020664	T21H3.5			gene	taxon:6239			
+WB	WBGene00020665	T22B2.1			gene	taxon:6239			
+WB	WBGene00020666	T22B2.2			gene	taxon:6239			
+WB	WBGene00020669	T22B2.5			gene	taxon:6239			
+WB	WBGene00020673	T22B7.4			gene	taxon:6239			
+WB	WBGene00020678	kin-36		T22B11.4	gene	taxon:6239			
+WB	WBGene00020679	ogdh-1		T22B11.5	gene	taxon:6239			
+WB	WBGene00020680	T22D1.1			gene	taxon:6239			
+WB	WBGene00020682	T22D1.3			gene	taxon:6239			
+WB	WBGene00020683	ribo-1		T22D1.4	gene	taxon:6239			
+WB	WBGene00020684	T22D1.5			gene	taxon:6239			
+WB	WBGene00020686	T22D1.8			gene	taxon:6239			
+WB	WBGene00020687	ruvb-2		T22D1.10	gene	taxon:6239			
+WB	WBGene00020688	cest-6		T22D1.11	gene	taxon:6239			
+WB	WBGene00020689	npr-12		T22D1.12	gene	taxon:6239			
+WB	WBGene00020692	T22E5.6			gene	taxon:6239			
+WB	WBGene00020693	lron-8		T22E7.1	gene	taxon:6239			
+WB	WBGene00020694	dhhc-11		T22E7.2	gene	taxon:6239			
+WB	WBGene00020695	T22F3.2			gene	taxon:6239			
+WB	WBGene00020696	pygl-1		T22F3.3	gene	taxon:6239			
+WB	WBGene00020697	T22F3.7			gene	taxon:6239			
+WB	WBGene00020698	T22F3.8			gene	taxon:6239			
+WB	WBGene00020699	T22F3.10			gene	taxon:6239			
+WB	WBGene00020700	T22F3.11			gene	taxon:6239			
+WB	WBGene00020701	T22F7.1			gene	taxon:6239			
+WB	WBGene00020702	T22F7.3			gene	taxon:6239			
+WB	WBGene00020705	T22H9.1			gene	taxon:6239			
+WB	WBGene00020706	atg-9		T22H9.2|atgr-9	gene	taxon:6239			
+WB	WBGene00020707	wago-10		T22H9.3	gene	taxon:6239			
+WB	WBGene00020708	dmd-8		T22H9.4	gene	taxon:6239			
+WB	WBGene00020710	T23B3.2			gene	taxon:6239			
+WB	WBGene00020712	ckr-1		T23B3.4	gene	taxon:6239			
+WB	WBGene00020714	T23B3.6			gene	taxon:6239			
+WB	WBGene00020716	phf-30		T23B12.1	gene	taxon:6239			
+WB	WBGene00020717	mrpl-4		T23B12.2	gene	taxon:6239			
+WB	WBGene00020718	mrps-2		T23B12.3	gene	taxon:6239			
+WB	WBGene00020719	natc-1		T23B12.4	gene	taxon:6239			
+WB	WBGene00020720	T23B12.5			gene	taxon:6239			
+WB	WBGene00020721	T23B12.6			gene	taxon:6239			
+WB	WBGene00020722	T23B12.8			gene	taxon:6239			
+WB	WBGene00020725	cnp-3		T23C6.3	gene	taxon:6239			
+WB	WBGene00020727	npr-21		T23C6.5	gene	taxon:6239			
+WB	WBGene00020728	T23E1.1			gene	taxon:6239			
+WB	WBGene00020736	T23F2.3			gene	taxon:6239			
+WB	WBGene00020737	T23F2.4			gene	taxon:6239			
+WB	WBGene00020738	T23F2.5			gene	taxon:6239			
+WB	WBGene00020741	dlhd-1		T23F4.3	gene	taxon:6239			
+WB	WBGene00020742	T23H2.3			gene	taxon:6239			
+WB	WBGene00020743	mam-8		T23H2.4	gene	taxon:6239			
+WB	WBGene00020746	srbc-66		T24A6.5	gene	taxon:6239			
+WB	WBGene00020748	nhr-221		T24A6.8	gene	taxon:6239			
+WB	WBGene00020749	srbc-67		T24A6.10	gene	taxon:6239			
+WB	WBGene00020750	nhr-222		T24A6.11	gene	taxon:6239			
+WB	WBGene00020752	srbc-68		T24A6.13	gene	taxon:6239			
+WB	WBGene00020753	T24A6.16			gene	taxon:6239			
+WB	WBGene00020757	ucr-2.3		T24C4.1	gene	taxon:6239			
+WB	WBGene00020760	T24C4.4			gene	taxon:6239			
+WB	WBGene00020761	T24C4.5		phi-53	gene	taxon:6239			
+WB	WBGene00020762	zer-1		T24C4.6	gene	taxon:6239			
+WB	WBGene00020763	ztf-18		T24C4.7	gene	taxon:6239			
+WB	WBGene00020764	T24C12.1			gene	taxon:6239			
+WB	WBGene00020765	T24C12.3			gene	taxon:6239			
+WB	WBGene00020766	T24C12.4			gene	taxon:6239			
+WB	WBGene00020767	lgc-40		T24D8.1	gene	taxon:6239			
+WB	WBGene00020770	eat-17		T24D11.1|tbc-4	gene	taxon:6239			
+WB	WBGene00020774	T24E12.5			gene	taxon:6239			
+WB	WBGene00020779	T24G10.2			gene	taxon:6239			
+WB	WBGene00020781	T24H7.2			gene	taxon:6239			
+WB	WBGene00020782	T24H7.3			gene	taxon:6239			
+WB	WBGene00020783	blos-4		T24H7.4	gene	taxon:6239			
+WB	WBGene00020784	tat-4		T24H7.5	gene	taxon:6239			
+WB	WBGene00020788	nep-22		T25B6.2	gene	taxon:6239			
+WB	WBGene00020790	T25B6.4			gene	taxon:6239			
+WB	WBGene00020796	mrpl-28		T25D3.2	gene	taxon:6239			
+WB	WBGene00020798	T25D3.4			gene	taxon:6239			
+WB	WBGene00020799	T25D10.1			gene	taxon:6239			
+WB	WBGene00020800	zig-10		T25D10.2	gene	taxon:6239			
+WB	WBGene00020804	T25E4.2			gene	taxon:6239			
+WB	WBGene00020806	T25F10.3			gene	taxon:6239			
+WB	WBGene00020807	T25F10.4			gene	taxon:6239			
+WB	WBGene00020812	acdh-7		T25G12.5	gene	taxon:6239			
+WB	WBGene00020813	T25G12.6			gene	taxon:6239			
+WB	WBGene00020817	T25G12.11			gene	taxon:6239			
+WB	WBGene00020820	algn-1		T26A5.4	gene	taxon:6239			
+WB	WBGene00020821	jhdm-1		T26A5.5	gene	taxon:6239			
+WB	WBGene00020822	T26A5.6			gene	taxon:6239			
+WB	WBGene00020823	T26A5.8			gene	taxon:6239			
+WB	WBGene00020824	T26A8.1			gene	taxon:6239			
+WB	WBGene00020825	tmem-231		T26A8.2	gene	taxon:6239			
+WB	WBGene00020827	T26A8.4			gene	taxon:6239			
+WB	WBGene00020831	T26C12.1			gene	taxon:6239			
+WB	WBGene00020832	T26C12.2			gene	taxon:6239			
+WB	WBGene00020833	T26C12.3			gene	taxon:6239			
+WB	WBGene00020835	T27A1.3			gene	taxon:6239			
+WB	WBGene00020836	lgc-34		T27A1.4	gene	taxon:6239			
+WB	WBGene00020837	slc-36.2		T27A1.5	gene	taxon:6239			
+WB	WBGene00020838	trak-1		T27A3.1	gene	taxon:6239			
+WB	WBGene00020839	usp-5		T27A3.2	gene	taxon:6239			
+WB	WBGene00020840	spch-3		T27A3.4	gene	taxon:6239			
+WB	WBGene00020841	T27A3.5			gene	taxon:6239			
+WB	WBGene00020842	nmrk-1		T27A3.6|moc-4	gene	taxon:6239			
+WB	WBGene00020843	T27A3.7			gene	taxon:6239			
+WB	WBGene00020847	cgr-1		T27A10.7|tag-133	gene	taxon:6239			
+WB	WBGene00020849	nhr-225		T27B7.2	gene	taxon:6239			
+WB	WBGene00020850	nhr-226		T27B7.3	gene	taxon:6239			
+WB	WBGene00020851	nhr-227		T27B7.5	gene	taxon:6239			
+WB	WBGene00020852	nhr-228		T27B7.6	gene	taxon:6239			
+WB	WBGene00020854	T27C4.1			gene	taxon:6239			
+WB	WBGene00020855	hpo-36		T27C4.2|Y39H10A.c|Y39H10A.d|Y39H10A.e	gene	taxon:6239			
+WB	WBGene00020856	srt-61		T27C10.1	gene	taxon:6239			
+WB	WBGene00020857	srt-62		T27C10.2	gene	taxon:6239			
+WB	WBGene00020858	mop-25.3		T27C10.3	gene	taxon:6239			
+WB	WBGene00020863	T27E4.5			gene	taxon:6239			
+WB	WBGene00020864	oac-50		T27E4.6	gene	taxon:6239			
+WB	WBGene00020866	vps-24		T27F7.1	gene	taxon:6239			
+WB	WBGene00020868	eif-1		T27F7.3|PIG-B	gene	taxon:6239			
+WB	WBGene00020874	srbc-5		T28A11.7	gene	taxon:6239			
+WB	WBGene00020877	srt-63		T28A11.15	gene	taxon:6239			
+WB	WBGene00020884	T28B4.1			gene	taxon:6239			
+WB	WBGene00020886	ttr-6		T28B4.3	gene	taxon:6239			
+WB	WBGene00020887	hic-1		T28B4.4	gene	taxon:6239			
+WB	WBGene00020888	T28C12.1			gene	taxon:6239			
+WB	WBGene00020889	T28C12.2			gene	taxon:6239			
+WB	WBGene00020891	cest-24		T28C12.4	gene	taxon:6239			
+WB	WBGene00020893	T28C12.6			gene	taxon:6239			
+WB	WBGene00020895	plpp-1.2		T28D9.3	gene	taxon:6239			
+WB	WBGene00020896	T28D9.4			gene	taxon:6239			
+WB	WBGene00020897	del-10		T28D9.7	gene	taxon:6239			
+WB	WBGene00020900	T28F2.1			gene	taxon:6239			
+WB	WBGene00020902	jmjc-1		T28F2.4	gene	taxon:6239			
+WB	WBGene00020903	acd-5		T28F2.7	gene	taxon:6239			
+WB	WBGene00020904	T28F12.1			gene	taxon:6239			
+WB	WBGene00020906	T28H11.8			gene	taxon:6239			
+WB	WBGene00020909	W01A11.1			gene	taxon:6239			
+WB	WBGene00020910	dgtr-1		W01A11.2	gene	taxon:6239			
+WB	WBGene00020911	cpt-6		W01A11.5	gene	taxon:6239			
+WB	WBGene00020913	W01B11.1			gene	taxon:6239			
+WB	WBGene00020914	sulp-6		W01B11.2	gene	taxon:6239			
+WB	WBGene00020915	nol-58		W01B11.3|nol-5	gene	taxon:6239			
+WB	WBGene00020921	W01C8.5		XG314	gene	taxon:6239			
+WB	WBGene00020924	W02B3.4			gene	taxon:6239			
+WB	WBGene00020927	W02B3.7			gene	taxon:6239			
+WB	WBGene00020929	W02C12.2			gene	taxon:6239			
+WB	WBGene00020930	hlh-30		W02C12.3	gene	taxon:6239			
+WB	WBGene00020931	cytb-5.2		W02D3.1	gene	taxon:6239			
+WB	WBGene00020932	dhod-1		W02D3.2	gene	taxon:6239			
+WB	WBGene00020933	W02D3.4			gene	taxon:6239			
+WB	WBGene00020935	fnci-1		W02D3.10	gene	taxon:6239			
+WB	WBGene00020936	hrpf-1		W02D3.11|W02D3.a	gene	taxon:6239			
+WB	WBGene00020938	clec-218		W02D7.2	gene	taxon:6239			
+WB	WBGene00020939	W02D7.3			gene	taxon:6239			
+WB	WBGene00020943	W02D7.8			gene	taxon:6239			
+WB	WBGene00020945	clec-219		W02D7.10	gene	taxon:6239			
+WB	WBGene00020946	W02D7.11			gene	taxon:6239			
+WB	WBGene00020947	W02F12.2			gene	taxon:6239			
+WB	WBGene00020949	W02F12.4			gene	taxon:6239			
+WB	WBGene00020950	dlst-1		W02F12.5	gene	taxon:6239			
+WB	WBGene00020951	sna-1		W02F12.6	gene	taxon:6239			
+WB	WBGene00020952	kel-8		W02G9.2	gene	taxon:6239			
+WB	WBGene00020953	W02G9.3			gene	taxon:6239			
+WB	WBGene00020955	angl-1		W02G9.5	gene	taxon:6239			
+WB	WBGene00020957	W02H5.2		W02H5.j|W02H5.k|W02H5.l|W02H5.m	gene	taxon:6239			
+WB	WBGene00020961	sknr-1		W02H5.7|W02H5.b|W02H5.e	gene	taxon:6239			
+WB	WBGene00020962	W02H5.8		W02H5.a|W02H5.n	gene	taxon:6239			
+WB	WBGene00020964	polq-1		W03A3.2|mus-1	gene	taxon:6239			
+WB	WBGene00020966	W03A5.1			gene	taxon:6239			
+WB	WBGene00020967	W03A5.2			gene	taxon:6239			
+WB	WBGene00020970	W03A5.6			gene	taxon:6239			
+WB	WBGene00020972	trpl-2		W03B1.2	gene	taxon:6239			
+WB	WBGene00020976	oac-51		W03B1.7	gene	taxon:6239			
+WB	WBGene00020977	oac-52		W03B1.8	gene	taxon:6239			
+WB	WBGene00020982	ilys-6		W03D2.7	gene	taxon:6239			
+WB	WBGene00020985	W03D8.2			gene	taxon:6239			
+WB	WBGene00020986	W03D8.3			gene	taxon:6239			
+WB	WBGene00020987	W03D8.5			gene	taxon:6239			
+WB	WBGene00020989	W03D8.8			gene	taxon:6239			
+WB	WBGene00020990	W03D8.9			gene	taxon:6239			
+WB	WBGene00020993	mtrf-1L		W03F8.3	gene	taxon:6239			
+WB	WBGene00020994	W03F8.4			gene	taxon:6239			
+WB	WBGene00020995	W03F8.6			gene	taxon:6239			
+WB	WBGene00020997	gpa-18		W03F8.9	gene	taxon:6239			
+WB	WBGene00020999	W03F9.1			gene	taxon:6239			
+WB	WBGene00021000	W03F9.2			gene	taxon:6239			
+WB	WBGene00021002	W03F9.4			gene	taxon:6239			
+WB	WBGene00021003	W03F9.9			gene	taxon:6239			
+WB	WBGene00021004	sftb-2		W03F9.10	gene	taxon:6239			
+WB	WBGene00021005	ule-1		W03F11.1	gene	taxon:6239			
+WB	WBGene00021006	dct-9		W03F11.3	gene	taxon:6239			
+WB	WBGene00021007	W03F11.4			gene	taxon:6239			
+WB	WBGene00021009	afd-1		W03F11.6|Y39G10BM.b|Y39G10BM.c|Y39G10BM.d|Y39G10BM.f|Y39G10BM.g|Y39G10BR.a	gene	taxon:6239			
+WB	WBGene00021012	pig-1		W03G1.6	gene	taxon:6239			
+WB	WBGene00021014	pid-4		W03G9.2	gene	taxon:6239			
+WB	WBGene00021015	enu-3.3		W03G9.3	gene	taxon:6239			
+WB	WBGene00021016	W03G9.5			gene	taxon:6239			
+WB	WBGene00021017	cil-7		W03G9.7	gene	taxon:6239			
+WB	WBGene00021020	W04B5.3			gene	taxon:6239			
+WB	WBGene00021021	mrpl-30		W04B5.4	gene	taxon:6239			
+WB	WBGene00021022	W04B5.5			gene	taxon:6239			
+WB	WBGene00021024	W04C9.2			gene	taxon:6239			
+WB	WBGene00021025	cutl-13		W04C9.3	gene	taxon:6239			
+WB	WBGene00021026	W04C9.4		W04C9.d	gene	taxon:6239			
+WB	WBGene00021027	W04C9.5			gene	taxon:6239			
+WB	WBGene00021028	W04C9.6			gene	taxon:6239			
+WB	WBGene00021032	clec-118		W04H10.4	gene	taxon:6239			
+WB	WBGene00021033	srz-32		W05E7.2	gene	taxon:6239			
+WB	WBGene00021035	W05F2.3			gene	taxon:6239			
+WB	WBGene00021041	clp-10		W05G11.4	gene	taxon:6239			
+WB	WBGene00021043	pck-1		W05G11.6	gene	taxon:6239			
+WB	WBGene00021046	sedl-1		W05H7.3	gene	taxon:6239			
+WB	WBGene00021047	zfp-3		W05H7.4	gene	taxon:6239			
+WB	WBGene00021048	W05H9.1			gene	taxon:6239			
+WB	WBGene00021056	W06B4.1			gene	taxon:6239			
+WB	WBGene00021057	W06B4.2			gene	taxon:6239			
+WB	WBGene00021058	vps-18		W06B4.3	gene	taxon:6239			
+WB	WBGene00021059	atat-2		W06B11.1	gene	taxon:6239			
+WB	WBGene00021060	dct-11		W06B11.3	gene	taxon:6239			
+WB	WBGene00021061	W06E11.1			gene	taxon:6239			
+WB	WBGene00021063	sbds-1		W06E11.4|W06E11.c	gene	taxon:6239			
+WB	WBGene00021066	W06H8.2			gene	taxon:6239			
+WB	WBGene00021070	cpr-8		W07B8.1|drd-3	gene	taxon:6239			
+WB	WBGene00021072	W07B8.4			gene	taxon:6239			
+WB	WBGene00021073	nsun-1		W07E6.1|nol-1|nol-2	gene	taxon:6239			
+WB	WBGene00021074	W07E6.2			gene	taxon:6239			
+WB	WBGene00021075	sms-5		W07E6.3	gene	taxon:6239			
+WB	WBGene00021076	W07E6.5			gene	taxon:6239			
+WB	WBGene00021080	W08A12.3			gene	taxon:6239			
+WB	WBGene00021082	zip-11		W08E12.1	gene	taxon:6239			
+WB	WBGene00021084	W08E12.3			gene	taxon:6239			
+WB	WBGene00021091	W08F4.1			gene	taxon:6239			
+WB	WBGene00021093	W08F4.3			gene	taxon:6239			
+WB	WBGene00021095	mlt-8		W08F4.6|phi-54	gene	taxon:6239			
+WB	WBGene00021097	cdc-37		W08F4.8	gene	taxon:6239			
+WB	WBGene00021103	eri-3		W09B6.3|fer-3	gene	taxon:6239			
+WB	WBGene00021109	W09C3.1			gene	taxon:6239			
+WB	WBGene00021110	W09C3.2			gene	taxon:6239			
+WB	WBGene00021112	W09C3.4			gene	taxon:6239			
+WB	WBGene00021113	gsp-3		W09C3.6	gene	taxon:6239			
+WB	WBGene00021116	ncs-6		W09G10.3	gene	taxon:6239			
+WB	WBGene00021117	clec-126		W09G10.5	gene	taxon:6239			
+WB	WBGene00021118	clec-125		W09G10.6	gene	taxon:6239			
+WB	WBGene00021122	W09G12.8			gene	taxon:6239			
+WB	WBGene00021123	W09G12.9			gene	taxon:6239			
+WB	WBGene00021124	W10C4.1			gene	taxon:6239			
+WB	WBGene00021125	ccb-2		W10C8.1	gene	taxon:6239			
+WB	WBGene00021128	W10C8.5			gene	taxon:6239			
+WB	WBGene00021129	W10D9.1			gene	taxon:6239			
+WB	WBGene00021132	nfyb-1		W10D9.4	gene	taxon:6239			
+WB	WBGene00021133	tomm-22		W10D9.5	gene	taxon:6239			
+WB	WBGene00021138	clec-127		W10G11.5	gene	taxon:6239			
+WB	WBGene00021139	clec-128		W10G11.6	gene	taxon:6239			
+WB	WBGene00021142	clec-133		W10G11.12	gene	taxon:6239			
+WB	WBGene00021143	clec-132		W10G11.13	gene	taxon:6239			
+WB	WBGene00021144	clec-130		W10G11.14	gene	taxon:6239			
+WB	WBGene00021145	clec-129		W10G11.15	gene	taxon:6239			
+WB	WBGene00021146	lgc-45		W10G11.16	gene	taxon:6239			
+WB	WBGene00021149	dnc-3		W10G11.20	gene	taxon:6239			
+WB	WBGene00021152	mgl-3		Y4C6A.2	gene	taxon:6239			
+WB	WBGene00021153	Y4C6A.3			gene	taxon:6239			
+WB	WBGene00021156	Y4C6B.2		Y4C6B.g	gene	taxon:6239			
+WB	WBGene00021157	Y4C6B.3		Y4C6B.f	gene	taxon:6239			
+WB	WBGene00021158	Y4C6B.4		Y4C6B.e	gene	taxon:6239			
+WB	WBGene00021159	slc-46A		Y4C6B.5	gene	taxon:6239			
+WB	WBGene00021160	gba-4		Y4C6B.6|Y4C6B.d	gene	taxon:6239			
+WB	WBGene00021163	nhr-275		Y5H2A.2	gene	taxon:6239			
+WB	WBGene00021164	svh-11		Y5H2B.1|Y5H2B.i	gene	taxon:6239			
+WB	WBGene00021166	srbc-42		Y5H2B.4|Y5H2B.e	gene	taxon:6239			
+WB	WBGene00021167	cyp-32B1		Y5H2B.5|Y5H2B.c	gene	taxon:6239			
+WB	WBGene00021168	cyp-33C12		Y5H2B.6|Y5H2B.b	gene	taxon:6239			
+WB	WBGene00021169	srt-40		Y5H2B.7|Y5H2B.a|Y5H2B.i	gene	taxon:6239			
+WB	WBGene00021170	arx-4		Y6D11A.2|tag-286	gene	taxon:6239			
+WB	WBGene00021177	Y9C9A.5			gene	taxon:6239			
+WB	WBGene00021183	Y9C9A.16			gene	taxon:6239			
+WB	WBGene00021185	Y9C12A.1			gene	taxon:6239			
+WB	WBGene00021190	Y14H12A.1		Y14H12A.b	gene	taxon:6239			
+WB	WBGene00021195	Y17G9A.2			gene	taxon:6239			
+WB	WBGene00021197	Y17G9A.4			gene	taxon:6239			
+WB	WBGene00021200	cyp-31A3		Y17G9B.3	gene	taxon:6239			
+WB	WBGene00021201	Y17G9B.4			gene	taxon:6239			
+WB	WBGene00021202	Y17G9B.5			gene	taxon:6239			
+WB	WBGene00021205	Y17G9B.8			gene	taxon:6239			
+WB	WBGene00021207	ptp-5.3		Y18H1A.1	gene	taxon:6239			
+WB	WBGene00021209	hgap-1		Y18H1A.3	gene	taxon:6239			
+WB	WBGene00021213	Y18H1A.9			gene	taxon:6239			
+WB	WBGene00021214	hasp-2		Y18H1A.10	gene	taxon:6239			
+WB	WBGene00021215	Y18H1A.11			gene	taxon:6239			
+WB	WBGene00021219	Y19D10A.4		Y19D10A.d	gene	taxon:6239			
+WB	WBGene00021220	Y19D10A.5		Y19D10A.m	gene	taxon:6239			
+WB	WBGene00021221	Y19D10A.6		Y19D10A.k	gene	taxon:6239			
+WB	WBGene00021223	Y19D10A.8			gene	taxon:6239			
+WB	WBGene00021226	Y19D10A.11			gene	taxon:6239			
+WB	WBGene00021227	mct-1		Y19D10A.12|Y19D10A.l	gene	taxon:6239			
+WB	WBGene00021228	str-265		Y19D10A.13	gene	taxon:6239			
+WB	WBGene00021235	Y19D10B.6		Y19D10B.b	gene	taxon:6239			
+WB	WBGene00021237	crtc-1		Y20F4.2	gene	taxon:6239			
+WB	WBGene00021238	gap-3		Y20F4.3	gene	taxon:6239			
+WB	WBGene00021241	Y22D7AL.1			gene	taxon:6239			
+WB	WBGene00021243	Y22D7AL.3			gene	taxon:6239			
+WB	WBGene00021248	Y22D7AL.10			gene	taxon:6239			
+WB	WBGene00021250	Y22D7AL.12			gene	taxon:6239			
+WB	WBGene00021251	Y22D7AL.13			gene	taxon:6239			
+WB	WBGene00021252	cht-4		Y22D7AL.14	gene	taxon:6239			
+WB	WBGene00021253	Y22D7AL.15			gene	taxon:6239			
+WB	WBGene00021256	Y22D7AR.2			gene	taxon:6239			
+WB	WBGene00021259	glb-30		Y22D7AR.5	gene	taxon:6239			
+WB	WBGene00021260	Y22D7AR.6		Y119D3_465.o	gene	taxon:6239			
+WB	WBGene00021261	Y22D7AR.7			gene	taxon:6239			
+WB	WBGene00021268	capa-1		Y23B4A.2|nlp-44	gene	taxon:6239			
+WB	WBGene00021270	pid-3		Y23H5A.3|pics|pics-1	gene	taxon:6239			
+WB	WBGene00021271	spe-47		Y23H5A.4	gene	taxon:6239			
+WB	WBGene00021275	dmsr-2		Y23H5B.4|Y23H5B.e	gene	taxon:6239			
+WB	WBGene00021276	Y23H5B.5		Y23H5B.d	gene	taxon:6239			
+WB	WBGene00021277	ddx-10		Y23H5B.6|Y23H5B.c|Y74C10A_153.a	gene	taxon:6239			
+WB	WBGene00021281	ell-1		Y24D9A.1|Y24D9A.i	gene	taxon:6239			
+WB	WBGene00021284	Y24D9A.6		Y24D9A.b	gene	taxon:6239			
+WB	WBGene00021285	Y24D9A.7		Y24D9A.a	gene	taxon:6239			
+WB	WBGene00021286	tald-1		Y24D9A.8	gene	taxon:6239			
+WB	WBGene00021288	clec-123		Y25C1A.1	gene	taxon:6239			
+WB	WBGene00021290	clec-122		Y25C1A.3|Y25C1A.b	gene	taxon:6239			
+WB	WBGene00021291	clec-121		Y25C1A.4|Y25C1A.c	gene	taxon:6239			
+WB	WBGene00021292	copb-1		Y25C1A.5|Y25C1A.g|Y25C1A.j	gene	taxon:6239			
+WB	WBGene00021294	Y25C1A.7		Y25C1A.h	gene	taxon:6239			
+WB	WBGene00021295	Y25C1A.8			gene	taxon:6239			
+WB	WBGene00021296	Y25C1A.13			gene	taxon:6239			
+WB	WBGene00021298	Y27F2A.6		Y27F2A.c	gene	taxon:6239			
+WB	WBGene00021304	nphp-2		Y32G9A.6	gene	taxon:6239			
+WB	WBGene00021305	zig-11		Y32G9A.8|oig-6	gene	taxon:6239			
+WB	WBGene00021309	Y32G9B.1			gene	taxon:6239			
+WB	WBGene00021310	Y32H12A.1			gene	taxon:6239			
+WB	WBGene00021311	thoc-5		Y32H12A.2	gene	taxon:6239			
+WB	WBGene00021312	szy-2		Y32H12A.4	gene	taxon:6239			
+WB	WBGene00021313	paqr-2		Y32H12A.5|egl-25	gene	taxon:6239			
+WB	WBGene00021314	Y32H12A.6			gene	taxon:6239			
+WB	WBGene00021316	Y32H12A.8			gene	taxon:6239			
+WB	WBGene00021319	Y34B4A.2		Y34B4A.f|Y34B4A.g	gene	taxon:6239			
+WB	WBGene00021320	Y34B4A.4		Y34B4A.d	gene	taxon:6239			
+WB	WBGene00021323	Y34B4A.7		Y34B4A.b	gene	taxon:6239			
+WB	WBGene00021324	rga-8		Y34B4A.8|Y34B4A.a	gene	taxon:6239			
+WB	WBGene00021327	mrpl-38		Y34D9A.1|Y34D9A.f	gene	taxon:6239			
+WB	WBGene00021328	npr-23		Y34D9A.2|Y34D9A.m	gene	taxon:6239			
+WB	WBGene00021331	glrx-10		Y34D9A.6|Y34D9A.k	gene	taxon:6239			
+WB	WBGene00021333	Y34D9A.8		Y34D9A.c	gene	taxon:6239			
+WB	WBGene00021334	vps-4		Y34D9A.10|phi-25|Y34D9A.b	gene	taxon:6239			
+WB	WBGene00021336	Y34F4.1			gene	taxon:6239			
+WB	WBGene00021337	Y34F4.2			gene	taxon:6239			
+WB	WBGene00021339	Y34F4.4			gene	taxon:6239			
+WB	WBGene00021340	Y34F4.5			gene	taxon:6239			
+WB	WBGene00021344	rev-3		Y37B11A.2	gene	taxon:6239			
+WB	WBGene00021345	Y37B11A.3			gene	taxon:6239			
+WB	WBGene00021347	rpb-10		Y37E3.3	gene	taxon:6239			
+WB	WBGene00021348	moag-4		Y37E3.4	gene	taxon:6239			
+WB	WBGene00021349	arl-13		Y37E3.5	gene	taxon:6239			
+WB	WBGene00021350	Y37E3.8			gene	taxon:6239			
+WB	WBGene00021351	eif-2alpha		Y37E3.10|eIF2alpha	gene	taxon:6239			
+WB	WBGene00021352	pcyt-2.1		Y37E3.11	gene	taxon:6239			
+WB	WBGene00021354	fpn-1.1		Y37E3.16	gene	taxon:6239			
+WB	WBGene00021355	Y37E3.17			gene	taxon:6239			
+WB	WBGene00021357	Y37E11AL.1		Y37E11AL.l	gene	taxon:6239			
+WB	WBGene00021358	Y37E11AL.2		Y37E11AL.k	gene	taxon:6239			
+WB	WBGene00021362	fmil-1		Y37E11AL.6|Y37E11AL.e|Y37E11AL.f|Y37E11AL.g|Y37E11AL.i	gene	taxon:6239			
+WB	WBGene00021363	taf-6.2		Y37E11AL.8	gene	taxon:6239			
+WB	WBGene00021365	smgl-2		Y37E11AM.1|Y37E11AM.a|Y37E11AM.c|Y37E11AM.d	gene	taxon:6239			
+WB	WBGene00021367	Y37E11AM.3		Y37E11AL.a	gene	taxon:6239			
+WB	WBGene00021368	best-20		Y37E11AR.1|Y37E11AR.e	gene	taxon:6239			
+WB	WBGene00021369	siah-1		Y37E11AR.2|Y37E11AR.b|Y37E11AR.d	gene	taxon:6239			
+WB	WBGene00021370	nape-2		Y37E11AR.3	gene	taxon:6239			
+WB	WBGene00021371	nape-1		Y37E11AR.4|Y37E11AR.c	gene	taxon:6239			
+WB	WBGene00021372	ugt-45		Y37E11AR.5	gene	taxon:6239			
+WB	WBGene00021373	Y37E11AR.7			gene	taxon:6239			
+WB	WBGene00021377	Y37E11B.5			gene	taxon:6239			
+WB	WBGene00021386	Y37F4.5			gene	taxon:6239			
+WB	WBGene00021387	Y37F4.6			gene	taxon:6239			
+WB	WBGene00021388	Y37F4.7			gene	taxon:6239			
+WB	WBGene00021391	smut-1		Y38A10A.6	gene	taxon:6239			
+WB	WBGene00021392	Y38A10A.7			gene	taxon:6239			
+WB	WBGene00021394	Y38C1AA.1			gene	taxon:6239			
+WB	WBGene00021395	pnc-1		Y38C1AA.3|cog-3|Y38C1AA.h	gene	taxon:6239			
+WB	WBGene00021396	cutl-24		Y38C1AA.5|Y38C1AA.f	gene	taxon:6239			
+WB	WBGene00021397	Y38C1AA.6			gene	taxon:6239			
+WB	WBGene00021398	Y38C1AA.7		Y38C1AA.d	gene	taxon:6239			
+WB	WBGene00021401	prdx-6		Y38C1AA.11|ceprx3|Y38C1AA.j	gene	taxon:6239			
+WB	WBGene00021403	Y38C1AB.1			gene	taxon:6239			
+WB	WBGene00021404	trpl-3		Y38C1AB.2	gene	taxon:6239			
+WB	WBGene00021407	Y38C1AB.5			gene	taxon:6239			
+WB	WBGene00021410	Y38C1BA.1			gene	taxon:6239			
+WB	WBGene00021412	cyp-29A3		Y38C9B.1	gene	taxon:6239			
+WB	WBGene00021413	srt-52		Y38C9B.2	gene	taxon:6239			
+WB	WBGene00021415	nsy-4		Y38F2AL.1|Y38F2AL.h	gene	taxon:6239			
+WB	WBGene00021416	mksr-2		Y38F2AL.2|tza-1|Y38F2AL.f	gene	taxon:6239			
+WB	WBGene00021417	nhr-236		Y38F2AL.5|Y38F2AL.b	gene	taxon:6239			
+WB	WBGene00021419	eri-5		Y38F2AR.1	gene	taxon:6239			
+WB	WBGene00021420	trap-3		Y38F2AR.2|Y38F2A_6126.e	gene	taxon:6239			
+WB	WBGene00021421	Y38F2AR.3			gene	taxon:6239			
+WB	WBGene00021423	tftc-1		Y38F2AR.5	gene	taxon:6239			
+WB	WBGene00021425	ppgn-1		Y38F2AR.7	gene	taxon:6239			
+WB	WBGene00021427	sec-61.B		Y38F2AR.9	gene	taxon:6239			
+WB	WBGene00021428	Y38F2AR.10			gene	taxon:6239			
+WB	WBGene00021430	Y38F2AR.12			gene	taxon:6239			
+WB	WBGene00021435	Y39A3A.4			gene	taxon:6239			
+WB	WBGene00021436	Y39A3B.1			gene	taxon:6239			
+WB	WBGene00021437	lgc-42		Y39A3B.2	gene	taxon:6239			
+WB	WBGene00021439	ckr-2		Y39A3B.5	gene	taxon:6239			
+WB	WBGene00021441	Y39A3CL.3			gene	taxon:6239			
+WB	WBGene00021446	hlh-33		Y39A3CR.6	gene	taxon:6239			
+WB	WBGene00021448	Y39D8A.1			gene	taxon:6239			
+WB	WBGene00021449	mltn-7		Y39D8B.1	gene	taxon:6239			
+WB	WBGene00021450	mltn-6		Y39D8B.2	gene	taxon:6239			
+WB	WBGene00021451	mltn-8		Y39D8B.3	gene	taxon:6239			
+WB	WBGene00021456	rfip-2		Y39F10B.1	gene	taxon:6239			
+WB	WBGene00021457	Y39F10C.1			gene	taxon:6239			
+WB	WBGene00021460	zwl-1		Y39G10AR.2	gene	taxon:6239			
+WB	WBGene00021461	nekl-1		Y39G10AR.3	gene	taxon:6239			
+WB	WBGene00021463	zeel-1		Y39G10AR.5	gene	taxon:6239			
+WB	WBGene00021464	ugt-31		Y39G10AR.6	gene	taxon:6239			
+WB	WBGene00021466	eif-2gamma		Y39G10AR.8	gene	taxon:6239			
+WB	WBGene00021468	epg-2		Y39G10AR.10	gene	taxon:6239			
+WB	WBGene00021470	tpxl-1		Y39G10AR.12	gene	taxon:6239			
+WB	WBGene00021472	Y39G10AR.16			gene	taxon:6239			
+WB	WBGene00021473	sydn-1		Y39G10AR.17	gene	taxon:6239			
+WB	WBGene00021474	dot-1.1		Y39G10AR.18	gene	taxon:6239			
+WB	WBGene00021475	tbca-1		Y39G10AR.20	gene	taxon:6239			
+WB	WBGene00021476	nsun-4		Y39G10AR.21	gene	taxon:6239			
+WB	WBGene00021477	srbc-64		Y39G10AR.22	gene	taxon:6239			
+WB	WBGene00021479	oac-55		Y39H10A.2|Y39H10A.h	gene	taxon:6239			
+WB	WBGene00021486	lbp-9		Y40B10A.1|Y40B10A.b|Y40B10A.h	gene	taxon:6239			
+WB	WBGene00021487	comt-3		Y40B10A.2|Y40B10A.g	gene	taxon:6239			
+WB	WBGene00021488	srab-23		Y40B10A.3	gene	taxon:6239			
+WB	WBGene00021490	Y40B10A.5		Y40B10A.f	gene	taxon:6239			
+WB	WBGene00021491	comt-4		Y40B10A.6|Y40B10A.e	gene	taxon:6239			
+WB	WBGene00021492	comt-5		Y40B10A.7|Y40B10A.c	gene	taxon:6239			
+WB	WBGene00021493	Y40B10A.9		Y40B10A.a	gene	taxon:6239			
+WB	WBGene00021495	sqst-2		Y40C5A.1	gene	taxon:6239			
+WB	WBGene00021497	Y40C5A.4			gene	taxon:6239			
+WB	WBGene00021502	Y40D12A.1			gene	taxon:6239			
+WB	WBGene00021503	ctsa-4.2		Y40D12A.2|ctsa-2|drd-8	gene	taxon:6239			
+WB	WBGene00021506	Y41D4A.4			gene	taxon:6239			
+WB	WBGene00021507	ptpn-22		Y41D4A.5	gene	taxon:6239			
+WB	WBGene00021508	Y41D4A.6			gene	taxon:6239			
+WB	WBGene00021510	frpr-19		Y41D4A.8	gene	taxon:6239			
+WB	WBGene00021511	Y41D4B.1			gene	taxon:6239			
+WB	WBGene00021515	set-23		Y41D4B.12	gene	taxon:6239			
+WB	WBGene00021518	hpo-6		Y41D4B.16	gene	taxon:6239			
+WB	WBGene00021522	nhr-274		Y41D4B.21	gene	taxon:6239			
+WB	WBGene00021524	Y41D4B.24			gene	taxon:6239			
+WB	WBGene00021526	nspg-5		Y41G9A.2	gene	taxon:6239			
+WB	WBGene00021527	aakg-3		Y41G9A.3	gene	taxon:6239			
+WB	WBGene00021528	gbb-1		Y41G9A.4	gene	taxon:6239			
+WB	WBGene00021534	mvk-1		Y42G9A.4	gene	taxon:6239			
+WB	WBGene00021535	wht-7		Y42G9A.6	gene	taxon:6239			
+WB	WBGene00021536	Y42H9AR.1		Y42H9AR.a	gene	taxon:6239			
+WB	WBGene00021537	Y42H9AR.2		Y42H9AR.e	gene	taxon:6239			
+WB	WBGene00021538	rabs-5		Y42H9AR.3|Y42H9AR.c|Y42H9AR.d|ztf-5	gene	taxon:6239			
+WB	WBGene00021544	Y43B11AR.3		Y43B11AR.c	gene	taxon:6239			
+WB	WBGene00021545	Y43H11AL.1		Y43H11AL.d	gene	taxon:6239			
+WB	WBGene00021546	laat-1		Y43H11AL.2|Y43H11AL.c	gene	taxon:6239			
+WB	WBGene00021548	trx-4		Y44E3A.3	gene	taxon:6239			
+WB	WBGene00021552	zip-4		Y44E3B.1	gene	taxon:6239			
+WB	WBGene00021553	tyr-5		Y44E3B.2	gene	taxon:6239			
+WB	WBGene00021555	pid-5		Y45G5AM.2	gene	taxon:6239			
+WB	WBGene00021558	Y45G5AM.6			gene	taxon:6239			
+WB	WBGene00021560	coh-4		Y45G5AM.8	gene	taxon:6239			
+WB	WBGene00021562	nuo-5		Y45G12B.1|nduf-1	gene	taxon:6239			
+WB	WBGene00021563	Y45G12B.2			gene	taxon:6239			
+WB	WBGene00021564	Y45G12B.3			gene	taxon:6239			
+WB	WBGene00021566	Y45G12C.3			gene	taxon:6239			
+WB	WBGene00021571	srbc-81		Y45G12C.8	gene	taxon:6239			
+WB	WBGene00021573	Y45G12C.10			gene	taxon:6239			
+WB	WBGene00021578	Y46B2A.3			gene	taxon:6239			
+WB	WBGene00021579	clec-73		Y46C8AL.1|Y46C8AL.a	gene	taxon:6239			
+WB	WBGene00021580	clec-174		Y46C8AL.2|Y46C8AL.b|Y46C8AL.f|Y46C8AL.g	gene	taxon:6239			
+WB	WBGene00021581	clec-70		Y46C8AL.3|Y46C8AL.d	gene	taxon:6239			
+WB	WBGene00021582	clec-71		Y46C8AL.4|Y46C8AL.e	gene	taxon:6239			
+WB	WBGene00021583	clec-72		Y46C8AL.5	gene	taxon:6239			
+WB	WBGene00021585	clec-74		Y46C8AL.8|Y46C8AL.k|Y46C8AL.l	gene	taxon:6239			
+WB	WBGene00021586	clec-75		Y46C8AL.9	gene	taxon:6239			
+WB	WBGene00021587	clec-76		Y46C8AR.1|Y46C8AR.a	gene	taxon:6239			
+WB	WBGene00021594	tig-3		Y46E12BL.1	gene	taxon:6239			
+WB	WBGene00021595	Y46E12BL.2			gene	taxon:6239			
+WB	WBGene00021597	spsb-1		Y46E12BL.4	gene	taxon:6239			
+WB	WBGene00021599	srt-42		Y46H3A.1	gene	taxon:6239			
+WB	WBGene00021601	Y46H3A.5			gene	taxon:6239			
+WB	WBGene00021602	clec-205		Y46H3B.1	gene	taxon:6239			
+WB	WBGene00021603	clec-204		Y46H3B.2	gene	taxon:6239			
+WB	WBGene00021610	nhr-237		Y46H3D.6	gene	taxon:6239			
+WB	WBGene00021611	nhr-238		Y46H3D.7	gene	taxon:6239			
+WB	WBGene00021613	ttc-37		Y47A7.1	gene	taxon:6239			
+WB	WBGene00021615	Y47C4A.1		Y47C4A.a	gene	taxon:6239			
+WB	WBGene00021617	Y47D7A.3			gene	taxon:6239			
+WB	WBGene00021626	rft-2		Y47D7A.14	gene	taxon:6239			
+WB	WBGene00021628	Y47D9A.1			gene	taxon:6239			
+WB	WBGene00021629	scpl-3		Y47D9A.2	gene	taxon:6239			
+WB	WBGene00021632	Y47D9A.5			gene	taxon:6239			
+WB	WBGene00021633	Y47G6A.3			gene	taxon:6239			
+WB	WBGene00021634	rde-10		Y47G6A.4	gene	taxon:6239			
+WB	WBGene00021635	Y47G6A.5			gene	taxon:6239			
+WB	WBGene00021636	pcaf-1		Y47G6A.6|CeGCN5|Y47G6A_241.b	gene	taxon:6239			
+WB	WBGene00021637	Y47G6A.7			gene	taxon:6239			
+WB	WBGene00021638	Y47G6A.9			gene	taxon:6239			
+WB	WBGene00021639	Y47G6A.13			gene	taxon:6239			
+WB	WBGene00021640	Y47G6A.14			gene	taxon:6239			
+WB	WBGene00021643	ccep-290		Y47G6A.17|cep-290	gene	taxon:6239			
+WB	WBGene00021644	Y47G6A.18			gene	taxon:6239			
+WB	WBGene00021645	Y47G6A.19			gene	taxon:6239			
+WB	WBGene00021646	Y47G6A.21			gene	taxon:6239			
+WB	WBGene00021647	Y47G6A.22			gene	taxon:6239			
+WB	WBGene00021648	mis-12		Y47G6A.24	gene	taxon:6239			
+WB	WBGene00021654	Y47G7B.2			gene	taxon:6239			
+WB	WBGene00021655	Y48A5A.1			gene	taxon:6239			
+WB	WBGene00021660	nol-14		Y48G1A.4|NOP14|Y48G1A.b|Y48G1A.c|Y48G1A.e	gene	taxon:6239			
+WB	WBGene00021661	mbtr-1		Y48G1A.6|Y48G1A.a|Y48G1A.g	gene	taxon:6239			
+WB	WBGene00021666	Y48G1BL.7			gene	taxon:6239			
+WB	WBGene00021667	snpc-3.2		Y48G1BM.1	gene	taxon:6239			
+WB	WBGene00021675	Y48G1BR.1		Y48G1BR.a	gene	taxon:6239			
+WB	WBGene00021676	pid-2		Y48G1C.1|Y48G1C.g	gene	taxon:6239			
+WB	WBGene00021677	pgs-1		Y48G1C.4|Y48G1C.e	gene	taxon:6239			
+WB	WBGene00021678	Y48G1C.5		Y48G1C.d	gene	taxon:6239			
+WB	WBGene00021682	natc-3		Y48G1C.9	gene	taxon:6239			
+WB	WBGene00021685	herc-1		Y48G8AL.1|hpo-23	gene	taxon:6239			
+WB	WBGene00021686	nsun-2		Y48G8AL.5	gene	taxon:6239			
+WB	WBGene00021689	znf-236		Y48G8AL.10	gene	taxon:6239			
+WB	WBGene00021691	Y48G8AL.13			gene	taxon:6239			
+WB	WBGene00021692	Y48G8AL.15			gene	taxon:6239			
+WB	WBGene00021693	Y48G8AR.2		Y48G8AR.c	gene	taxon:6239			
+WB	WBGene00021697	gcn-1		Y48G9A.3|Y48G9A.a|Y48G9A.l|Y48G9A.m|Y48G9A.n|Y48G9A.o	gene	taxon:6239			
+WB	WBGene00021698	frl-1		Y48G9A.4	gene	taxon:6239			
+WB	WBGene00021702	Y48G9A.9		Y48G9A.f	gene	taxon:6239			
+WB	WBGene00021703	cpt-3		Y48G9A.10|Y48G9A.d|Y48G9A.e	gene	taxon:6239			
+WB	WBGene00021706	srbc-39		Y49C4A.1	gene	taxon:6239			
+WB	WBGene00021707	srbc-38		Y49C4A.2	gene	taxon:6239			
+WB	WBGene00021708	srbc-37		Y49C4A.3|Y49C4A.e	gene	taxon:6239			
+WB	WBGene00021709	ugt-29		Y49C4A.8	gene	taxon:6239			
+WB	WBGene00021710	cyp-33C11		Y49C4A.9|Y49C4A.a	gene	taxon:6239			
+WB	WBGene00021714	cyh-1		Y49F6B.1|Y49F6B_108.i	gene	taxon:6239			
+WB	WBGene00021715	Y49F6B.2			gene	taxon:6239			
+WB	WBGene00021721	Y49F6B.9		Y49F6B.o	gene	taxon:6239			
+WB	WBGene00021722	srz-5		Y49F6B.11	gene	taxon:6239			
+WB	WBGene00021731	Y49G5A.1			gene	taxon:6239			
+WB	WBGene00021736	wrb-1		Y50D4A.2|Y50D4A.e	gene	taxon:6239			
+WB	WBGene00021738	Y50D4A.4		Y50D4A.b|Y50D4A.c	gene	taxon:6239			
+WB	WBGene00021743	Y50D4B.4		Y50D4B.d	gene	taxon:6239			
+WB	WBGene00021744	clec-203		Y50D4B.5|Y50D4B.c	gene	taxon:6239			
+WB	WBGene00021745	Y50D4B.6		Y50D4B.b	gene	taxon:6239			
+WB	WBGene00021748	Y50D4C.3			gene	taxon:6239			
+WB	WBGene00021750	Y50D4C.6			gene	taxon:6239			
+WB	WBGene00021752	xpd-1		Y50D7A.2|Y50D7A.d|Y50D7A.h	gene	taxon:6239			
+WB	WBGene00021753	Y50D7A.3		Y50D7A.g	gene	taxon:6239			
+WB	WBGene00021758	Y50D7A.10			gene	taxon:6239			
+WB	WBGene00021763	Y51F10.2			gene	taxon:6239			
+WB	WBGene00021764	Y51F10.3			gene	taxon:6239			
+WB	WBGene00021765	Y51F10.4			gene	taxon:6239			
+WB	WBGene00021766	hex-4		Y51F10.5	gene	taxon:6239			
+WB	WBGene00021776	Y51H7BR.4			gene	taxon:6239			
+WB	WBGene00021783	alkb-1		Y51H7C.5|Y51H7C.o	gene	taxon:6239			
+WB	WBGene00021784	cogc-4		Y51H7C.6|Y51H7C.k|Y51H7C.o	gene	taxon:6239			
+WB	WBGene00021788	Y51H7C.10		Y51H7C.h	gene	taxon:6239			
+WB	WBGene00021789	nol-6		Y51H7C.11|rpa-6|rpa-9|Y51H7C.g	gene	taxon:6239			
+WB	WBGene00021790	Y51H7C.12		Y51H7C.f|Y51H7C.g	gene	taxon:6239			
+WB	WBGene00021793	Y52D5A.2			gene	taxon:6239			
+WB	WBGene00021795	Y52E8A.2		Y52E8A.d	gene	taxon:6239			
+WB	WBGene00021797	plep-1		Y52E8A.4|Y52E8A.b	gene	taxon:6239			
+WB	WBGene00021798	Y52E8A.6			gene	taxon:6239			
+WB	WBGene00021800	nduf-9		Y53G8AL.2|Y53G8AL.a	gene	taxon:6239			
+WB	WBGene00021804	Y53G8AM.4		Y53G8AM.g	gene	taxon:6239			
+WB	WBGene00021810	phf-15		Y53G8AR.2|Y53G8AR.g	gene	taxon:6239			
+WB	WBGene00021811	ral-1		Y53G8AR.3|Y53G8AR.f	gene	taxon:6239			
+WB	WBGene00021812	Y53G8AR.5		Y53G8AR.e	gene	taxon:6239			
+WB	WBGene00021814	mfsd-8		Y53G8AR.7|Y53G8AR.c	gene	taxon:6239			
+WB	WBGene00021815	Y53G8AR.8		Y53G8AR.b	gene	taxon:6239			
+WB	WBGene00021816	Y53G8AR.9		Y53G8AR.a	gene	taxon:6239			
+WB	WBGene00021817	Y53G8B.1			gene	taxon:6239			
+WB	WBGene00021818	Y53G8B.2			gene	taxon:6239			
+WB	WBGene00021820	nipa-1		Y53G8B.4	gene	taxon:6239			
+WB	WBGene00021826	txl-1		Y54E10A.3|txl	gene	taxon:6239			
+WB	WBGene00021827	dnc-6		Y54E10A.5	gene	taxon:6239			
+WB	WBGene00021828	Y54E10A.6			gene	taxon:6239			
+WB	WBGene00021829	mrpl-17		Y54E10A.7	gene	taxon:6239			
+WB	WBGene00021830	Y54E10A.10			gene	taxon:6239			
+WB	WBGene00021831	Y54E10A.11			gene	taxon:6239			
+WB	WBGene00021834	mab-31		Y54E10A.16	gene	taxon:6239			
+WB	WBGene00021838	Y54E10BL.3			gene	taxon:6239			
+WB	WBGene00021839	nduf-5		Y54E10BL.5|Y54E10134BL.5	gene	taxon:6239			
+WB	WBGene00021840	pign-1		Y54E10BR.1|M01B12.e|Y54E10BR.j	gene	taxon:6239			
+WB	WBGene00021841	Y54E10BR.2		Y54E10BR.i	gene	taxon:6239			
+WB	WBGene00021842	Y54E10BR.3			gene	taxon:6239			
+WB	WBGene00021843	Y54E10BR.4		Y54E10BR.e|Y54E10BR.f|Y54E10BR.g	gene	taxon:6239			
+WB	WBGene00021844	sec-11		Y54E10BR.5|Y54E10BR.d	gene	taxon:6239			
+WB	WBGene00021845	rpb-7		Y54E10BR.6|Y54E10BR.c	gene	taxon:6239			
+WB	WBGene00021846	ztf-23		Y54E10BR.8|Y54E10BR.a	gene	taxon:6239			
+WB	WBGene00021847	Y54F10AL.1		Y54F10AL.b	gene	taxon:6239			
+WB	WBGene00021848	nhr-239		Y54F10AM.1	gene	taxon:6239			
+WB	WBGene00021849	Y54F10AM.5			gene	taxon:6239			
+WB	WBGene00021852	Y54F10AM.8			gene	taxon:6239			
+WB	WBGene00021854	Y54F10AR.1			gene	taxon:6239			
+WB	WBGene00021856	ppm-1.D		Y54F10BM.1	gene	taxon:6239			
+WB	WBGene00021857	iffb-1		Y54F10BM.2	gene	taxon:6239			
+WB	WBGene00021858	Y54F10BM.3			gene	taxon:6239			
+WB	WBGene00021861	Y54F10BM.6			gene	taxon:6239			
+WB	WBGene00021867	Y54F10BM.13			gene	taxon:6239			
+WB	WBGene00021868	atln-1		Y54G2A.2|4D561	gene	taxon:6239			
+WB	WBGene00021870	samt-1		Y54G2A.4|Y54G2A.n	gene	taxon:6239			
+WB	WBGene00021872	clec-85		Y54G2A.6	gene	taxon:6239			
+WB	WBGene00021873	clec-82		Y54G2A.8	gene	taxon:6239			
+WB	WBGene00021876	Y54G2A.11			gene	taxon:6239			
+WB	WBGene00021877	Y54G2A.12		Y54G2A.z	gene	taxon:6239			
+WB	WBGene00021878	Y54G2A.13		Y54G2A.y	gene	taxon:6239			
+WB	WBGene00021879	clec-83		Y54G2A.14|Y54G2A.x	gene	taxon:6239			
+WB	WBGene00021881	Y54G2A.16			gene	taxon:6239			
+WB	WBGene00021882	nprt-1		Y54G2A.17|Y54G2A.u	gene	taxon:6239			
+WB	WBGene00021883	Y54G2A.18			gene	taxon:6239			
+WB	WBGene00021888	manf-1		Y54G2A.23|Y54G2A.o	gene	taxon:6239			
+WB	WBGene00021895	clec-84		Y54G2A.33	gene	taxon:6239			
+WB	WBGene00021897	ser-6		Y54G2A.35	gene	taxon:6239			
+WB	WBGene00021898	Y54G2A.36			gene	taxon:6239			
+WB	WBGene00021899	Y54H5A.1			gene	taxon:6239			
+WB	WBGene00021901	rbm-42		Y54H5A.3|tag-262	gene	taxon:6239			
+WB	WBGene00021902	oxy-4		Y54H5A.4	gene	taxon:6239			
+WB	WBGene00021904	gtf-2H5		Y55B1AL.2|Y55B1AL.b	gene	taxon:6239			
+WB	WBGene00021905	helq-1		Y55B1AL.3|hel-308|Y55B1AL.a|Y55B1AM.c	gene	taxon:6239			
+WB	WBGene00021910	stim-1		Y55B1BM.1|Y55B1BM.c	gene	taxon:6239			
+WB	WBGene00021912	affl-2		Y55B1BR.2|sup-45	gene	taxon:6239			
+WB	WBGene00021913	cec-8		Y55B1BR.3	gene	taxon:6239			
+WB	WBGene00021914	magu-1		Y55B1BR.4|tag-117	gene	taxon:6239			
+WB	WBGene00021917	Y55D5A.3			gene	taxon:6239			
+WB	WBGene00021919	cutl-25		Y55D5A.6	gene	taxon:6239			
+WB	WBGene00021920	mrps-25		Y55F3AM.1	gene	taxon:6239			
+WB	WBGene00021921	rbm-39		Y55F3AM.3	gene	taxon:6239			
+WB	WBGene00021922	atg-3		Y55F3AM.4	gene	taxon:6239			
+WB	WBGene00021925	immp-2		Y55F3AM.8|Y55F3A_746.b	gene	taxon:6239			
+WB	WBGene00021926	Y55F3AM.9			gene	taxon:6239			
+WB	WBGene00021927	abhd-14		Y55F3AM.10	gene	taxon:6239			
+WB	WBGene00021929	dcap-1		Y55F3AM.12|dcp1	gene	taxon:6239			
+WB	WBGene00021931	znf-782		Y55F3AM.14	gene	taxon:6239			
+WB	WBGene00021932	cox-18		Y55F3AR.1	gene	taxon:6239			
+WB	WBGene00021933	Y55F3AR.2			gene	taxon:6239			
+WB	WBGene00021934	cct-8		Y55F3AR.3	gene	taxon:6239			
+WB	WBGene00021935	mrpl-46		Y55F3BL.1	gene	taxon:6239			
+WB	WBGene00021936	zipt-15		Y55F3BL.2|zipt-20	gene	taxon:6239			
+WB	WBGene00021938	Y55F3BR.1		Y55F3BR.l	gene	taxon:6239			
+WB	WBGene00021939	Y55F3BR.2		Y55F3BR.j|Y55F3BR.k	gene	taxon:6239			
+WB	WBGene00021941	lgc-33		Y55F3BR.4|Y55F3BR.d|Y55F3BR.i	gene	taxon:6239			
+WB	WBGene00021945	lem-4		Y55F3BR.8|Y55F3BR.a|Y55F3BR.b|Y55F3BR.c|Y55F3BR.i	gene	taxon:6239			
+WB	WBGene00021947	srt-23		Y55F3C.2|Y55F3C.g|Y55F3C.h	gene	taxon:6239			
+WB	WBGene00021948	kvs-5		Y55F3C.3|Y55F3C.e|Y55F3C.f	gene	taxon:6239			
+WB	WBGene00021949	clec-164		Y55F3C.5|Y55F3C.d	gene	taxon:6239			
+WB	WBGene00021950	cutl-26		Y55F3C.7	gene	taxon:6239			
+WB	WBGene00021951	srt-24		Y55F3C.8	gene	taxon:6239			
+WB	WBGene00021952	vha-19		Y55H10A.1	gene	taxon:6239			
+WB	WBGene00021953	Y55H10A.2			gene	taxon:6239			
+WB	WBGene00021956	Y57E12AL.1		Y57E12AL.f|Y57E12AM.a	gene	taxon:6239			
+WB	WBGene00021960	tmem-258		Y57E12AM.1	gene	taxon:6239			
+WB	WBGene00021963	lipl-6		Y57E12B.3	gene	taxon:6239			
+WB	WBGene00021967	Y57G7A.3			gene	taxon:6239			
+WB	WBGene00021969	Y57G7A.6			gene	taxon:6239			
+WB	WBGene00021970	srz-64		Y57G7A.7	gene	taxon:6239			
+WB	WBGene00021972	glb-31		Y57G7A.9	gene	taxon:6239			
+WB	WBGene00021973	emc-2		Y57G7A.10|tpr-2	gene	taxon:6239			
+WB	WBGene00021975	Y58A7A.1		Y58A7A.e	gene	taxon:6239			
+WB	WBGene00021979	Y58A7A.5			gene	taxon:6239			
+WB	WBGene00021980	glb-32		Y58A7A.6|Y58A7A.a|Y58A7A.b	gene	taxon:6239			
+WB	WBGene00021981	lgc-26		Y58G8A.1	gene	taxon:6239			
+WB	WBGene00021983	npr-5		Y58G8A.4	gene	taxon:6239			
+WB	WBGene00021984	Y59C2A.1			gene	taxon:6239			
+WB	WBGene00021985	Y59C2A.2			gene	taxon:6239			
+WB	WBGene00021992	thn-6		Y59E9AL.1	gene	taxon:6239			
+WB	WBGene00021994	Y59E9AL.4			gene	taxon:6239			
+WB	WBGene00021997	Y59E9AR.1			gene	taxon:6239			
+WB	WBGene00021999	thn-5		Y59E9AR.4	gene	taxon:6239			
+WB	WBGene00022000	tbx-42		Y59E9AR.5	gene	taxon:6239			
+WB	WBGene00022004	npr-22		Y59H11AL.1|Y59H11AL.a	gene	taxon:6239			
+WB	WBGene00022005	Y59H11AM.1		Y59H11AM.d	gene	taxon:6239			
+WB	WBGene00022006	mpst-5		Y59H11AM.2	gene	taxon:6239			
+WB	WBGene00022010	catp-7		Y59H11AR.2	gene	taxon:6239			
+WB	WBGene00022012	Y59H11AR.4		Y59H11AR.a	gene	taxon:6239			
+WB	WBGene00022013	Y60C6A.1			gene	taxon:6239			
+WB	WBGene00022014	Y61A9LA.1		Y61A9LA.m	gene	taxon:6239			
+WB	WBGene00022019	sut-2		Y61A9LA.8|Y61A9LA.e|Y61A9LA_72.a	gene	taxon:6239			
+WB	WBGene00022021	Y61A9LA.10		Y61A9LA.a|Y61A9LA.b	gene	taxon:6239			
+WB	WBGene00022025	cus-2		Y65B4A.1|Y65B4A.b|Y65B4A.j|Y65B4A_179.b	gene	taxon:6239			
+WB	WBGene00022026	Y65B4A.2		Y65B4A.i|Y65B4A.j|Y65B4A_179.b	gene	taxon:6239			
+WB	WBGene00022027	vps-20		Y65B4A.3|Y65B4A.d|Y65B4A.h	gene	taxon:6239			
+WB	WBGene00022028	Y65B4A.4			gene	taxon:6239			
+WB	WBGene00022029	Y65B4A.6		Y65B4A.e	gene	taxon:6239			
+WB	WBGene00022030	Y65B4A.7		Y65B4A.c|Y65B4A.i	gene	taxon:6239			
+WB	WBGene00022031	Y65B4A.8			gene	taxon:6239			
+WB	WBGene00022032	Y65B4A.9		Y65B4A.a|Y65B4A.k	gene	taxon:6239			
+WB	WBGene00022034	deps-1		Y65B4BL.2	gene	taxon:6239			
+WB	WBGene00022035	Y65B4BL.3			gene	taxon:6239			
+WB	WBGene00022036	Y65B4BL.4			gene	taxon:6239			
+WB	WBGene00022039	Y65B4BL.7			gene	taxon:6239			
+WB	WBGene00022040	Y65B4BR.1			gene	taxon:6239			
+WB	WBGene00022042	icd-2		Y65B4BR.5	gene	taxon:6239			
+WB	WBGene00022043	psf-3		Y65B4BR.8	gene	taxon:6239			
+WB	WBGene00022044	dpm-1		Y66H1A.2	gene	taxon:6239			
+WB	WBGene00022045	mrpl-55		Y66H1A.3|tag-313	gene	taxon:6239			
+WB	WBGene00022046	Y66H1A.4			gene	taxon:6239			
+WB	WBGene00022048	fln-1		Y66H1B.2	gene	taxon:6239			
+WB	WBGene00022051	rep-1		Y67D2.1	gene	taxon:6239			
+WB	WBGene00022052	Y67D2.2			gene	taxon:6239			
+WB	WBGene00022053	cisd-3.2		Y67D2.3	gene	taxon:6239			
+WB	WBGene00022054	mtg-1		Y67D2.4	gene	taxon:6239			
+WB	WBGene00022055	Y67D2.5			gene	taxon:6239			
+WB	WBGene00022056	ddx-35		Y67D2.6	gene	taxon:6239			
+WB	WBGene00022057	Y67D2.7			gene	taxon:6239			
+WB	WBGene00022059	Y67D8A.2			gene	taxon:6239			
+WB	WBGene00022060	dmd-9		Y67D8A.3	gene	taxon:6239			
+WB	WBGene00022061	Y67D8B.1		Y67D8B.c	gene	taxon:6239			
+WB	WBGene00022062	Y67D8B.2		Y67D8B.b	gene	taxon:6239			
+WB	WBGene00022063	nlp-81		Y67D8B.4	gene	taxon:6239			
+WB	WBGene00022064	Y67D8B.5			gene	taxon:6239			
+WB	WBGene00022069	eel-1		Y67D8C.5	gene	taxon:6239			
+WB	WBGene00022070	Y67D8C.6			gene	taxon:6239			
+WB	WBGene00022073	Y67D8C.9			gene	taxon:6239			
+WB	WBGene00022075	Y69A2AR.3			gene	taxon:6239			
+WB	WBGene00022076	daao-1		Y69A2AR.5	gene	taxon:6239			
+WB	WBGene00022077	vamp-7		Y69A2AR.6	gene	taxon:6239			
+WB	WBGene00022078	epg-9		Y69A2AR.7	gene	taxon:6239			
+WB	WBGene00022083	Y69A2AR.12			gene	taxon:6239			
+WB	WBGene00022086	sprr-3		Y69A2AR.15	gene	taxon:6239			
+WB	WBGene00022087	Y69A2AR.16			gene	taxon:6239			
+WB	WBGene00022089	Y69A2AR.18			gene	taxon:6239			
+WB	WBGene00022090	Y69A2AR.19			gene	taxon:6239			
+WB	WBGene00022094	Y69A2AR.23			gene	taxon:6239			
+WB	WBGene00022097	nhr-242		Y69A2AR.26	gene	taxon:6239			
+WB	WBGene00022100	Y69A2AR.31			gene	taxon:6239			
+WB	WBGene00022101	Y69A2AR.32			gene	taxon:6239			
+WB	WBGene00022102	Y69F12A.1			gene	taxon:6239			
+WB	WBGene00022103	cdh-12		Y71D11A.1|Y92C3A.b|Y92C3A.c|Y92C3A.e	gene	taxon:6239			
+WB	WBGene00022104	acsd-1		Y71D11A.3|ACMSD	gene	taxon:6239			
+WB	WBGene00022106	lgc-46		Y71D11A.5	gene	taxon:6239			
+WB	WBGene00022107	Y71F9AL.1			gene	taxon:6239			
+WB	WBGene00022108	Y71F9AL.2			gene	taxon:6239			
+WB	WBGene00022110	Y71F9AL.4			gene	taxon:6239			
+WB	WBGene00022111	Y71F9AL.6			gene	taxon:6239			
+WB	WBGene00022114	Y71F9AL.9			gene	taxon:6239			
+WB	WBGene00022115	Y71F9AL.10			gene	taxon:6239			
+WB	WBGene00022118	dnc-5		Y71F9AL.14	gene	taxon:6239			
+WB	WBGene00022119	copa-1		Y71F9AL.17|Y71F9AL.d	gene	taxon:6239			
+WB	WBGene00022121	cogc-3		Y71F9AM.4|mig-29|Y71F9AM.b|Y71F9AM.c|Y71F9AM.d	gene	taxon:6239			
+WB	WBGene00022122	trap-1		Y71F9AM.6	gene	taxon:6239			
+WB	WBGene00022123	Y71F9AR.2		Y71F9AR.b	gene	taxon:6239			
+WB	WBGene00022124	supr-1		Y71F9AR.3|Y54E10BL.f	gene	taxon:6239			
+WB	WBGene00022125	Y71F9B.1			gene	taxon:6239			
+WB	WBGene00022126	Y71F9B.2			gene	taxon:6239			
+WB	WBGene00022127	yop-1		Y71F9B.3	gene	taxon:6239			
+WB	WBGene00022128	Y71F9B.6			gene	taxon:6239			
+WB	WBGene00022129	lron-11		Y71F9B.8|1D304	gene	taxon:6239			
+WB	WBGene00022130	Y71F9B.9			gene	taxon:6239			
+WB	WBGene00022133	Y71F9B.15			gene	taxon:6239			
+WB	WBGene00022138	trpp-10		Y71G12A.2|Y71G12A.b|Y71G12A.d	gene	taxon:6239			
+WB	WBGene00022140	Y71G12A.4			gene	taxon:6239			
+WB	WBGene00022143	Y71G12B.3			gene	taxon:6239			
+WB	WBGene00022144	pghm-1		Y71G12B.4	gene	taxon:6239			
+WB	WBGene00022148	ddx-27		Y71G12B.8|let-362	gene	taxon:6239			
+WB	WBGene00022149	lin-65		Y71G12B.9	gene	taxon:6239			
+WB	WBGene00022150	Y71G12B.10			gene	taxon:6239			
+WB	WBGene00022152	atg-5		Y71G12B.12|atgr-5	gene	taxon:6239			
+WB	WBGene00022154	drag-1		Y71G12B.16	gene	taxon:6239			
+WB	WBGene00022155	Y71G12B.17			gene	taxon:6239			
+WB	WBGene00022158	Y71G12B.23			gene	taxon:6239			
+WB	WBGene00022159	mppa-1		Y71G12B.24	gene	taxon:6239			
+WB	WBGene00022160	Y71G12B.25			gene	taxon:6239			
+WB	WBGene00022161	Y71G12B.26			gene	taxon:6239			
+WB	WBGene00022162	Y71G12B.27		Y71G12A_203.a	gene	taxon:6239			
+WB	WBGene00022165	Y71H2AL.2			gene	taxon:6239			
+WB	WBGene00022166	Y71H2AM.1			gene	taxon:6239			
+WB	WBGene00022167	Y71H2AM.2			gene	taxon:6239			
+WB	WBGene00022169	Y71H2AM.4			gene	taxon:6239			
+WB	WBGene00022170	cox-6B		Y71H2AM.5	gene	taxon:6239			
+WB	WBGene00022172	cosa-1		Y71H2AM.7	gene	taxon:6239			
+WB	WBGene00022173	set-27		Y71H2AM.8	gene	taxon:6239			
+WB	WBGene00022174	slc-30A9		Y71H2AM.9	gene	taxon:6239			
+WB	WBGene00022175	Y71H2AM.10			gene	taxon:6239			
+WB	WBGene00022176	Y71H2AM.11			gene	taxon:6239			
+WB	WBGene00022177	Y71H2AM.12			gene	taxon:6239			
+WB	WBGene00022179	Y71H2AM.14			gene	taxon:6239			
+WB	WBGene00022180	Y71H2AM.15			gene	taxon:6239			
+WB	WBGene00022182	swsn-3		Y71H2AM.17	gene	taxon:6239			
+WB	WBGene00022185	Y71H2AM.20			gene	taxon:6239			
+WB	WBGene00022188	txdc-17		Y71H2AR.1	gene	taxon:6239			
+WB	WBGene00022189	Y71H2AR.2		Y71H2AR.a	gene	taxon:6239			
+WB	WBGene00022190	josd-1		Y71H2AR.3	gene	taxon:6239			
+WB	WBGene00022191	Y71H2B.1			gene	taxon:6239			
+WB	WBGene00022192	Y71H2B.2			gene	taxon:6239			
+WB	WBGene00022193	ppfr-4		Y71H2B.3|ppfr-3|Y71H2_386.b	gene	taxon:6239			
+WB	WBGene00022195	Y71H2B.5			gene	taxon:6239			
+WB	WBGene00022196	gpa-17		Y71H2B.7	gene	taxon:6239			
+WB	WBGene00022199	pfk-1.1		Y71H10A.1|pfk-1	gene	taxon:6239			
+WB	WBGene00022200	fard-1		Y71H10A.2	gene	taxon:6239			
+WB	WBGene00022201	Y71H10B.1			gene	taxon:6239			
+WB	WBGene00022228	Y73B6A.1			gene	taxon:6239			
+WB	WBGene00022231	tyr-6		Y73B6BL.1	gene	taxon:6239			
+WB	WBGene00022232	exos-2		Y73B6BL.3	gene	taxon:6239			
+WB	WBGene00022233	ipla-6		Y73B6BL.4	gene	taxon:6239			
+WB	WBGene00022235	sqd-1		Y73B6BL.6	gene	taxon:6239			
+WB	WBGene00022237	Y73B6BL.14			gene	taxon:6239			
+WB	WBGene00022240	shl-1		Y73B6BL.19	gene	taxon:6239			
+WB	WBGene00022242	sfrp-1		Y73B6BL.21	gene	taxon:6239			
+WB	WBGene00022243	Y73B6BL.22			gene	taxon:6239			
+WB	WBGene00022247	lgc-10		Y73B6BL.26	gene	taxon:6239			
+WB	WBGene00022250	Y73B6BL.29			gene	taxon:6239			
+WB	WBGene00022251	blos-2		Y73B6BL.30	gene	taxon:6239			
+WB	WBGene00022252	Y73B6BL.31			gene	taxon:6239			
+WB	WBGene00022253	hrpf-2		Y73B6BL.33	gene	taxon:6239			
+WB	WBGene00022254	nlp-71		Y73B6BL.35	gene	taxon:6239			
+WB	WBGene00022255	tmed-13		Y73B6BL.36	gene	taxon:6239			
+WB	WBGene00022256	Y73B6BL.37			gene	taxon:6239			
+WB	WBGene00022257	puf-11		Y73B6BL.38	gene	taxon:6239			
+WB	WBGene00022261	clec-210		Y73C8C.2	gene	taxon:6239			
+WB	WBGene00022265	Y73C8C.8			gene	taxon:6239			
+WB	WBGene00022266	srt-56		Y73C8C.9	gene	taxon:6239			
+WB	WBGene00022267	Y73C8C.10			gene	taxon:6239			
+WB	WBGene00022269	aatf-1		Y73E7A.2	gene	taxon:6239			
+WB	WBGene00022270	Y73E7A.3			gene	taxon:6239			
+WB	WBGene00022271	cpx-1		Y73E7A.4	gene	taxon:6239			
+WB	WBGene00022273	Y73E7A.6		bc10	gene	taxon:6239			
+WB	WBGene00022274	Y73E7A.8			gene	taxon:6239			
+WB	WBGene00022276	nlp-40		Y74C9A.2	gene	taxon:6239			
+WB	WBGene00022277	homt-1		Y74C9A.3	gene	taxon:6239			
+WB	WBGene00022278	rcor-1		Y74C9A.4	gene	taxon:6239			
+WB	WBGene00022279	sesn-1		Y74C9A.5	gene	taxon:6239			
+WB	WBGene00022280	Y74C10AL.2		Y74C10AL.a	gene	taxon:6239			
+WB	WBGene00022281	abtm-1		Y74C10AR.3	gene	taxon:6239			
+WB	WBGene00022283	lgc-27		Y74E4A.1	gene	taxon:6239			
+WB	WBGene00022284	glb-33		Y75B7AL.1	gene	taxon:6239			
+WB	WBGene00022285	Y75B7AL.2			gene	taxon:6239			
+WB	WBGene00022286	rga-4		Y75B7AL.4	gene	taxon:6239			
+WB	WBGene00022295	cng-2		Y76B12C.1	gene	taxon:6239			
+WB	WBGene00022296	xpc-1		Y76B12C.2	gene	taxon:6239			
+WB	WBGene00022301	cpsf-1		Y76B12C.7	gene	taxon:6239			
+WB	WBGene00022306	hxk-3		Y77E11A.1|hxk-1	gene	taxon:6239			
+WB	WBGene00022307	nadk-1		Y77E11A.2|Y77E11A.r	gene	taxon:6239			
+WB	WBGene00022309	rpc-11		Y77E11A.6	gene	taxon:6239			
+WB	WBGene00022313	Y77E11A.12			gene	taxon:6239			
+WB	WBGene00022318	Y82E9BL.1			gene	taxon:6239			
+WB	WBGene00022320	Y82E9BL.3			gene	taxon:6239			
+WB	WBGene00022322	Y82E9BL.5			gene	taxon:6239			
+WB	WBGene00022323	Y82E9BL.6			gene	taxon:6239			
+WB	WBGene00022336	Y82E9BR.3			gene	taxon:6239			
+WB	WBGene00022345	fbxa-138		Y82E9BR.12	gene	taxon:6239			
+WB	WBGene00022347	Y82E9BR.14			gene	taxon:6239			
+WB	WBGene00022348	Y82E9BR.16			gene	taxon:6239			
+WB	WBGene00022357	kbp-4		Y92C3B.1	gene	taxon:6239			
+WB	WBGene00022358	Y92H12A.2			gene	taxon:6239			
+WB	WBGene00022363	Y92H12BL.1			gene	taxon:6239			
+WB	WBGene00022365	Y92H12BL.4			gene	taxon:6239			
+WB	WBGene00022366	Y92H12BL.5			gene	taxon:6239			
+WB	WBGene00022367	Y92H12BM.1			gene	taxon:6239			
+WB	WBGene00022369	Y92H12BR.3			gene	taxon:6239			
+WB	WBGene00022373	mrpl-15		Y92H12BR.8	gene	taxon:6239			
+WB	WBGene00022374	nhr-277		Y94H6A.1|Y94H6A.j	gene	taxon:6239			
+WB	WBGene00022377	gpx-4		Y94H6A.4|Y94H6A.g	gene	taxon:6239			
+WB	WBGene00022378	Y94H6A.5		Y94H6A.f	gene	taxon:6239			
+WB	WBGene00022379	Y94H6A.7			gene	taxon:6239			
+WB	WBGene00022380	Y94H6A.8		Y94H6A.c	gene	taxon:6239			
+WB	WBGene00022381	ubxn-2		Y94H6A.9|Y94H6A.a|Y94H6A.b	gene	taxon:6239			
+WB	WBGene00022385	Y95B8A.4			gene	taxon:6239			
+WB	WBGene00022388	zfr-1		Y95B8A.8	gene	taxon:6239			
+WB	WBGene00022389	pde-6		Y95B8A.10	gene	taxon:6239			
+WB	WBGene00022390	him-19		Y95B8A.11	gene	taxon:6239			
+WB	WBGene00022391	prhg-1		Y95B8A.12	gene	taxon:6239			
+WB	WBGene00022392	Y97E10AL.1		Y97E10AL.c	gene	taxon:6239			
+WB	WBGene00022393	abhd-12		Y97E10AL.2	gene	taxon:6239			
+WB	WBGene00022394	natb-1		Y97E10AL.3|Y97E10AL.a	gene	taxon:6239			
+WB	WBGene00022395	ceh-76		Y97E10AM.1|Y97E10AM.a	gene	taxon:6239			
+WB	WBGene00022397	Y97E10AR.2		Y97E10AR.e	gene	taxon:6239			
+WB	WBGene00022400	rpb-9		Y97E10AR.5|Y97E10AR.a	gene	taxon:6239			
+WB	WBGene00022402	lmtr-2		Y97E10AR.7|Y97E10AR.b	gene	taxon:6239			
+WB	WBGene00022403	Y97E10B.1			gene	taxon:6239			
+WB	WBGene00022404	srsx-5		Y97E10B.2|Y97E10B.f	gene	taxon:6239			
+WB	WBGene00022405	srsx-6		Y97E10B.3	gene	taxon:6239			
+WB	WBGene00022406	srsx-7		Y97E10B.4	gene	taxon:6239			
+WB	WBGene00022408	srsx-3		Y97E10B.9	gene	taxon:6239			
+WB	WBGene00022409	srt-53		Y97E10B.10|Y97E10B.a	gene	taxon:6239			
+WB	WBGene00022411	Y102A11A.1			gene	taxon:6239			
+WB	WBGene00022416	Y102A11A.6			gene	taxon:6239			
+WB	WBGene00022417	Y102A11A.7			gene	taxon:6239			
+WB	WBGene00022418	igcm-4		Y102A11A.8	gene	taxon:6239			
+WB	WBGene00022420	wdr-4		Y102E9.2	gene	taxon:6239			
+WB	WBGene00022423	nhr-41		Y104H12A.1	gene	taxon:6239			
+WB	WBGene00022425	plst-1		Y104H12BR.1	gene	taxon:6239			
+WB	WBGene00022427	spl-3		Y104H12D.3	gene	taxon:6239			
+WB	WBGene00022433	Y108F1.5			gene	taxon:6239			
+WB	WBGene00022434	Y108G3AL.2			gene	taxon:6239			
+WB	WBGene00022435	cfap-36		Y108G3AL.3|ccdc-104	gene	taxon:6239			
+WB	WBGene00022447	pigw-1		Y110A2AL.12|hpo-20	gene	taxon:6239			
+WB	WBGene00022448	pinn-1		Y110A2AL.13|Pin1	gene	taxon:6239			
+WB	WBGene00022450	ubc-26		Y110A2AM.3	gene	taxon:6239			
+WB	WBGene00022452	Y110A2AR.1			gene	taxon:6239			
+WB	WBGene00022453	ncap-1		Y110A2AR.3	gene	taxon:6239			
+WB	WBGene00022455	tyms-1		Y110A7A.4|emb-6|thymidilate synthase|thymidylate synthase	gene	taxon:6239			
+WB	WBGene00022456	pfkb-1.1		Y110A7A.6	gene	taxon:6239			
+WB	WBGene00022457	Y110A7A.7			gene	taxon:6239			
+WB	WBGene00022458	prp-31		Y110A7A.8|phi-5	gene	taxon:6239			
+WB	WBGene00022460	use-1		Y110A7A.11	gene	taxon:6239			
+WB	WBGene00022463	elpc-1		Y110A7A.16	gene	taxon:6239			
+WB	WBGene00022465	ift-20		Y110A7A.20	gene	taxon:6239			
+WB	WBGene00022466	Y119C1A.1			gene	taxon:6239			
+WB	WBGene00022467	Y119C1B.1		Y119C1B.a|Y119C1B.j	gene	taxon:6239			
+WB	WBGene00022469	Y119C1B.3		Y119C1B.b|Y119C1B.h|Y119C1B.i	gene	taxon:6239			
+WB	WBGene00022470	mrpl-19		Y119C1B.4|Y119C1B.f	gene	taxon:6239			
+WB	WBGene00022471	rnf-145		Y119C1B.5	gene	taxon:6239			
+WB	WBGene00022473	bet-1		Y119C1B.8|tag-332|Y119C1B.d	gene	taxon:6239			
+WB	WBGene00022489	Y119D3B.12			gene	taxon:6239			
+WB	WBGene00022491	Y119D3B.14			gene	taxon:6239			
+WB	WBGene00022492	dss-1		Y119D3B.15	gene	taxon:6239			
+WB	WBGene00022493	mrpl-45		Y119D3B.16	gene	taxon:6239			
+WB	WBGene00022498	hsd-2		ZC8.1	gene	taxon:6239			
+WB	WBGene00022499	set-30		ZC8.3|tag-226	gene	taxon:6239			
+WB	WBGene00022500	lfi-1		ZC8.4	gene	taxon:6239			
+WB	WBGene00022501	ZC8.6			gene	taxon:6239			
+WB	WBGene00022502	ZC13.1			gene	taxon:6239			
+WB	WBGene00022503	ZC13.2			gene	taxon:6239			
+WB	WBGene00022504	mam-1		ZC13.3	gene	taxon:6239			
+WB	WBGene00022512	dot-1.5		ZC53.6	gene	taxon:6239			
+WB	WBGene00022515	ttr-48		ZC64.2	gene	taxon:6239			
+WB	WBGene00022516	mtx-2		ZC97.1|tag-354	gene	taxon:6239			
+WB	WBGene00022518	zfh-2		ZC123.3|let-129	gene	taxon:6239			
+WB	WBGene00022519	cdk-14		ZC123.4	gene	taxon:6239			
+WB	WBGene00022522	ZC132.3			gene	taxon:6239			
+WB	WBGene00022527	ZC132.9			gene	taxon:6239			
+WB	WBGene00022528	srt-13		ZC142.1	gene	taxon:6239			
+WB	WBGene00022529	srt-14		ZC142.2	gene	taxon:6239			
+WB	WBGene00022530	ZC155.2			gene	taxon:6239			
+WB	WBGene00022531	morc-1		ZC155.3	gene	taxon:6239			
+WB	WBGene00022532	ZC155.4			gene	taxon:6239			
+WB	WBGene00022533	cutl-19		ZC155.5	gene	taxon:6239			
+WB	WBGene00022534	syx-16		ZC155.7|syn-16	gene	taxon:6239			
+WB	WBGene00022536	ZC178.2			gene	taxon:6239			
+WB	WBGene00022537	ZC190.2			gene	taxon:6239			
+WB	WBGene00022538	ZC190.4			gene	taxon:6239			
+WB	WBGene00022539	ZC190.5			gene	taxon:6239			
+WB	WBGene00022540	ZC190.6			gene	taxon:6239			
+WB	WBGene00022541	ZC190.7			gene	taxon:6239			
+WB	WBGene00022542	ZC190.8			gene	taxon:6239			
+WB	WBGene00022546	ZC196.2			gene	taxon:6239			
+WB	WBGene00022549	ZC196.5			gene	taxon:6239			
+WB	WBGene00022551	ZC196.8			gene	taxon:6239			
+WB	WBGene00022552	ZC196.9			gene	taxon:6239			
+WB	WBGene00022554	duxl-1		ZC204.2|ceh-80|dux-1	gene	taxon:6239			
+WB	WBGene00022566	ZC239.3			gene	taxon:6239			
+WB	WBGene00022567	ZC239.4			gene	taxon:6239			
+WB	WBGene00022568	ZC239.5			gene	taxon:6239			
+WB	WBGene00022569	ZC239.6			gene	taxon:6239			
+WB	WBGene00022570	sdz-35		ZC239.12	gene	taxon:6239			
+WB	WBGene00022571	ZC239.13			gene	taxon:6239			
+WB	WBGene00022572	ZC239.14			gene	taxon:6239			
+WB	WBGene00022573	ZC239.15			gene	taxon:6239			
+WB	WBGene00022574	ZC239.16			gene	taxon:6239			
+WB	WBGene00022575	ZC239.17			gene	taxon:6239			
+WB	WBGene00022576	ZC250.2			gene	taxon:6239			
+WB	WBGene00022577	nstp-3		ZC250.3	gene	taxon:6239			
+WB	WBGene00022580	iglr-2		ZC262.3	gene	taxon:6239			
+WB	WBGene00022582	ZC262.5			gene	taxon:6239			
+WB	WBGene00022583	mrps-18A		ZC262.8	gene	taxon:6239			
+WB	WBGene00022584	ZC266.1			gene	taxon:6239			
+WB	WBGene00022588	ZC317.2			gene	taxon:6239			
+WB	WBGene00022591	cuti-1		ZC328.1|let-601	gene	taxon:6239			
+WB	WBGene00022593	ZC328.3			gene	taxon:6239			
+WB	WBGene00022598	ztf-8		ZC395.8	gene	taxon:6239			
+WB	WBGene00022599	daf-41		ZC395.10	gene	taxon:6239			
+WB	WBGene00022603	gck-2		ZC404.9	gene	taxon:6239			
+WB	WBGene00022604	dmsr-10		ZC404.10	gene	taxon:6239			
+WB	WBGene00022605	dmsr-11		ZC404.11	gene	taxon:6239			
+WB	WBGene00022606	dmsr-9		ZC404.13	gene	taxon:6239			
+WB	WBGene00022610	ltah-1.2		ZC416.6	gene	taxon:6239			
+WB	WBGene00022613	sek-3		ZC449.3	gene	taxon:6239			
+WB	WBGene00022614	ZC449.4			gene	taxon:6239			
+WB	WBGene00022615	ZC449.5			gene	taxon:6239			
+WB	WBGene00022616	hsd-3		ZC449.6	gene	taxon:6239			
+WB	WBGene00022617	ZC477.2			gene	taxon:6239			
+WB	WBGene00022618	ZC477.3			gene	taxon:6239			
+WB	WBGene00022620	rde-8		ZC477.5	gene	taxon:6239			
+WB	WBGene00022623	ZC487.1			gene	taxon:6239			
+WB	WBGene00022624	ZC487.2			gene	taxon:6239			
+WB	WBGene00022627	ZC513.2			gene	taxon:6239			
+WB	WBGene00022628	ZC513.3			gene	taxon:6239			
+WB	WBGene00022629	algn-12		ZC513.5	gene	taxon:6239			
+WB	WBGene00022631	nekl-2		ZC581.1|phi-35	gene	taxon:6239			
+WB	WBGene00022632	ZC581.2			gene	taxon:6239			
+WB	WBGene00022633	ZC581.3			gene	taxon:6239			
+WB	WBGene00022634	ZC581.7		ZC581.b	gene	taxon:6239			
+WB	WBGene00022635	ZC581.9			gene	taxon:6239			
+WB	WBGene00022637	nhr-252		ZK6.2	gene	taxon:6239			
+WB	WBGene00022639	nhr-253		ZK6.4	gene	taxon:6239			
+WB	WBGene00022640	nhr-254		ZK6.5	gene	taxon:6239			
+WB	WBGene00022641	ZK6.6			gene	taxon:6239			
+WB	WBGene00022642	lipl-5		ZK6.7	gene	taxon:6239			
+WB	WBGene00022643	ZK6.8			gene	taxon:6239			
+WB	WBGene00022644	dod-19		ZK6.10	gene	taxon:6239			
+WB	WBGene00022645	ZK6.11			gene	taxon:6239			
+WB	WBGene00022646	acl-9		ZK40.1	gene	taxon:6239			
+WB	WBGene00022647	slc-17.1		ZK54.1|C36E6.a	gene	taxon:6239			
+WB	WBGene00022648	ZK54.3			gene	taxon:6239			
+WB	WBGene00022650	ZK84.2			gene	taxon:6239			
+WB	WBGene00022651	ZK84.4			gene	taxon:6239			
+WB	WBGene00022655	srsx-40		ZK105.4|ZK105.c	gene	taxon:6239			
+WB	WBGene00022663	glrx-21		ZK121.1	gene	taxon:6239			
+WB	WBGene00022664	ZK121.2			gene	taxon:6239			
+WB	WBGene00022668	ZK154.6			gene	taxon:6239			
+WB	WBGene00022669	ZK177.1			gene	taxon:6239			
+WB	WBGene00022670	ZK177.2			gene	taxon:6239			
+WB	WBGene00022672	npp-24		ZK177.4	gene	taxon:6239			
+WB	WBGene00022675	gbb-2		ZK180.1	gene	taxon:6239			
+WB	WBGene00022677	rfth-1		ZK180.3	gene	taxon:6239			
+WB	WBGene00022678	sar-1		ZK180.4	gene	taxon:6239			
+WB	WBGene00022682	ZK185.2		ZK185.a	gene	taxon:6239			
+WB	WBGene00022694	gcna-1		ZK328.4	gene	taxon:6239			
+WB	WBGene00022695	ZK328.6			gene	taxon:6239			
+WB	WBGene00022696	ift-139		ZK328.7	gene	taxon:6239			
+WB	WBGene00022697	cyy-1		ZK353.1	gene	taxon:6239			
+WB	WBGene00022700	ZK353.4			gene	taxon:6239			
+WB	WBGene00022702	cutc-1		ZK353.7	gene	taxon:6239			
+WB	WBGene00022703	ubxn-4		ZK353.8	gene	taxon:6239			
+WB	WBGene00022705	ZK354.2			gene	taxon:6239			
+WB	WBGene00022707	ZK354.6			gene	taxon:6239			
+WB	WBGene00022708	ZK354.7			gene	taxon:6239			
+WB	WBGene00022709	ZK354.8			gene	taxon:6239			
+WB	WBGene00022710	ZK354.9			gene	taxon:6239			
+WB	WBGene00022712	ZK355.2			gene	taxon:6239			
+WB	WBGene00022717	hipr-1		ZK370.3|hip-1	gene	taxon:6239			
+WB	WBGene00022718	ZK370.4			gene	taxon:6239			
+WB	WBGene00022719	pdhk-2		ZK370.5	gene	taxon:6239			
+WB	WBGene00022721	ugtp-1		ZK370.7	gene	taxon:6239			
+WB	WBGene00022722	tomm-70		ZK370.8	gene	taxon:6239			
+WB	WBGene00022725	ZK381.2			gene	taxon:6239			
+WB	WBGene00022726	nhr-249		ZK381.3	gene	taxon:6239			
+WB	WBGene00022727	prkl-1		ZK381.5|nde-2	gene	taxon:6239			
+WB	WBGene00022733	tmem-17		ZK418.3	gene	taxon:6239			
+WB	WBGene00022734	ZK418.5			gene	taxon:6239			
+WB	WBGene00022735	ZK418.6			gene	taxon:6239			
+WB	WBGene00022736	ZK418.7			gene	taxon:6239			
+WB	WBGene00022737	tofu-7		ZK418.8	gene	taxon:6239			
+WB	WBGene00022738	fubl-2		ZK418.9|fubl-3.2|fubp-3.2	gene	taxon:6239			
+WB	WBGene00022739	toe-1		ZK430.1	gene	taxon:6239			
+WB	WBGene00022741	ZK430.5			gene	taxon:6239			
+WB	WBGene00022742	ZK430.7			gene	taxon:6239			
+WB	WBGene00022743	mlt-7		ZK430.8|phi-48	gene	taxon:6239			
+WB	WBGene00022744	ZK470.1			gene	taxon:6239			
+WB	WBGene00022748	oaz-1		ZK484.1	gene	taxon:6239			
+WB	WBGene00022750	tres-1		ZK484.4	gene	taxon:6239			
+WB	WBGene00022753	ZK484.7			gene	taxon:6239			
+WB	WBGene00022756	nhr-251		ZK488.4	gene	taxon:6239			
+WB	WBGene00022757	ZK488.5			gene	taxon:6239			
+WB	WBGene00022758	ZK488.6			gene	taxon:6239			
+WB	WBGene00022761	ZK546.4			gene	taxon:6239			
+WB	WBGene00022765	ZK546.14			gene	taxon:6239			
+WB	WBGene00022766	cblc-1		ZK546.17	gene	taxon:6239			
+WB	WBGene00022767	ZK563.2			gene	taxon:6239			
+WB	WBGene00022769	sorf-1		ZK563.5|wdr-91	gene	taxon:6239			
+WB	WBGene00022770	acp-1		ZK563.6	gene	taxon:6239			
+WB	WBGene00022771	ZK616.1		ZK616.j	gene	taxon:6239			
+WB	WBGene00022772	ZK616.2		ZK616.i	gene	taxon:6239			
+WB	WBGene00022773	ZK616.3		ZK616.h	gene	taxon:6239			
+WB	WBGene00022776	perm-3		ZK616.6|emc-4|ZK616.e|ZK616.g	gene	taxon:6239			
+WB	WBGene00022780	ZK622.1			gene	taxon:6239			
+WB	WBGene00022781	pmt-1		ZK622.3|phi-40	gene	taxon:6239			
+WB	WBGene00022782	ZK622.4			gene	taxon:6239			
+WB	WBGene00022783	tomm-7		ZK652.2	gene	taxon:6239			
+WB	WBGene00022785	kcmf-1		ZK652.6	gene	taxon:6239			
+WB	WBGene00022787	tag-307		ZK652.10	gene	taxon:6239			
+WB	WBGene00022788	slc-17.7		ZK682.2	gene	taxon:6239			
+WB	WBGene00022789	lron-2		ZK682.5	gene	taxon:6239			
+WB	WBGene00022792	ZK686.2			gene	taxon:6239			
+WB	WBGene00022793	ZK686.3			gene	taxon:6239			
+WB	WBGene00022794	snu-23		ZK686.4	gene	taxon:6239			
+WB	WBGene00022795	ZK686.5			gene	taxon:6239			
+WB	WBGene00022797	best-24		ZK688.2	gene	taxon:6239			
+WB	WBGene00022798	fahd-1		ZK688.3	gene	taxon:6239			
+WB	WBGene00022800	ZK688.5			gene	taxon:6239			
+WB	WBGene00022801	pcp-5		ZK688.6|tag-282	gene	taxon:6239			
+WB	WBGene00022803	ZK688.9			gene	taxon:6239			
+WB	WBGene00022804	ZK697.1			gene	taxon:6239			
+WB	WBGene00022805	nhr-256		ZK697.2	gene	taxon:6239			
+WB	WBGene00022807	srab-25		ZK697.7	gene	taxon:6239			
+WB	WBGene00022808	ZK697.8			gene	taxon:6239			
+WB	WBGene00022809	ZK697.14			gene	taxon:6239			
+WB	WBGene00022811	ZK721.4			gene	taxon:6239			
+WB	WBGene00022812	uvs-1		ZK742.2	gene	taxon:6239			
+WB	WBGene00022813	ZK742.3			gene	taxon:6239			
+WB	WBGene00022814	ZK742.4			gene	taxon:6239			
+WB	WBGene00022815	asic-1		ZK770.1	gene	taxon:6239			
+WB	WBGene00022816	fbn-1		ZK783.1|cpg-16|let-821	gene	taxon:6239			
+WB	WBGene00022817	upp-1		ZK783.2	gene	taxon:6239			
+WB	WBGene00022820	ZK813.1			gene	taxon:6239			
+WB	WBGene00022822	ZK813.3			gene	taxon:6239			
+WB	WBGene00022824	ZK813.5		ZK813.b	gene	taxon:6239			
+WB	WBGene00022825	ZK816.1			gene	taxon:6239			
+WB	WBGene00022829	ZK867.2			gene	taxon:6239			
+WB	WBGene00022830	ZK973.1			gene	taxon:6239			
+WB	WBGene00022832	pdp-1		ZK973.3	gene	taxon:6239			
+WB	WBGene00022835	ZK973.9			gene	taxon:6239			
+WB	WBGene00022836	ZK973.11			gene	taxon:6239			
+WB	WBGene00022837	ceh-45		ZK993.1	gene	taxon:6239			
+WB	WBGene00022843	ZK1055.2			gene	taxon:6239			
+WB	WBGene00022845	ZK1055.4			gene	taxon:6239			
+WB	WBGene00022848	ZK1055.7			gene	taxon:6239			
+WB	WBGene00022850	ZK1127.3			gene	taxon:6239			
+WB	WBGene00022852	ZK1127.5			gene	taxon:6239			
+WB	WBGene00022854	cin-4		ZK1127.7	gene	taxon:6239			
+WB	WBGene00022855	tcer-1		ZK1127.9|gos-1	gene	taxon:6239			
+WB	WBGene00022856	cth-2		ZK1127.10	gene	taxon:6239			
+WB	WBGene00022861	dve-1		ZK1193.5	gene	taxon:6239			
+WB	WBGene00022862	ZK1236.1			gene	taxon:6239			
+WB	WBGene00022865	ufbp-1		ZK1236.7	gene	taxon:6239			
+WB	WBGene00022866	ZK1240.1			gene	taxon:6239			
+WB	WBGene00022867	ZK1240.2			gene	taxon:6239			
+WB	WBGene00022868	ZK1240.3			gene	taxon:6239			
+WB	WBGene00022870	ZK1240.5			gene	taxon:6239			
+WB	WBGene00022871	ZK1240.6			gene	taxon:6239			
+WB	WBGene00022872	ZK1240.8			gene	taxon:6239			
+WB	WBGene00022873	ZK1240.9			gene	taxon:6239			
+WB	WBGene00022874	nep-25		ZK1248.1	gene	taxon:6239			
+WB	WBGene00022877	wago-5		ZK1248.7	gene	taxon:6239			
+WB	WBGene00022880	tbc-2		ZK1248.10	gene	taxon:6239			
+WB	WBGene00022881	ZK1248.11			gene	taxon:6239			
+WB	WBGene00022885	ZK1248.19			gene	taxon:6239			
+WB	WBGene00022887	ZK1290.5			gene	taxon:6239			
+WB	WBGene00022888	rnh-1.1		ZK1290.6	gene	taxon:6239			
+WB	WBGene00022889	ZK1290.7			gene	taxon:6239			
+WB	WBGene00022893	ZK1290.13			gene	taxon:6239			
+WB	WBGene00023067	rpl-41.1		F54D7.6	gene	taxon:6239			
+WB	WBGene00023068	rpl-41.2		F54D7.7	gene	taxon:6239			
+WB	WBGene00023186	Y67D8B.3		Y67D8B.a	gene	taxon:6239			
+WB	WBGene00023284	F41B5.1			gene	taxon:6239			
+WB	WBGene00023404	plr-1		Y47D3B.11	gene	taxon:6239			
+WB	WBGene00023405	sor-1		ZK1236.3|phi-57	gene	taxon:6239			
+WB	WBGene00023407	cex-1		F56D1.6	gene	taxon:6239			
+WB	WBGene00023408	cex-2		T09A5.1	gene	taxon:6239			
+WB	WBGene00023410	clpr-2		F47F6.9	gene	taxon:6239			
+WB	WBGene00023411	srz-3		F08A10.2	gene	taxon:6239			
+WB	WBGene00023414	R01H2.7			gene	taxon:6239			
+WB	WBGene00023416	spi-1		R10H1.4|isl-1	gene	taxon:6239			
+WB	WBGene00023417	swm-1		C25E10.9|isl-2	gene	taxon:6239			
+WB	WBGene00023418	R06F6.12			gene	taxon:6239			
+WB	WBGene00023420	C26D10.7			gene	taxon:6239			
+WB	WBGene00023421	rde-11		B0564.11	gene	taxon:6239			
+WB	WBGene00023422	mrpl-21		F43C1.6	gene	taxon:6239			
+WB	WBGene00023423	F43C1.7			gene	taxon:6239			
+WB	WBGene00023424	C53D6.10			gene	taxon:6239			
+WB	WBGene00023425	try-9		B0286.6	gene	taxon:6239			
+WB	WBGene00023451	mlc-7		K08E3.10	gene	taxon:6239			
+WB	WBGene00023462	srz-83		C09G12.10	gene	taxon:6239			
+WB	WBGene00023463	srz-82		C09G12.11	gene	taxon:6239			
+WB	WBGene00023474	srz-37		C09G12.16	gene	taxon:6239			
+WB	WBGene00023475	srz-69		C09G12.15	gene	taxon:6239			
+WB	WBGene00023478	srz-62		F56D6.7	gene	taxon:6239			
+WB	WBGene00023479	srz-67		C17F4.10	gene	taxon:6239			
+WB	WBGene00023484	Y54G2A.37			gene	taxon:6239			
+WB	WBGene00023485	ttr-49		E02C12.13	gene	taxon:6239			
+WB	WBGene00023487	mrps-24		F33D4.8	gene	taxon:6239			
+WB	WBGene00023489	F42A10.9			gene	taxon:6239			
+WB	WBGene00023491	tsp-21		C17G1.8	gene	taxon:6239			
+WB	WBGene00023497	lin-15B		ZK662.4|lin-15	gene	taxon:6239			
+WB	WBGene00023498	lin-15A		ZK678.1|lin-15	gene	taxon:6239			
+WB	WBGene00023499	srz-63		Y57G7A.12	gene	taxon:6239			
+WB	WBGene00023501	F11E6.11			gene	taxon:6239			
+WB	WBGene00023502	clec-184		F08G5.7	gene	taxon:6239			
+WB	WBGene00023503	F17C11.13			gene	taxon:6239			
+WB	WBGene00023505	srz-102		F14F8.13	gene	taxon:6239			
+WB	WBGene00023506	srz-11		T09F5.16	gene	taxon:6239			
+WB	WBGene00023508	srz-38		C35D6.9	gene	taxon:6239			
+WB	WBGene00023513	srz-71		C35D6.10	gene	taxon:6239			
+WB	WBGene00023514	srz-72		Y7A9C.7	gene	taxon:6239			
+WB	WBGene00023515	srz-97		F08H9.12	gene	taxon:6239			
+WB	WBGene00023517	srz-75		Y7A9C.9	gene	taxon:6239			
+WB	WBGene00043050	oig-4		R07G3.9	gene	taxon:6239			
+WB	WBGene00043052	srz-104		K03D3.11	gene	taxon:6239			
+WB	WBGene00043056	nfya-2		Y53H1A.5	gene	taxon:6239			
+WB	WBGene00043057	M142.8			gene	taxon:6239			
+WB	WBGene00043058	sre-34		W05H5.8	gene	taxon:6239			
+WB	WBGene00043059	srab-26		T11A5.7	gene	taxon:6239			
+WB	WBGene00043061	Y54G2A.38			gene	taxon:6239			
+WB	WBGene00043062	clec-80		Y54G2A.39|clec-81	gene	taxon:6239			
+WB	WBGene00043064	nbet-1		Y59E9AL.7	gene	taxon:6239			
+WB	WBGene00043066	acr-25		Y73B6BL.42	gene	taxon:6239			
+WB	WBGene00043067	dlc-5		Y73B6BL.43	gene	taxon:6239			
+WB	WBGene00043069	F20D6.12			gene	taxon:6239			
+WB	WBGene00043097	C02D5.4			gene	taxon:6239			
+WB	WBGene00043120	C09H10.4			gene	taxon:6239			
+WB	WBGene00043156	C27F2.9			gene	taxon:6239			
+WB	WBGene00043308	tmem-107		F39B2.9	gene	taxon:6239			
+WB	WBGene00043702	Y54G2A.7			gene	taxon:6239			
+WB	WBGene00043952	ZC404.2			gene	taxon:6239			
+WB	WBGene00043980	F11D5.7			gene	taxon:6239			
+WB	WBGene00043982	B0403.6			gene	taxon:6239			
+WB	WBGene00043986	fut-5		T05A7.10|ceft-2	gene	taxon:6239			
+WB	WBGene00043992	bbs-4		F58A4.14	gene	taxon:6239			
+WB	WBGene00043994	C07A9.12			gene	taxon:6239			
+WB	WBGene00043995	F40F12.9			gene	taxon:6239			
+WB	WBGene00043997	Y79H2A.12			gene	taxon:6239			
+WB	WBGene00043998	T21C12.8			gene	taxon:6239			
+WB	WBGene00044002	srt-74		F40G12.15	gene	taxon:6239			
+WB	WBGene00044003	Y41E3.18			gene	taxon:6239			
+WB	WBGene00044004	C24A8.6			gene	taxon:6239			
+WB	WBGene00044006	nlp-82		H32K21.1	gene	taxon:6239			
+WB	WBGene00044008	gip-2		C45G3.5	gene	taxon:6239			
+WB	WBGene00044012	srxa-19		C08B6.13	gene	taxon:6239			
+WB	WBGene00044018	T04B2.8			gene	taxon:6239			
+WB	WBGene00044020	ZK856.14			gene	taxon:6239			
+WB	WBGene00044021	R02E4.2			gene	taxon:6239			
+WB	WBGene00044025	T01G1.4			gene	taxon:6239			
+WB	WBGene00044026	cisd-1		W02B12.15	gene	taxon:6239			
+WB	WBGene00044027	F27E5.8			gene	taxon:6239			
+WB	WBGene00044028	nlp-63		F33H1.6	gene	taxon:6239			
+WB	WBGene00044031	F49C5.9			gene	taxon:6239			
+WB	WBGene00044032	ceh-99		T21B4.17	gene	taxon:6239			
+WB	WBGene00044034	Y38E10A.28			gene	taxon:6239			
+WB	WBGene00044044	C08B6.14			gene	taxon:6239			
+WB	WBGene00044045	R11G10.3			gene	taxon:6239			
+WB	WBGene00044047	Y57A10C.11			gene	taxon:6239			
+WB	WBGene00044048	F57G9.7			gene	taxon:6239			
+WB	WBGene00044049	sfxn-5		C41C4.10	gene	taxon:6239			
+WB	WBGene00044058	F17B5.6			gene	taxon:6239			
+WB	WBGene00044059	T27C5.12			gene	taxon:6239			
+WB	WBGene00044062	snb-6		T14D7.3|tag-212	gene	taxon:6239			
+WB	WBGene00044063	bpnt-1		ZK430.2|tag-231	gene	taxon:6239			
+WB	WBGene00044065	tag-229		W09G3.3	gene	taxon:6239			
+WB	WBGene00044067	zipt-7.1		T28F3.3|hke-4.1|tag-230	gene	taxon:6239			
+WB	WBGene00044068	syd-9		ZK867.1|tag-239|ztf-10	gene	taxon:6239			
+WB	WBGene00044069	hat-1		M03C11.4|tag-235	gene	taxon:6239			
+WB	WBGene00044070	set-18		T22A3.4|tag-237	gene	taxon:6239			
+WB	WBGene00044071	dhhc-14		D2021.2|tag-233	gene	taxon:6239			
+WB	WBGene00044072	ham-3		ZK1128.5|swsn-2.1|tag-246	gene	taxon:6239			
+WB	WBGene00044073	tag-244		C34H4.3	gene	taxon:6239			
+WB	WBGene00044074	mltn-5		W02B8.6	gene	taxon:6239			
+WB	WBGene00044078	tag-243		T04A8.4	gene	taxon:6239			
+WB	WBGene00044083	tin-9.2		B0564.1|tim9b	gene	taxon:6239			
+WB	WBGene00044084	sre-46		Y54G9A.10	gene	taxon:6239			
+WB	WBGene00044086	clec-228		H02K04.2	gene	taxon:6239			
+WB	WBGene00044087	C45H4.18			gene	taxon:6239			
+WB	WBGene00044088	oac-2		C02A12.8	gene	taxon:6239			
+WB	WBGene00044089	srbc-31		C02A12.9	gene	taxon:6239			
+WB	WBGene00044090	srbc-33		C02A12.10	gene	taxon:6239			
+WB	WBGene00044091	srbc-60		R09E12.8	gene	taxon:6239			
+WB	WBGene00044092	srbc-71		F30B5.8	gene	taxon:6239			
+WB	WBGene00044094	fitm-2		ZK265.9	gene	taxon:6239			
+WB	WBGene00044100	srbc-27		F20E11.15	gene	taxon:6239			
+WB	WBGene00044105	srbc-55		F54B8.16	gene	taxon:6239			
+WB	WBGene00044106	srbc-84		C31A11.10	gene	taxon:6239			
+WB	WBGene00044107	F58G6.9			gene	taxon:6239			
+WB	WBGene00044112	srm-5		F47B8.12	gene	taxon:6239			
+WB	WBGene00044114	srxa-11		C06B3.12	gene	taxon:6239			
+WB	WBGene00044115	srxa-12		C06B3.13	gene	taxon:6239			
+WB	WBGene00044116	srxa-13		C06B3.14	gene	taxon:6239			
+WB	WBGene00044117	srsx-10		F26G5.12	gene	taxon:6239			
+WB	WBGene00044120	C36B1.13			gene	taxon:6239			
+WB	WBGene00044122	T28B8.6			gene	taxon:6239			
+WB	WBGene00044124	srsx-15		C39H7.8	gene	taxon:6239			
+WB	WBGene00044125	srsx-16		C39H7.9	gene	taxon:6239			
+WB	WBGene00044138	sssh-1		F31F6.8	gene	taxon:6239			
+WB	WBGene00044141	H03G16.6			gene	taxon:6239			
+WB	WBGene00044143	K09E9.4			gene	taxon:6239			
+WB	WBGene00044145	M163.9			gene	taxon:6239			
+WB	WBGene00044146	M163.10			gene	taxon:6239			
+WB	WBGene00044152	W04G3.10			gene	taxon:6239			
+WB	WBGene00044176	C30G7.2			gene	taxon:6239			
+WB	WBGene00044178	C30G7.4			gene	taxon:6239			
+WB	WBGene00044179	C30G7.5			gene	taxon:6239			
+WB	WBGene00044187	ttll-9		F25C8.5	gene	taxon:6239			
+WB	WBGene00044191	F43D2.6			gene	taxon:6239			
+WB	WBGene00044201	H39E23.3			gene	taxon:6239			
+WB	WBGene00044205	T13F3.8			gene	taxon:6239			
+WB	WBGene00044208	Y6G8.6			gene	taxon:6239			
+WB	WBGene00044210	Y51A2D.21			gene	taxon:6239			
+WB	WBGene00044221	F41G3.18			gene	taxon:6239			
+WB	WBGene00044225	C38D4.10			gene	taxon:6239			
+WB	WBGene00044233	dolk-1		Y56A3A.36	gene	taxon:6239			
+WB	WBGene00044236	C17E4.11			gene	taxon:6239			
+WB	WBGene00044241	C53D6.11			gene	taxon:6239			
+WB	WBGene00044245	F32A7.8			gene	taxon:6239			
+WB	WBGene00044247	F36H2.4			gene	taxon:6239			
+WB	WBGene00044253	M117.6			gene	taxon:6239			
+WB	WBGene00044257	Y45F10D.16			gene	taxon:6239			
+WB	WBGene00044260	Y87G2A.19			gene	taxon:6239			
+WB	WBGene00044280	W02A2.9			gene	taxon:6239			
+WB	WBGene00044281	R04A9.7			gene	taxon:6239			
+WB	WBGene00044286	ugt-35		C32C4.7	gene	taxon:6239			
+WB	WBGene00044290	B0035.18			gene	taxon:6239			
+WB	WBGene00044291	C25F9.10			gene	taxon:6239			
+WB	WBGene00044295	C09E7.10			gene	taxon:6239			
+WB	WBGene00044297	C25B8.8			gene	taxon:6239			
+WB	WBGene00044298	T23B7.2			gene	taxon:6239			
+WB	WBGene00044300	D1022.9			gene	taxon:6239			
+WB	WBGene00044301	lgc-28		D2062.12	gene	taxon:6239			
+WB	WBGene00044303	hst-3.2		F52B10.2	gene	taxon:6239			
+WB	WBGene00044304	F52B10.3			gene	taxon:6239			
+WB	WBGene00044305	rad-8		F56H1.6	gene	taxon:6239			
+WB	WBGene00044310	H20J04.9			gene	taxon:6239			
+WB	WBGene00044311	K04C2.7			gene	taxon:6239			
+WB	WBGene00044319	tag-266		W06E11.5|chic	gene	taxon:6239			
+WB	WBGene00044321	mrps-30		B0511.8|tag-264	gene	taxon:6239			
+WB	WBGene00044322	tag-280		F15A4.12	gene	taxon:6239			
+WB	WBGene00044323	tag-281		F15A4.11	gene	taxon:6239			
+WB	WBGene00044324	ufm-1		ZK652.3|3H949|tag-277	gene	taxon:6239			
+WB	WBGene00044325	tag-321		C33H5.19	gene	taxon:6239			
+WB	WBGene00044329	cpsf-4		F11A10.8|tag-287	gene	taxon:6239			
+WB	WBGene00044330	alr-1		R08B4.2|sns-10	gene	taxon:6239			
+WB	WBGene00044331	clec-25		T20B3.15	gene	taxon:6239			
+WB	WBGene00044332	clec-36		T20B3.16	gene	taxon:6239			
+WB	WBGene00044344	mrpl-39		Y46H3A.7	gene	taxon:6239			
+WB	WBGene00044345	Y48G1C.12			gene	taxon:6239			
+WB	WBGene00044347	Y71G12B.30			gene	taxon:6239			
+WB	WBGene00044348	Y71G12B.31			gene	taxon:6239			
+WB	WBGene00044352	ZK381.8			gene	taxon:6239			
+WB	WBGene00044353	ZK418.10			gene	taxon:6239			
+WB	WBGene00044354	ZK418.11			gene	taxon:6239			
+WB	WBGene00044355	ZK563.7			gene	taxon:6239			
+WB	WBGene00044358	Y71G12B.33			gene	taxon:6239			
+WB	WBGene00044360	C33C12.11			gene	taxon:6239			
+WB	WBGene00044381	K10G6.5			gene	taxon:6239			
+WB	WBGene00044383	T05A7.11			gene	taxon:6239			
+WB	WBGene00044384	F11G11.14			gene	taxon:6239			
+WB	WBGene00044387	C27A2.8			gene	taxon:6239			
+WB	WBGene00044388	C27D6.11			gene	taxon:6239			
+WB	WBGene00044390	ZK177.11			gene	taxon:6239			
+WB	WBGene00044392	C25H3.16			gene	taxon:6239			
+WB	WBGene00044393	ZK1248.20			gene	taxon:6239			
+WB	WBGene00044406	F02A9.7			gene	taxon:6239			
+WB	WBGene00044411	R12B2.8			gene	taxon:6239			
+WB	WBGene00044414	C06A5.12			gene	taxon:6239			
+WB	WBGene00044417	C08F1.11			gene	taxon:6239			
+WB	WBGene00044418	C08G5.7			gene	taxon:6239			
+WB	WBGene00044423	F53F10.8			gene	taxon:6239			
+WB	WBGene00044427	F56A6.5			gene	taxon:6239			
+WB	WBGene00044428	T01D1.7			gene	taxon:6239			
+WB	WBGene00044431	mzt-1		W03G9.8	gene	taxon:6239			
+WB	WBGene00044433	W10C8.6			gene	taxon:6239			
+WB	WBGene00044434	Y18H1A.15			gene	taxon:6239			
+WB	WBGene00044437	Y47G6A.32			gene	taxon:6239			
+WB	WBGene00044438	Y51F10.11			gene	taxon:6239			
+WB	WBGene00044446	C06G4.6			gene	taxon:6239			
+WB	WBGene00044447	ZK688.10			gene	taxon:6239			
+WB	WBGene00044455	F23F12.13			gene	taxon:6239			
+WB	WBGene00044457	C18H7.11			gene	taxon:6239			
+WB	WBGene00044458	K11H12.10			gene	taxon:6239			
+WB	WBGene00044459	Y55F3C.9			gene	taxon:6239			
+WB	WBGene00044460	Y55F3C.10		Y55F3C.b	gene	taxon:6239			
+WB	WBGene00044461	Y18H1A.14			gene	taxon:6239			
+WB	WBGene00044463	W09G12.10			gene	taxon:6239			
+WB	WBGene00044464	Y77E11A.16			gene	taxon:6239			
+WB	WBGene00044467	R05C11.4			gene	taxon:6239			
+WB	WBGene00044468	Y69A2AL.2			gene	taxon:6239			
+WB	WBGene00044469	clec-173		T26C12.6	gene	taxon:6239			
+WB	WBGene00044473	F56D6.11			gene	taxon:6239			
+WB	WBGene00044474	F56D6.12			gene	taxon:6239			
+WB	WBGene00044475	F56D6.13			gene	taxon:6239			
+WB	WBGene00044476	F56D6.14			gene	taxon:6239			
+WB	WBGene00044477	F49F1.14			gene	taxon:6239			
+WB	WBGene00044480	ZK185.4			gene	taxon:6239			
+WB	WBGene00044481	ZK185.5			gene	taxon:6239			
+WB	WBGene00044482	F29B9.12			gene	taxon:6239			
+WB	WBGene00044484	hot-9		C09B9.8	gene	taxon:6239			
+WB	WBGene00044488	Y54G2A.45			gene	taxon:6239			
+WB	WBGene00044492	Y54G2A.49			gene	taxon:6239			
+WB	WBGene00044493	Y54G2A.50			gene	taxon:6239			
+WB	WBGene00044495	Y54G2A.40			gene	taxon:6239			
+WB	WBGene00044499	T11F8.5			gene	taxon:6239			
+WB	WBGene00044501	C55C3.8			gene	taxon:6239			
+WB	WBGene00044508	nsy-7		C18F3.4	gene	taxon:6239			
+WB	WBGene00044511	clec-181		Y59H11AR.5	gene	taxon:6239			
+WB	WBGene00044513	nlp-70		Y58G8A.5	gene	taxon:6239			
+WB	WBGene00044525	Y73C8B.5			gene	taxon:6239			
+WB	WBGene00044527	Y39H10B.2			gene	taxon:6239			
+WB	WBGene00044528	lgc-29		Y45G5AL.2	gene	taxon:6239			
+WB	WBGene00044529	irld-1		D2063.4	gene	taxon:6239			
+WB	WBGene00044534	H23N18.6			gene	taxon:6239			
+WB	WBGene00044535	K11D12.13			gene	taxon:6239			
+WB	WBGene00044537	B0238.15			gene	taxon:6239			
+WB	WBGene00044544	F26F12.8			gene	taxon:6239			
+WB	WBGene00044547	C13A2.12			gene	taxon:6239			
+WB	WBGene00044551	ZK105.8			gene	taxon:6239			
+WB	WBGene00044556	F38G1.3			gene	taxon:6239			
+WB	WBGene00044557	ZC13.10			gene	taxon:6239			
+WB	WBGene00044560	C36C9.6			gene	taxon:6239			
+WB	WBGene00044562	C14E2.7			gene	taxon:6239			
+WB	WBGene00044563	T26C11.8			gene	taxon:6239			
+WB	WBGene00044567	C46C11.4			gene	taxon:6239			
+WB	WBGene00044568	ntc-1		F39C12.4|nlp-75	gene	taxon:6239			
+WB	WBGene00044570	T22B7.8			gene	taxon:6239			
+WB	WBGene00044574	F23G4.1			gene	taxon:6239			
+WB	WBGene00044584	T03G11.9			gene	taxon:6239			
+WB	WBGene00044587	srz-105		K03D3.12	gene	taxon:6239			
+WB	WBGene00044602	C31B8.16			gene	taxon:6239			
+WB	WBGene00044603	acbp-7		F26A1.15	gene	taxon:6239			
+WB	WBGene00044604	T10F2.5			gene	taxon:6239			
+WB	WBGene00044605	ttr-36		F22A3.7	gene	taxon:6239			
+WB	WBGene00044608	glrx-22		C07G1.8	gene	taxon:6239			
+WB	WBGene00044609	tbcc-1		Y71H2AM.24	gene	taxon:6239			
+WB	WBGene00044611	T27A3.8			gene	taxon:6239			
+WB	WBGene00044612	Y57E12AR.1			gene	taxon:6239			
+WB	WBGene00044614	C36B1.14			gene	taxon:6239			
+WB	WBGene00044616	M01A12.4			gene	taxon:6239			
+WB	WBGene00044617	bus-1		R03H4.6	gene	taxon:6239			
+WB	WBGene00044618	bus-2		K08D12.5	gene	taxon:6239			
+WB	WBGene00044620	bus-4		T22B11.2	gene	taxon:6239			
+WB	WBGene00044623	bus-8		T23F2.1|nic-1|phi-42|tag-249	gene	taxon:6239			
+WB	WBGene00044630	bus-17		ZK678.8	gene	taxon:6239			
+WB	WBGene00044631	bus-18		F55A11.5|acl-10	gene	taxon:6239			
+WB	WBGene00044633	F54H12.7			gene	taxon:6239			
+WB	WBGene00044634	C29E4.14			gene	taxon:6239			
+WB	WBGene00044637	rft-1		Y47D7A.16	gene	taxon:6239			
+WB	WBGene00044645	Y51H7BR.8			gene	taxon:6239			
+WB	WBGene00044649	C23H5.11			gene	taxon:6239			
+WB	WBGene00044650	Y71G10AR.4		Y71G10AR.a	gene	taxon:6239			
+WB	WBGene00044663	F26G1.10			gene	taxon:6239			
+WB	WBGene00044666	F33G12.7			gene	taxon:6239			
+WB	WBGene00044674	B0280.17			gene	taxon:6239			
+WB	WBGene00044677	ZK353.10			gene	taxon:6239			
+WB	WBGene00044678	B0303.16			gene	taxon:6239			
+WB	WBGene00044681	T24C4.8			gene	taxon:6239			
+WB	WBGene00044683	C36E6.8			gene	taxon:6239			
+WB	WBGene00044689	arid-1		Y108G3AL.7	gene	taxon:6239			
+WB	WBGene00044697	poml-4		K05F6.11	gene	taxon:6239			
+WB	WBGene00044698	K09F5.6			gene	taxon:6239			
+WB	WBGene00044699	nhr-286		VC5.6	gene	taxon:6239			
+WB	WBGene00044701	AH9.6			gene	taxon:6239			
+WB	WBGene00044705	T22F3.12			gene	taxon:6239			
+WB	WBGene00044707	pals-15		F22G12.7	gene	taxon:6239			
+WB	WBGene00044719	clec-172		K03H6.7	gene	taxon:6239			
+WB	WBGene00044720	metl-2		Y53F4B.42	gene	taxon:6239			
+WB	WBGene00044731	eat-1			gene	taxon:6239			
+WB	WBGene00044734	Y19D10A.16			gene	taxon:6239			
+WB	WBGene00044736	gfrp-1		Y38C1AA.13	gene	taxon:6239			
+WB	WBGene00044737	ttr-45		JC8.14	gene	taxon:6239			
+WB	WBGene00044738	folt-3		C50E3.16	gene	taxon:6239			
+WB	WBGene00044743	crb-3		C35B8.4	gene	taxon:6239			
+WB	WBGene00044754	Y119C1B.12			gene	taxon:6239			
+WB	WBGene00044756	F58F12.4			gene	taxon:6239			
+WB	WBGene00044760	Y71H2AM.25			gene	taxon:6239			
+WB	WBGene00044762	ZK688.11			gene	taxon:6239			
+WB	WBGene00044770	C53C11.5			gene	taxon:6239			
+WB	WBGene00044771	tmem-218		T23E7.5	gene	taxon:6239			
+WB	WBGene00044772	T23E7.6			gene	taxon:6239			
+WB	WBGene00044774	F16B3.3			gene	taxon:6239			
+WB	WBGene00044777	T02B11.9			gene	taxon:6239			
+WB	WBGene00044778	K09C6.10			gene	taxon:6239			
+WB	WBGene00044780	F18E9.8			gene	taxon:6239			
+WB	WBGene00044784	F13H10.8			gene	taxon:6239			
+WB	WBGene00044788	ttr-38		F35G8.2	gene	taxon:6239			
+WB	WBGene00044790	clec-224		ZK863.9	gene	taxon:6239			
+WB	WBGene00044792	F59C6.14			gene	taxon:6239			
+WB	WBGene00044794	Y59A8B.25			gene	taxon:6239			
+WB	WBGene00044795	C06H5.8			gene	taxon:6239			
+WB	WBGene00044797	F13E9.13			gene	taxon:6239			
+WB	WBGene00044798	tbx-43		Y46E12A.4	gene	taxon:6239			
+WB	WBGene00044801	ZC262.9			gene	taxon:6239			
+WB	WBGene00044803	C02G6.3			gene	taxon:6239			
+WB	WBGene00044805	Y53C10A.15			gene	taxon:6239			
+WB	WBGene00044807	T19H5.6			gene	taxon:6239			
+WB	WBGene00044810	Y37E3.19			gene	taxon:6239			
+WB	WBGene00044811	F12E12.11		F12E12.c|F12E12.i	gene	taxon:6239			
+WB	WBGene00044889	T10D4.14			gene	taxon:6239			
+WB	WBGene00044892	clec-257		Y17D7B.8	gene	taxon:6239			
+WB	WBGene00044895	R06A10.5			gene	taxon:6239			
+WB	WBGene00044900	cnc-11		R09B5.13	gene	taxon:6239			
+WB	WBGene00044903	K03H1.13			gene	taxon:6239			
+WB	WBGene00044911	H38K22.6			gene	taxon:6239			
+WB	WBGene00044916	F40F8.11			gene	taxon:6239			
+WB	WBGene00044917	F40F8.12			gene	taxon:6239			
+WB	WBGene00044921	F53C11.9			gene	taxon:6239			
+WB	WBGene00044922	Y43C5A.7			gene	taxon:6239			
+WB	WBGene00044924	M106.7			gene	taxon:6239			
+WB	WBGene00044987	K07A1.17			gene	taxon:6239			
+WB	WBGene00044988	W01A8.8			gene	taxon:6239			
+WB	WBGene00044989	Y37A1B.17			gene	taxon:6239			
+WB	WBGene00045013	F08A7.1			gene	taxon:6239			
+WB	WBGene00045052	K12C11.6			gene	taxon:6239			
+WB	WBGene00045053	K12C11.7		K12C11.d|K12C11.e	gene	taxon:6239			
+WB	WBGene00045056	F13H10.9			gene	taxon:6239			
+WB	WBGene00045058	gadr-5		Y71A12B.17	gene	taxon:6239			
+WB	WBGene00045067	F07C6.6			gene	taxon:6239			
+WB	WBGene00045101	C35D6.13			gene	taxon:6239			
+WB	WBGene00045190	R01H2.8			gene	taxon:6239			
+WB	WBGene00045192	aho-3		K04G2.2	gene	taxon:6239			
+WB	WBGene00045212	Y110A7A.21			gene	taxon:6239			
+WB	WBGene00045215	ceh-63		C02F12.10	gene	taxon:6239			
+WB	WBGene00045234	Y26D4A.17			gene	taxon:6239			
+WB	WBGene00045237	mrt-1		F39H2.5	gene	taxon:6239			
+WB	WBGene00045239	Y49E10.29			gene	taxon:6239			
+WB	WBGene00045245	ttr-34		F09A5.9	gene	taxon:6239			
+WB	WBGene00045246	C29E4.15			gene	taxon:6239			
+WB	WBGene00045247	F54H12.8			gene	taxon:6239			
+WB	WBGene00045248	ZK180.7			gene	taxon:6239			
+WB	WBGene00045250	Y73B6BL.47			gene	taxon:6239			
+WB	WBGene00045255	nhr-146		Y41D4B.27	gene	taxon:6239			
+WB	WBGene00045303	Y27F2A.10		Y27F2A.f	gene	taxon:6239			
+WB	WBGene00045304	Y27F2A.11		Y27F2A.j	gene	taxon:6239			
+WB	WBGene00045306	ZC250.5			gene	taxon:6239			
+WB	WBGene00045308	C37H5.14			gene	taxon:6239			
+WB	WBGene00045356	T03E6.9			gene	taxon:6239			
+WB	WBGene00045364	clec-250		F11D11.14	gene	taxon:6239			
+WB	WBGene00045379	C45B11.6			gene	taxon:6239			
+WB	WBGene00045380	W06G6.15			gene	taxon:6239			
+WB	WBGene00045382	T05E12.8			gene	taxon:6239			
+WB	WBGene00045383	sup-46		C25A1.4	gene	taxon:6239			
+WB	WBGene00045385	lgc-24		C15A7.4	gene	taxon:6239			
+WB	WBGene00045386	nlp-76		C02B4.4	gene	taxon:6239			
+WB	WBGene00045387	K09H9.8			gene	taxon:6239			
+WB	WBGene00045395	F09F9.5			gene	taxon:6239			
+WB	WBGene00045397	Y54G2A.52			gene	taxon:6239			
+WB	WBGene00045401	eol-1		T26F2.3	gene	taxon:6239			
+WB	WBGene00045403	K10H10.12			gene	taxon:6239			
+WB	WBGene00045413	C25F9.13			gene	taxon:6239			
+WB	WBGene00045416	Y37H2A.14			gene	taxon:6239			
+WB	WBGene00045418	F15B9.10			gene	taxon:6239			
+WB	WBGene00045419	lsy-12		R07B5.9|mys-3	gene	taxon:6239			
+WB	WBGene00045455	F26G1.11			gene	taxon:6239			
+WB	WBGene00045456	C10A4.9			gene	taxon:6239			
+WB	WBGene00045468	F08A8.8			gene	taxon:6239			
+WB	WBGene00045474	C49G9.2			gene	taxon:6239			
+WB	WBGene00045482	T03F6.9			gene	taxon:6239			
+WB	WBGene00045483	oxy-5		F56H1.7	gene	taxon:6239			
+WB	WBGene00045486	K05F6.12			gene	taxon:6239			
+WB	WBGene00045488	F57B1.9			gene	taxon:6239			
+WB	WBGene00045495	F11C1.7			gene	taxon:6239			
+WB	WBGene00045497	K03A11.6			gene	taxon:6239			
+WB	WBGene00045498	F56F4.8			gene	taxon:6239			
+WB	WBGene00045515	nhr-291		ZK1037.13	gene	taxon:6239			
+WB	WBGene00045516	F43D2.7			gene	taxon:6239			
+WB	WBGene00050875	bah-1		ZK1025.7	gene	taxon:6239			
+WB	WBGene00050879	D1081.11			gene	taxon:6239			
+WB	WBGene00050881	ZK39.10			gene	taxon:6239			
+WB	WBGene00050885	Y94H6A.12			gene	taxon:6239			
+WB	WBGene00050889	T04C12.9			gene	taxon:6239			
+WB	WBGene00050892	ttr-57		F46B3.18	gene	taxon:6239			
+WB	WBGene00050893	Y94A7B.11			gene	taxon:6239			
+WB	WBGene00050896	ttr-56		F56F4.9	gene	taxon:6239			
+WB	WBGene00050913	T12B5.14			gene	taxon:6239			
+WB	WBGene00050916	F55F10.3			gene	taxon:6239			
+WB	WBGene00050934	T19C9.10			gene	taxon:6239			
+WB	WBGene00050937	R02D5.8			gene	taxon:6239			
+WB	WBGene00050941	C33F10.14			gene	taxon:6239			
+WB	WBGene00050955	C14A6.12			gene	taxon:6239			
+WB	WBGene00050956	C14A6.13			gene	taxon:6239			
+WB	WBGene00050957	C10A4.10			gene	taxon:6239			
+WB	WBGene00077450	K06B4.15			gene	taxon:6239			
+WB	WBGene00077464	Y70C5B.2			gene	taxon:6239			
+WB	WBGene00077490	M03A1.8			gene	taxon:6239			
+WB	WBGene00077493	F09C6.16			gene	taxon:6239			
+WB	WBGene00077497	K06A4.10			gene	taxon:6239			
+WB	WBGene00077500	C27H6.9			gene	taxon:6239			
+WB	WBGene00077503	AC3.12			gene	taxon:6239			
+WB	WBGene00077508	T27F6.10			gene	taxon:6239			
+WB	WBGene00077514	F07B10.7			gene	taxon:6239			
+WB	WBGene00077520	C37A5.11			gene	taxon:6239			
+WB	WBGene00077521	maf-1		F45H11.6	gene	taxon:6239			
+WB	WBGene00077523	C23H5.12			gene	taxon:6239			
+WB	WBGene00077525	C41G7.8			gene	taxon:6239			
+WB	WBGene00077536	F38B7.10			gene	taxon:6239			
+WB	WBGene00077543	F27D4.8			gene	taxon:6239			
+WB	WBGene00077546	C01A2.9			gene	taxon:6239			
+WB	WBGene00077548	F21C3.7			gene	taxon:6239			
+WB	WBGene00077559	R05D7.7			gene	taxon:6239			
+WB	WBGene00077562	ZC443.7			gene	taxon:6239			
+WB	WBGene00077563	peel-1		Y39G10AR.25	gene	taxon:6239			
+WB	WBGene00077569	F53F4.18			gene	taxon:6239			
+WB	WBGene00077576	C15H11.13			gene	taxon:6239			
+WB	WBGene00077577	R02D5.9			gene	taxon:6239			
+WB	WBGene00077588	T26H8.5			gene	taxon:6239			
+WB	WBGene00077599	T20F5.8			gene	taxon:6239			
+WB	WBGene00077640	Y26G10.4			gene	taxon:6239			
+WB	WBGene00077643	trpp-1		DC2.8	gene	taxon:6239			
+WB	WBGene00077655	asp-19		ZK384.6	gene	taxon:6239			
+WB	WBGene00077658	M106.8			gene	taxon:6239			
+WB	WBGene00077679	K11E4.6			gene	taxon:6239			
+WB	WBGene00077680	F54F7.10			gene	taxon:6239			
+WB	WBGene00077681	Y44A6D.7			gene	taxon:6239			
+WB	WBGene00077688	Y43F8B.19			gene	taxon:6239			
+WB	WBGene00077690	mtp-18		T13C5.8	gene	taxon:6239			
+WB	WBGene00077693	T04C12.11			gene	taxon:6239			
+WB	WBGene00077696	marc-1		F58E6.12	gene	taxon:6239			
+WB	WBGene00077699	C45B11.8			gene	taxon:6239			
+WB	WBGene00077700	sex-2			gene	taxon:6239			
+WB	WBGene00077712	nipi-4		F40A3.5	gene	taxon:6239			
+WB	WBGene00077729	szy-1			gene	taxon:6239			
+WB	WBGene00077731	szy-3			gene	taxon:6239			
+WB	WBGene00077732	szy-4		C30B5.1|tag-319	gene	taxon:6239			
+WB	WBGene00077735	szy-7			gene	taxon:6239			
+WB	WBGene00077736	szy-8			gene	taxon:6239			
+WB	WBGene00077737	szy-9			gene	taxon:6239			
+WB	WBGene00077739	szy-11			gene	taxon:6239			
+WB	WBGene00077740	szy-12			gene	taxon:6239			
+WB	WBGene00077742	szy-14			gene	taxon:6239			
+WB	WBGene00077743	szy-15			gene	taxon:6239			
+WB	WBGene00077744	szy-16			gene	taxon:6239			
+WB	WBGene00077745	szy-17			gene	taxon:6239			
+WB	WBGene00077746	szy-18			gene	taxon:6239			
+WB	WBGene00077747	szy-19			gene	taxon:6239			
+WB	WBGene00077761	zip-9		F17C11.17	gene	taxon:6239			
+WB	WBGene00077763	glb-34		Y57G11B.97	gene	taxon:6239			
+WB	WBGene00077768	K04G2.12			gene	taxon:6239			
+WB	WBGene00077770	M04D5.3			gene	taxon:6239			
+WB	WBGene00077771	tspo-1		C41G7.9	gene	taxon:6239			
+WB	WBGene00077775	nlp-58		T07C12.15	gene	taxon:6239			
+WB	WBGene00077786	F53F8.7			gene	taxon:6239			
+WB	WBGene00086546	cil-1		C50C3.7	gene	taxon:6239			
+WB	WBGene00086554	D1081.12			gene	taxon:6239			
+WB	WBGene00086557	K07A12.8			gene	taxon:6239			
+WB	WBGene00086559	Y43F8B.20			gene	taxon:6239			
+WB	WBGene00086568	Y2H9A.6			gene	taxon:6239			
+WB	WBGene00138716	F17B5.10			gene	taxon:6239			
+WB	WBGene00138717	F52C12.6			gene	taxon:6239			
+WB	WBGene00138720	F58H1.8			gene	taxon:6239			
+WB	WBGene00138721	pals-37		C54D10.14	gene	taxon:6239			
+WB	WBGene00164973	C39B10.7			gene	taxon:6239			
+WB	WBGene00164985	ZK1010.10			gene	taxon:6239			
+WB	WBGene00175030	Y53C12A.10			gene	taxon:6239			
+WB	WBGene00185014	F17C8.9			gene	taxon:6239			
+WB	WBGene00185048	urm-1		F43D9.6	gene	taxon:6239			
+WB	WBGene00185067	Y54G11A.17			gene	taxon:6239			
+WB	WBGene00185089	C16A11.10			gene	taxon:6239			
+WB	WBGene00185092	K08D8.7			gene	taxon:6239			
+WB	WBGene00185097	C49C3.20			gene	taxon:6239			
+WB	WBGene00185117	C45B11.9			gene	taxon:6239			
+WB	WBGene00189930	Y26G10.5			gene	taxon:6239			
+WB	WBGene00189933	F38B7.11			gene	taxon:6239			
+WB	WBGene00189949	Y48G1C.13			gene	taxon:6239			
+WB	WBGene00189950	C39B5.14			gene	taxon:6239			
+WB	WBGene00189954	F40G9.18			gene	taxon:6239			
+WB	WBGene00189955	F40G9.19			gene	taxon:6239			
+WB	WBGene00189956	Y34F4.6			gene	taxon:6239			
+WB	WBGene00189957	M03F8.7			gene	taxon:6239			
+WB	WBGene00189987	C18H7.12			gene	taxon:6239			
+WB	WBGene00189993	C49C3.21			gene	taxon:6239			
+WB	WBGene00194641	F47G3.4			gene	taxon:6239			
+WB	WBGene00194642	C25H3.17			gene	taxon:6239			
+WB	WBGene00194643	C48D1.9			gene	taxon:6239			
+WB	WBGene00194645	Y105C5A.1269			gene	taxon:6239			
+WB	WBGene00194646	Y105C5A.1270			gene	taxon:6239			
+WB	WBGene00194653	F36H2.6			gene	taxon:6239			
+WB	WBGene00194654	M05B5.7			gene	taxon:6239			
+WB	WBGene00194689	Y38H6C.24			gene	taxon:6239			
+WB	WBGene00194691	ZK1098.12			gene	taxon:6239			
+WB	WBGene00194697	F59A3.13			gene	taxon:6239			
+WB	WBGene00194698	F49D11.11			gene	taxon:6239			
+WB	WBGene00194700	B0025.5			gene	taxon:6239			
+WB	WBGene00194701	Y23H5B.12			gene	taxon:6239			
+WB	WBGene00194707	C53A5.17			gene	taxon:6239			
+WB	WBGene00194708	Y36E3A.2			gene	taxon:6239			
+WB	WBGene00194710	mks-2		C30B5.9	gene	taxon:6239			
+WB	WBGene00194712	T11F9.21			gene	taxon:6239			
+WB	WBGene00194715	T25E12.16			gene	taxon:6239			
+WB	WBGene00194726	R13A5.15			gene	taxon:6239			
+WB	WBGene00194730	C29E4.17			gene	taxon:6239			
+WB	WBGene00194737	Y50D7A.13			gene	taxon:6239			
+WB	WBGene00194747	H05C05.4			gene	taxon:6239			
+WB	WBGene00194780	C12D8.20			gene	taxon:6239			
+WB	WBGene00194799	Y70C5A.4			gene	taxon:6239			
+WB	WBGene00194821	dmsr-16		T27B2.1	gene	taxon:6239			
+WB	WBGene00194850	F44F4.15			gene	taxon:6239			
+WB	WBGene00194855	Y75B8A.44			gene	taxon:6239			
+WB	WBGene00194868	M03C11.9			gene	taxon:6239			
+WB	WBGene00194870	F53A2.11			gene	taxon:6239			
+WB	WBGene00194892	dsb-2		F26H11.6	gene	taxon:6239			
+WB	WBGene00194894	T05B4.14			gene	taxon:6239			
+WB	WBGene00194895	ZK105.11		ZK105.e	gene	taxon:6239			
+WB	WBGene00194896	W02H5.11			gene	taxon:6239			
+WB	WBGene00194910	ZC404.15			gene	taxon:6239			
+WB	WBGene00194915	JC8.16			gene	taxon:6239			
+WB	WBGene00194918	K08D8.9			gene	taxon:6239			
+WB	WBGene00194919	K08D8.10			gene	taxon:6239			
+WB	WBGene00194926	K08D8.12			gene	taxon:6239			
+WB	WBGene00194934	ZK809.9			gene	taxon:6239			
+WB	WBGene00194952	ZK666.14			gene	taxon:6239			
+WB	WBGene00194986	pigb-1		T27F7.4	gene	taxon:6239			
+WB	WBGene00195010	Y37E11AL.12			gene	taxon:6239			
+WB	WBGene00195045	W05F2.8			gene	taxon:6239			
+WB	WBGene00195050	T22D1.17			gene	taxon:6239			
+WB	WBGene00195051	T22D1.18			gene	taxon:6239			
+WB	WBGene00195069	W03G9.10			gene	taxon:6239			
+WB	WBGene00195073	F02E11.7			gene	taxon:6239			
+WB	WBGene00195086	F21C10.13			gene	taxon:6239			
+WB	WBGene00195093	Y59E9AL.36			gene	taxon:6239			
+WB	WBGene00195142	M110.10			gene	taxon:6239			
+WB	WBGene00195143	nlp-78		C16D2.2	gene	taxon:6239			
+WB	WBGene00195145	ZK666.15			gene	taxon:6239			
+WB	WBGene00195150	Y81G3A.6			gene	taxon:6239			
+WB	WBGene00195166	W05B10.6			gene	taxon:6239			
+WB	WBGene00195177	Y43F8B.25			gene	taxon:6239			
+WB	WBGene00195210	Y7A5A.13			gene	taxon:6239			
+WB	WBGene00195211	C34F6.12			gene	taxon:6239			
+WB	WBGene00195212	F09B12.7			gene	taxon:6239			
+WB	WBGene00195214	F11C1.10			gene	taxon:6239			
+WB	WBGene00195215	F55G7.5			gene	taxon:6239			
+WB	WBGene00195239	ZK1127.13			gene	taxon:6239			
+WB	WBGene00195243	F46B3.23			gene	taxon:6239			
+WB	WBGene00195244	F30A10.15			gene	taxon:6239			
+WB	WBGene00195248	emc-5		B0334.15	gene	taxon:6239			
+WB	WBGene00195250	C13C4.8			gene	taxon:6239			
+WB	WBGene00202496	R02F11.9			gene	taxon:6239			
+WB	WBGene00202497	R02F11.10			gene	taxon:6239			
+WB	WBGene00202504	Y32B12B.8			gene	taxon:6239			
+WB	WBGene00202511	F07C3.16			gene	taxon:6239			
+WB	WBGene00202513	ZK938.10			gene	taxon:6239			
+WB	WBGene00202514	T09F5.20			gene	taxon:6239			
+WB	WBGene00206354	F27E5.9			gene	taxon:6239			
+WB	WBGene00206363	F56H1.10			gene	taxon:6239			
+WB	WBGene00206364	C07A12.18			gene	taxon:6239			
+WB	WBGene00206366	C03H5.9			gene	taxon:6239			
+WB	WBGene00206370	F02D8.9			gene	taxon:6239			
+WB	WBGene00206374	K10G6.9			gene	taxon:6239			
+WB	WBGene00206377	F44E5.15			gene	taxon:6239			
+WB	WBGene00206381	F52H2.15			gene	taxon:6239			
+WB	WBGene00206382	F01G12.18			gene	taxon:6239			
+WB	WBGene00206383	C32C4.16			gene	taxon:6239			
+WB	WBGene00206392	F47D2.11			gene	taxon:6239			
+WB	WBGene00206417	W04H10.6			gene	taxon:6239			
+WB	WBGene00206460	F56H9.9			gene	taxon:6239			
+WB	WBGene00206461	Y47D3A.34			gene	taxon:6239			
+WB	WBGene00206466	T08D10.5			gene	taxon:6239			
+WB	WBGene00206468	ZC262.11			gene	taxon:6239			
+WB	WBGene00206473	B0273.115			gene	taxon:6239			
+WB	WBGene00206477	ZC262.12			gene	taxon:6239			
+WB	WBGene00206478	M6.11			gene	taxon:6239			
+WB	WBGene00206482	B0416.10			gene	taxon:6239			
+WB	WBGene00206487	best-19		T21D12.15	gene	taxon:6239			
+WB	WBGene00206496	Y51A2B.16			gene	taxon:6239			
+WB	WBGene00206498	C29A12.22			gene	taxon:6239			
+WB	WBGene00206508	ZK262.19			gene	taxon:6239			
+WB	WBGene00206511	W02H5.16			gene	taxon:6239			
+WB	WBGene00206513	B0244.15			gene	taxon:6239			
+WB	WBGene00219207	C01F6.14			gene	taxon:6239			
+WB	WBGene00219274	T25G12.13			gene	taxon:6239			
+WB	WBGene00219280	C05B5.16			gene	taxon:6239			
+WB	WBGene00219282	F43G9.21			gene	taxon:6239			
+WB	WBGene00219288	Y87G2A.25			gene	taxon:6239			
+WB	WBGene00219297	T23F11.11			gene	taxon:6239			
+WB	WBGene00219300	W10G6.6			gene	taxon:6239			
+WB	WBGene00219314	C05B5.17			gene	taxon:6239			
+WB	WBGene00219316	F21A3.11			gene	taxon:6239			
+WB	WBGene00219317	F31E3.12			gene	taxon:6239			
+WB	WBGene00219362	ZK470.14			gene	taxon:6239			
+WB	WBGene00219368	F14H12.17			gene	taxon:6239			
+WB	WBGene00219369	R160.10			gene	taxon:6239			
+WB	WBGene00219371	C03G5.14			gene	taxon:6239			
+WB	WBGene00219395	M199.134			gene	taxon:6239			
+WB	WBGene00219412	ZK381.62			gene	taxon:6239			
+WB	WBGene00219436	C49H3.16			gene	taxon:6239			
+WB	WBGene00219476	D1046.16			gene	taxon:6239			
+WB	WBGene00219478	Y105C5B.1418			gene	taxon:6239			
+WB	WBGene00219547	T06A10.106			gene	taxon:6239			
+WB	WBGene00219750	Y38C1AA.19		linc-132|Y38C1AA.e	gene	taxon:6239			
+WB	WBGene00219796	C03D6.9			gene	taxon:6239			
+WB	WBGene00220250	C09B9.85			gene	taxon:6239			
+WB	WBGene00220257	C02H6.3			gene	taxon:6239			
+WB	WBGene00220259	ZK418.13			gene	taxon:6239			
+WB	WBGene00235102	dib-1		Y54G2A.75	gene	taxon:6239			
+WB	WBGene00235116	C03G6.21			gene	taxon:6239			
+WB	WBGene00235132	ZK792.12			gene	taxon:6239			
+WB	WBGene00235254	F49D11.14			gene	taxon:6239			
+WB	WBGene00235256	Y54G11A.19			gene	taxon:6239			
+WB	WBGene00235257	T05C7.4			gene	taxon:6239			
+WB	WBGene00235269	F59E12.15		F59E12.h|F59E12.i	gene	taxon:6239			
+WB	WBGene00235273	T11F8.12			gene	taxon:6239			
+WB	WBGene00235274	C54E4.12			gene	taxon:6239			
+WB	WBGene00235279	Y67D8C.22			gene	taxon:6239			
+WB	WBGene00235283	Y55F3BL.6			gene	taxon:6239			
+WB	WBGene00235285	F56D6.18			gene	taxon:6239			
+WB	WBGene00235287	Y55F3C.17			gene	taxon:6239			
+WB	WBGene00235290	Y59H11AR.10		Y59H11AR.d	gene	taxon:6239			
+WB	WBGene00235293	F56D6.19			gene	taxon:6239			
+WB	WBGene00235296	C07G1.15			gene	taxon:6239			
+WB	WBGene00235297	F56D6.20			gene	taxon:6239			
+WB	WBGene00235300	T06A10.107			gene	taxon:6239			
+WB	WBGene00235310	R02D1.2			gene	taxon:6239			
+WB	WBGene00235311	Y57E12B.11			gene	taxon:6239			
+WB	WBGene00235315	Y50D4A.10			gene	taxon:6239			
+WB	WBGene00235316	B0222.15			gene	taxon:6239			
+WB	WBGene00235320	R02F11.11			gene	taxon:6239			
+WB	WBGene00235325	C08D8.7			gene	taxon:6239			
+WB	WBGene00235328	T06E4.21			gene	taxon:6239			
+WB	WBGene00235333	C24H12.18			gene	taxon:6239			
+WB	WBGene00235350	Y54G2A.77			gene	taxon:6239			
+WB	WBGene00235358	F56D6.21			gene	taxon:6239			
+WB	WBGene00235359	F56D6.22			gene	taxon:6239			
+WB	WBGene00235361	F56D6.23			gene	taxon:6239			
+WB	WBGene00235363	F49F1.2			gene	taxon:6239			
+WB	WBGene00235364	F49F1.4			gene	taxon:6239			
+WB	WBGene00235365	F49F1.15		F49F1.k	gene	taxon:6239			
+WB	WBGene00235368	F49F1.18			gene	taxon:6239			
+WB	WBGene00235383	ZK616.65		ZK616.c|ZK616.d	gene	taxon:6239			
+WB	WBGene00235391	F38A5.22			gene	taxon:6239			
+WB	WBGene00236809	ZK993.5			gene	taxon:6239			
+WB	WBGene00255420	Y51F10.15			gene	taxon:6239			
+WB	WBGene00255469	C25G4.17			gene	taxon:6239			
+WB	WBGene00255594	Y48G1BL.8			gene	taxon:6239			
+WB	WBGene00255595	D1046.18			gene	taxon:6239			
+WB	WBGene00255598	BE0003N10.6			gene	taxon:6239			
+WB	WBGene00255600	F54H5.14			gene	taxon:6239			
+WB	WBGene00255702	C06A12.19			gene	taxon:6239			
+WB	WBGene00255714	B0511.19			gene	taxon:6239			
+WB	WBGene00268196	F59A7.14			gene	taxon:6239			
+WB	WBGene00268198	F22F7.12			gene	taxon:6239			
+WB	WBGene00268206	F54E2.9			gene	taxon:6239			
+WB	WBGene00269379	C30B5.17			gene	taxon:6239			
+WB	WBGene00269385	F41F3.9			gene	taxon:6239			
+WB	WBGene00269387	btb-22		F39E9.27	gene	taxon:6239			
+WB	WBGene00269388	F45C12.17			gene	taxon:6239			
+WB	WBGene00269389	C08F1.12			gene	taxon:6239			
+WB	WBGene00269392	F54F7.14			gene	taxon:6239			
+WB	WBGene00269394	F59H6.15			gene	taxon:6239			
+WB	WBGene00269424	K09D9.14			gene	taxon:6239			
+WB	WBGene00269432	ZC132.11			gene	taxon:6239			
+WB	WBGene00269433	T16G12.12			gene	taxon:6239			
+WB	WBGene00269434	sqst-5		T17A3.13	gene	taxon:6239			
+WB	WBGene00269435	T27C10.9			gene	taxon:6239			
+WB	WBGene00269438	Y56A3A.41			gene	taxon:6239			
+WB	WBGene00270303	T28D9.16			gene	taxon:6239			
+WB	WBGene00270322	C17G10.13			gene	taxon:6239			
+WB	WBGene00271415	T05A7.13			gene	taxon:6239			
+WB	WBGene00271437	F10D2.16			gene	taxon:6239			
+WB	WBGene00271444	T04C12.33			gene	taxon:6239			
+WB	WBGene00271577	B0244.16			gene	taxon:6239			
+WB	WBGene00271694	T10E9.14			gene	taxon:6239			
+WB	WBGene00271715	B0244.17			gene	taxon:6239			
+WB	WBGene00271776	F53G12.18			gene	taxon:6239			
+WB	WBGene00271778	T01A4.9			gene	taxon:6239			
+WB	WBGene00271788	M01H9.10			gene	taxon:6239			
+WB	WBGene00271795	Y46C8AM.1			gene	taxon:6239			
+WB	WBGene00271816	R02F11.12			gene	taxon:6239			
+WB	WBGene00271817	F55C12.19			gene	taxon:6239			
+WB	WBGene00271818	K05F1.14			gene	taxon:6239			
+WB	WBGene00271822	F11G11.15			gene	taxon:6239			
+WB	WBGene00284844	H38K22.9			gene	taxon:6239			
+WB	WBGene00284849	C03A3.9			gene	taxon:6239			
+WB	WBGene00284850	Y46B2A.4			gene	taxon:6239			
+WB	WBGene00284854	Y95D11A.5			gene	taxon:6239			
+WB	WBGene00284855	C04C11.25			gene	taxon:6239			
+WB	WBGene00302968	Y62E10A.24			gene	taxon:6239			
+WB	WBGene00302976	F49E8.8			gene	taxon:6239			
+WB	WBGene00302978	C42C1.19			gene	taxon:6239			
+WB	WBGene00302980	F53E2.2			gene	taxon:6239			
+WB	WBGene00302984	Y51H7C.41			gene	taxon:6239			
+WB	WBGene00302991	cox-16		C24G6.13	gene	taxon:6239			
+WB	WBGene00302995	H06H21.37			gene	taxon:6239			
+WB	WBGene00303000	C37C3.18			gene	taxon:6239			
+WB	WBGene00303002	Y48E1B.17			gene	taxon:6239			
+WB	WBGene00303005	C34E10.12			gene	taxon:6239			
+WB	WBGene00303007	Y57G11C.1147			gene	taxon:6239			
+WB	WBGene00303009	mrpl-42		ZC410.10	gene	taxon:6239			
+WB	WBGene00303015	F20C5.11			gene	taxon:6239			
+WB	WBGene00303019	Y70G10A.4			gene	taxon:6239			
+WB	WBGene00303021	mccc-2		F02A9.10	gene	taxon:6239			
+WB	WBGene00303023	K07F5.22			gene	taxon:6239			
+WB	WBGene00303026	T20D3.14			gene	taxon:6239			
+WB	WBGene00303081	T23F2.13			gene	taxon:6239			
+WB	WBGene00303105	R07E5.19			gene	taxon:6239			
+WB	WBGene00303208	Y71H2AM.29			gene	taxon:6239			
+WB	WBGene00303364	Y14H12A.5			gene	taxon:6239			
+WB	WBGene00303421	F20D6.15			gene	taxon:6239			
+WB	WBGene00303425	R02E12.12			gene	taxon:6239			
+WB	WBGene00304175	C37E2.10			gene	taxon:6239			
+WB	WBGene00304195	M163.22			gene	taxon:6239			
+WB	WBGene00304237	F39B3.7			gene	taxon:6239			
+WB	WBGene00304775	Y38E10A.34			gene	taxon:6239			
+WB	WBGene00304788	C52B9.19			gene	taxon:6239			
+WB	WBGene00304790	ZC53.22			gene	taxon:6239			
+WB	WBGene00304792	Y71F9AL.25			gene	taxon:6239			
+WB	WBGene00304811	E02D9.3			gene	taxon:6239			
+WB	WBGene00304818	R160.14			gene	taxon:6239			
+WB	WBGene00304819	R160.13			gene	taxon:6239			
+WB	WBGene00305047	M01G12.15			gene	taxon:6239			
+WB	WBGene00305048	M01G12.16			gene	taxon:6239			
+WB	WBGene00305050	Y92H12BL.7			gene	taxon:6239			
+WB	WBGene00305066	Y55B1BR.8			gene	taxon:6239			
+WB	WBGene00305069	Y80D4G.2			gene	taxon:6239			
+WB	WBGene00305086	B0252.11			gene	taxon:6239			
+WB	WBGene00305113	F36H5.18			gene	taxon:6239			
+WB	WBGene00305131	F54H12.10			gene	taxon:6239			
+WB	WBGene00305157	T24H7.9			gene	taxon:6239			
+WB	WBGene00305999	T12A2.21			gene	taxon:6239			


### PR DESCRIPTION
Full drop-n-reload of 155 models from `wb_oa_4.gpad`. No source data change, only code. Though, I committed the `wb.gpi` file this time. To test biolink/ontobio#604 for issue https://github.com/biolink/ontobio/issues/599.